### PR TITLE
[data] feat: add verify rules for Torch profiling files

### DIFF
--- a/rl_insight/data/data_checker.py
+++ b/rl_insight/data/data_checker.py
@@ -27,6 +27,8 @@ from .rules import (
     MstxJsonFieldValidRule,
     PathExistsRule,
     ValidationRule,
+    TorchJsonFileExistsRule,
+    TorchJsonFieldValidRule,
 )
 from .verl_log_rules import VerlLogExistRule, VerlLogKeyParamsRule
 
@@ -53,7 +55,11 @@ class DataChecker:
             MstxJsonFileExistsRule(),
             MstxJsonFieldValidRule(),
         ],
-        DataEnum.MULTI_JSON_TORCH: [],
+        DataEnum.MULTI_JSON_TORCH: [
+            PathExistsRule(),
+            TorchJsonFileExistsRule(),
+            TorchJsonFieldValidRule(),
+        ],
         DataEnum.VERL_LOG: [VerlLogExistRule(), VerlLogKeyParamsRule()],
         DataEnum.SUMMARY_EVENT: [
             ParserOutputValidatorRule(

--- a/rl_insight/data/rules.py
+++ b/rl_insight/data/rules.py
@@ -13,6 +13,7 @@
 # limitations under the License.
 
 import glob
+import gzip
 import json
 import os
 from typing import Any, List, Optional
@@ -240,3 +241,107 @@ class ParserOutputValidatorRule(ValidationRule):
             )
             return False
         return True
+
+
+class TorchJsonFileExistsRule(ValidationRule):
+    """valid Torch *.json.gz files is existed in 'torch_profile' sub path"""
+
+    def check(self, data) -> bool:
+        if not isinstance(data, str):
+            self._error_message = "Data object is not a path"
+            return False
+        self._error_message = ""
+        try:
+            root_path = Path(data)  # 路径：torch_profile
+            is_success = True
+            sub_dirs_no_json: List = []
+
+            if not root_path.exists():
+                self._error_message = f"Source path does not exist: {data}"
+                return False
+            for subdir in root_path.iterdir():
+                if subdir.is_dir():
+                    gz_files = list(subdir.glob("*.json.gz"))
+                    if not gz_files:
+                        sub_dirs_no_json.append(str(subdir))
+                        is_success = False
+            if len(sub_dirs_no_json) > 0:
+                paths = "; ".join(sub_dirs_no_json)
+                self._error_message = f"The path '{paths}' has no prof_*.json.gz file"
+            return is_success
+
+        except Exception as e:
+            self._error_message = f"Error checking path {data}: {e}"
+            return False
+
+    @property
+    def error_message(self) -> str:
+        return self._error_message
+
+
+class TorchJsonFieldValidRule(ValidationRule):
+    """valid torch *.json.gz files JSON format"""
+
+    def check(self, data) -> bool:
+        if not isinstance(data, str):
+            self._error_message = "Data object is not a path"
+            return False
+        self._error_message = ""
+        try:
+            root_path = Path(data)
+
+            if not root_path.exists():
+                self._error_message = f"Source path does not exist: {data}"
+                return False
+            for item in os.listdir(root_path):
+                item_path = os.path.join(root_path, item)
+                # 检查是否为目录
+                if os.path.isdir(item_path):
+                    # 查找该子目录下所有.json.gz文件
+                    json_gz_pattern = os.path.join(item_path, "*.json.gz")
+                    json_gz_files = glob.glob(json_gz_pattern)
+                    for json_gz_file in json_gz_files:
+                        # 打开并读取.json.gz文件
+                        with gzip.open(json_gz_file, "rt", encoding="utf-8") as f:
+                            # 加载JSON数据
+                            json_data = json.load(f)
+                        if len(json_data) == 0:
+                            self._error_message = f"File is empty: {json_gz_file}"
+                            return False
+
+                        distributed_info = json_data.get("distributedInfo", {})
+                        required_keys = {"rank", "world_size", "backend"}
+                        missing_keys = required_keys - distributed_info.keys()
+                        if missing_keys:
+                            self._error_message = (
+                                f"The 'distributedInfo' field missing: {missing_keys} in FilePath: "
+                                f"{json_gz_file}"
+                            )
+                            return False
+                        trace_events = json_data.get("traceEvents", [])
+                        trace_valid = (
+                            isinstance(trace_events, list) and len(trace_events) > 1
+                        )
+                        if not trace_valid:
+                            self._error_message = f"The 'traceEvents' field is empty in FilePath: {json_gz_file}"
+                            return False
+
+                        required_keys = {"ph", "name", "pid", "tid", "ts"}
+
+                        for event in trace_events:
+                            missing_keys = required_keys - event.keys()
+                            if missing_keys:
+                                self._error_message = (
+                                    f"The 'traceEvents' field missing: {missing_keys} in FilePath: "
+                                    f"{json_gz_file}"
+                                )
+                                return False
+            return True
+
+        except Exception as e:
+            self._error_message = f"Error checking path {data}: {e}"
+            return False
+
+    @property
+    def error_message(self) -> str:
+        return self._error_message

--- a/rl_insight/data/rules.py
+++ b/rl_insight/data/rules.py
@@ -320,7 +320,7 @@ class TorchJsonFieldValidRule(ValidationRule):
                             return False
                         trace_events = json_data.get("traceEvents", [])
                         trace_valid = (
-                            isinstance(trace_events, list) and len(trace_events) > 1
+                            isinstance(trace_events, list) and len(trace_events) > 0
                         )
                         if not trace_valid:
                             self._error_message = f"The 'traceEvents' field is empty in FilePath: {json_gz_file}"

--- a/tests/data/test_data_checker.py
+++ b/tests/data/test_data_checker.py
@@ -24,6 +24,7 @@ from rl_insight.data.rules import DataValidationError
 CURRENT_FILE = Path(__file__).resolve()
 PROJECT_ROOT = CURRENT_FILE.parents[2]
 MSTX_PROFILE_PATH = PROJECT_ROOT / "data/mstx_data/mstx_profile"
+TORCH_PROFILE_PATH = PROJECT_ROOT / "data/torch_data/torch_profile"
 
 
 def test_data_checker_multi_json_path_exists():

--- a/tests/data/test_rules.py
+++ b/tests/data/test_rules.py
@@ -17,9 +17,11 @@ from rl_insight.data.rules import (
     PathExistsRule,
     MstxJsonFileExistsRule,
     MstxJsonFieldValidRule,
+    TorchJsonFileExistsRule,
+    TorchJsonFieldValidRule,
 )
 from rl_insight.data.verl_log_rules import VerlLogExistRule, VerlLogKeyParamsRule
-from test_data_checker import MSTX_PROFILE_PATH
+from test_data_checker import MSTX_PROFILE_PATH, TORCH_PROFILE_PATH
 
 
 def test_path_exists_rule_accepts_existing_directory():
@@ -134,3 +136,23 @@ def test_verl_log_key_params_fails_when_missing_keyword(tmp_path):
     )
     assert rule.check(str(log)) is False
     assert "response_length/mean" in rule.error_message
+
+
+def test_torch_jsonfile_exists():
+    path_rule = PathExistsRule()
+    file_rule = TorchJsonFileExistsRule()
+    assert path_rule.check(str(TORCH_PROFILE_PATH)) is True
+    assert file_rule.check(str(TORCH_PROFILE_PATH)) is True
+
+
+def test_torch_jsonfile_exists_with_fake_path():
+    file_rule = TorchJsonFileExistsRule()
+    fake_path = "fake_path"
+    assert file_rule.check(fake_path) is False
+
+
+def test_torch_json_fields_valid():
+    path_rule = PathExistsRule()
+    filed_rule = TorchJsonFieldValidRule()
+    assert path_rule.check(str(TORCH_PROFILE_PATH)) is True
+    assert filed_rule.check(str(TORCH_PROFILE_PATH)) is True


### PR DESCRIPTION
### What does this PR do?

> Add Torch JsonFile Exists Rule and Torch JsonField Valid Rule for Torch profile.

### Checklist Before Starting

- [x] Search for similar PRs. Paste at least one query link here: ...
- [x] Format the PR title as `[{modules}] {type}: {description}` (This will be checked by the CI)
  - `{modules}` include `pipeline`, `parser`, `visualizer`, `data`, `deployment`, `perf`, `algo`, `env`, `doc`, `cfg`, `ci`, `misc`
  - If this PR involves multiple modules, separate them with `,` like `[mstx, ci]`
  - `{type}` is in `feat`, `fix`, `refactor`, `chore`, `test`
  - If this PR breaks any API (CLI arguments, config, function signature, etc.), add `[BREAKING]` to the beginning of the title.
  - Example: `[BREAKING][mstx, torch_profile] feat: support timeline parsing`

### Test

> For changes that can not be tested by CI (e.g., algorithm implementation, new model support), validate by experiment(s) and show results like training curve plots, evaluation results, etc.

### API and Usage Example

> Demonstrate how the API changes if any, and provide usage example(s) if possible.

```python
# Add code snippet or script demonstrating how to use this
```

### Design & Code Changes

> Demonstrate the high-level design if this PR is complex, and list the specific changes.

### Checklist Before Submitting

> [!IMPORTANT]
> Please check all the following items before requesting a review, otherwise the reviewer might deprioritize this PR for review.

- [x] Read the [Contribute Guide](https://github.com/verl-project/rl-insight/blob/main/CONTRIBUTING.md).
- [x] Apply [pre-commit checks](https://github.com/verl-project/rl-insight/blob/main/CONTRIBUTING.md#code-linting-and-formatting): `pre-commit install && pre-commit run --all-files --show-diff-on-failure --color=always`
- [ ] Add / Update [the documentation](https://github.com/verl-project/rl-insight/tree/main/docs).
- [x] Add unit or end-to-end test(s) to [the CI workflow](https://github.com/verl-project/rl-insight/tree/main/.github/workflows) to cover all the code. If not feasible, explain why: ...
