### PR TITLE
[visualizer] feat: add memory timeline HTML visualizer with segment s…

### DIFF
--- a/rl_insight/data/data_checker.py
+++ b/rl_insight/data/data_checker.py
@@ -50,7 +50,7 @@ class DataEnum(Enum):
     # output data type of parser, input data type of visualizer
     SUMMARY_EVENT = "summary_event"
     GMM_SUMMARY = "gmm_summary"
-    SUMMARY_MEMORY_EVENT = "summary_memory_event"
+    MEMORY_SUMMARY = "memory_summary"
     # other data type
     UNKNOWN = "unknown"
 
@@ -82,6 +82,8 @@ class DataChecker:
         DataEnum.GMM_SUMMARY: [
             ParserOutputValidatorRule(domains=list(GMMKEYS)),
         ],
+        DataEnum.ASCEND_MEMORY: [],
+        DataEnum.MEMORY_SUMMARY: [],
         DataEnum.UNKNOWN: [],
     }
 

--- a/rl_insight/visualizer/__init__.py
+++ b/rl_insight/visualizer/__init__.py
@@ -19,6 +19,7 @@ from .visualizer import (
     get_cluster_visualizer_cls,
 )
 from .gmm_visualizer import GmmVisualizer
+from .memory_visualizer import MemoryVisualizer
 
 
 __all__ = [
@@ -27,4 +28,5 @@ __all__ = [
     "RLTimelineVisualizer",
     "RLTimelinePNGVisualizer",
     "GmmVisualizer",
+    "MemoryVisualizer",
 ]

--- a/rl_insight/visualizer/memory_template.html
+++ b/rl_insight/visualizer/memory_template.html
@@ -1,0 +1,365 @@
+<!DOCTYPE html>
+<html lang="zh-CN">
+<head>
+<meta charset="UTF-8">
+<meta name="viewport" content="width=device-width, initial-scale=1.0">
+<title>Memory Timeline</title>
+<script src="https://cdn.plot.ly/plotly-2.35.2.min.js"></script>
+<style>
+* { box-sizing: border-box; margin: 0; padding: 0; }
+body { font-family: -apple-system, BlinkMacSystemFont, sans-serif; background: #f5f5f5; color: #333; padding: 20px; }
+.container { max-width: 1600px; margin: 0 auto; }
+h1 { text-align: center; margin-bottom: 10px; font-size: 20px; }
+.chart-box { background: #fff; border: 1px solid #ddd; border-radius: 6px; margin-bottom: 12px; padding: 8px 12px 4px; box-shadow: 0 1px 4px rgba(0,0,0,.08); }
+.chart-box h3 { font-size: 14px; margin-bottom: 4px; color: #555; }
+#chart1, #chart2 { width: 100%; }
+.controls { display: flex; flex-wrap: wrap; gap: 16px; align-items: center; background: #fff; border: 1px solid #ddd; border-radius: 6px; padding: 14px 18px; margin-bottom: 12px; box-shadow: 0 1px 4px rgba(0,0,0,.08); }
+.control-group { display: flex; align-items: center; gap: 6px; }
+.control-group label { font-weight: 600; font-size: 13px; white-space: nowrap; color: #555; }
+.control-group input { border: 1px solid #ccc; border-radius: 4px; padding: 5px 8px; font-size: 13px; width: 130px; font-family: 'Consolas', monospace; }
+.control-group input:focus { outline: none; border-color: #4e79a7; box-shadow: 0 0 0 2px rgba(78,121,167,.2); }
+.control-group input.invalid { border-color: #e15759; background: #fff0f0; }
+.control-group .unit { font-size: 11px; color: #999; }
+.legend-note { font-size: 12px; color: #888; margin-left: 8px; }
+.detail-panel { background: #fff; border: 1px solid #ddd; border-radius: 6px; padding: 16px 20px; margin-bottom: 12px; box-shadow: 0 1px 4px rgba(0,0,0,.08); display: none; }
+.detail-panel.active { display: block; }
+.detail-panel h3 { font-size: 14px; margin-bottom: 10px; color: #333; }
+.detail-grid { display: grid; grid-template-columns: 160px 1fr; gap: 6px 12px; font-size: 13px; }
+.detail-grid .label { font-weight: 600; color: #666; text-align: right; }
+.detail-grid .value { color: #333; word-break: break-all; font-family: 'Consolas', monospace; }
+.call-stack-box { grid-column: 2; background: #f8f8f8; border: 1px solid #e0e0e0; border-radius: 4px; padding: 10px 14px; font-family: 'Consolas', monospace; font-size: 12px; line-height: 1.6; white-space: pre-wrap; word-break: break-all; max-height: 350px; overflow-y: auto; color: #444; }
+</style>
+</head>
+<body>
+<div class="container">
+<h1>Memory Allocation Timeline</h1>
+<div class="controls">
+<div class="control-group"><label for="range-left">Left:</label><input type="number" id="range-left" step="any" /><span class="unit">ms</span></div>
+<div class="control-group"><label for="range-right">Right:</label><input type="number" id="range-right" step="any" /><span class="unit">ms</span></div>
+__SEGMENT_NAV__
+<div id="seg-hint" style="font-size:12px;color:#4e79a7;font-weight:600;margin-left:auto;display:none"></div>
+<div class="legend-note" id="range-info"></div>
+</div>
+<div class="chart-box"><h3>Memory Usage Over Time</h3><div id="chart1"></div></div>
+<div class="chart-box"><h3>Operator Memory Gantt</h3><div id="chart2"></div></div>
+<div class="detail-panel" id="detail-panel"><h3>Operator Detail</h3><div class="detail-grid" id="detail-content"></div></div>
+</div>
+<script src="__DATA_FILE__"></script>
+<script>
+var T_MIN = 0;
+var T_MAX = GANTT_STARTS[GANTT_STARTS.length-1] + GANTT_DURS[GANTT_DURS.length-1];
+var currentRange = [T_MIN, T_MAX];
+
+// Pre-compute active ops at each TL_XY time point from segment bars.
+// Two-pointer sweep: TL_XY times sorted, GANTT_STARTS sorted, GANTT_ENDS sorted.
+// Result: segActive[i] = [count, [[name, size_kb], ...]]  (top-10 by size)
+var _ganttEnds = [];
+for (var k=0; k<GANTT_STARTS.length; k++) _ganttEnds.push(GANTT_STARTS[k]+GANTT_DURS[k]);
+var segActive = [];
+(function() {
+  var barIdx = 0, n = GANTT_STARTS.length;
+  var active = [];  // heap-like: [origIdx, ...]
+  for (var i=0; i<TL_XY.length; i++) {
+    var t = TL_XY[i][0];
+    // Remove bars that ended before t
+    var j = 0;
+    while (j < active.length) {
+      if (_ganttEnds[active[j]] <= t) {
+        active[j] = active[active.length-1];
+        active.pop();
+      } else {
+        j++;
+      }
+    }
+    // Add bars that start at or before t
+    while (barIdx < n && GANTT_STARTS[barIdx] <= t) {
+      active.push(barIdx);
+      barIdx++;
+    }
+    // Top-10 by size
+    var topList = active.slice().sort(function(a,b){
+      return GANTT_SIZES[b] - GANTT_SIZES[a];
+    }).slice(0, 10);
+    var summaries = topList.map(function(idx){
+      return [OP_NAMES[GANTT_IDS[idx]], GANTT_SIZES[idx]];
+    });
+    segActive.push([active.length, summaries]);
+  }
+})();
+var isSyncing = false;
+var leftInput = document.getElementById('range-left');
+var rightInput = document.getElementById('range-right');
+var rangeInfo = document.getElementById('range-info');
+
+// Pre-compute Chart1 x-axis tick labels in absolute time
+function makeTickInfo(t0, t1) {
+  var span = t1 - t0;
+  if (span <= 0) span = 1;
+  var tickStep = Math.pow(10, Math.floor(Math.log10(span)));
+  var niceTick = span / tickStep;
+  if (niceTick <= 2) tickStep /= 5;
+  else if (niceTick <= 5) tickStep /= 2;
+  var firstTick = Math.floor(t0 / tickStep) * tickStep;
+  var vals=[], texts=[];
+  for (var v = firstTick; v <= t1; v += tickStep) {
+    vals.push(v); texts.push((v + T_OFFSET).toFixed(0));
+  }
+  return { tickvals: vals, ticktext: texts };
+}
+var _chart1Ticks = makeTickInfo(T_MIN, T_MAX);
+
+function buildChart1(range) {
+  var times=[], values=[], hoverTimes=[], cd=[];
+  for (var i=0; i<TL_XY.length; i++) {
+    var p=TL_XY[i];
+    times.push(p[0]); values.push(p[1]);
+    hoverTimes.push((p[0]+T_OFFSET).toFixed(3));
+    var sa = segActive[i];
+    var count = sa[0], topList = sa[1];
+    var lines = [];
+    for (var j=0; j<topList.length; j++) {
+      lines.push('<span style="color:#888">' + escHtml(topList[j][0])
+        + '</span>: ' + (topList[j][1]/1024).toFixed(2) + ' MB');
+    }
+    cd.push([count + ' events', lines.join('<br>')]);
+  }
+  var ht = '<b>Time</b>: %{text} ms<br><b>Total Memory</b>: %{y:.3f} MB<br><b>Active</b>: %{customdata[0]}<br>%{customdata[1]}<extra></extra>';
+  Plotly.newPlot('chart1',[{ x:times, y:values, text:hoverTimes, type:'scatter', mode:'lines', name:'Total Memory',
+    line:{ color:'#4e79a7', width:1.8 }, fill:'tozeroy', fillcolor:'rgba(78,121,167,0.12)',
+    hoveron:'points+fills', customdata:cd, hovertemplate:ht,
+    hoverlabel:{ bgcolor:'#fff', bordercolor:'#4e79a7', font:{ size:12 } }
+  }], {
+    xaxis:{ title:'Time (ms)', range:range, showticklabels:true,
+      tickmode:'array', tickvals:_chart1Ticks.tickvals, ticktext:_chart1Ticks.ticktext,
+      showgrid:true, gridcolor:'#eaeaea', zeroline:false, fixedrange:false },
+    yaxis:{ title:'Memory (MB)', showgrid:true, gridcolor:'#eaeaea', zeroline:true, tickformat:'.1f', fixedrange:true },
+    margin:{ l:70, r:30, t:10, b:50 }, height:350, hovermode:'x', hoverdistance:-1, dragmode:'pan', showlegend:false
+  }, { displaylogo:false, displayModeBar:true, modeBarButtonsToRemove:['lasso2d','select2d'], scrollZoom:true });
+  document.getElementById('chart1').on('plotly_relayout', function(edata) {
+    if (isSyncing) return;
+    if (edata['xaxis.range[0]']!==undefined||edata['xaxis.range[1]']!==undefined) {
+      // Read actual current range from chart layout (more reliable than event)
+      var layout = document.getElementById('chart1').layout;
+      if (layout && layout.xaxis && layout.xaxis.range) {
+        currentRange = [layout.xaxis.range[0], layout.xaxis.range[1]];
+      }
+      syncInputsFromRange(); buildChart2(currentRange); updateRangeInfo();
+      updateSegmentHint(currentRange);
+    }
+  });
+}
+
+function findBestSegment(range) {
+  if (typeof SEGMENTS === "undefined") return null;
+  var best = null, bestOverlap = 0;
+  for (var i = 0; i < SEGMENTS.length; i++) {
+    var segStart = SEGMENTS[i][1], segEnd = SEGMENTS[i][2];
+    var overlap = Math.min(range[1], segEnd) - Math.max(range[0], segStart);
+    if (overlap > bestOverlap) {
+      bestOverlap = overlap;
+      best = SEGMENTS[i];
+    }
+  }
+  if (bestOverlap <= 0) return null;
+  return best;
+}
+function updateSegmentHint(range) {
+  var hint = document.getElementById("seg-hint");
+  if (typeof SEGMENTS === "undefined" || typeof SEG_INDEX === "undefined") {
+    hint.style.display = "none"; return;
+  }
+  var best = findBestSegment(range);
+  if (!best || best[0] === SEG_INDEX) {
+    hint.style.display = "none"; return;
+  }
+  var absStart = (best[1] + T_OFFSET).toFixed(0);
+  var absEnd = (best[2] + T_OFFSET).toFixed(0);
+  var segFile = "memory_timeline_" + String(best[0]).padStart(2, "0") + ".html";
+  hint.innerHTML = "&#128269; Best: Seg " + (best[0] + 1)
+    + " (" + absStart + "–" + absEnd + " ms) "
+    + "<a href=\"" + segFile + "\" style=\"color:#e15759;font-weight:700\">Go →</a>";
+  hint.style.display = "block";
+}
+function buildChart2(range) {
+  Plotly.purge('chart2');
+  // Step 1: Collect bar indices that overlap with the visible time range
+  var vi=[];
+  for (var i=0; i<GANTT_STARTS.length; i++)
+    if (GANTT_STARTS[i]+GANTT_DURS[i]>range[0]&&GANTT_STARTS[i]<range[1]) vi.push(i);
+
+  // Step 2: Sort visible bars by start time
+  vi.sort(function(a,b){ return GANTT_STARTS[a] - GANTT_STARTS[b]; });
+  var filteredBars = vi;
+
+  // Step 3: Group filtered bars by operator name (preserve time order)
+  var groups={}, opOrder=[];
+  for (var k=0; k<filteredBars.length; k++) {
+    var i=filteredBars[k], nm=OP_NAMES[GANTT_IDS[i]];
+    if (!groups[nm]) { groups[nm]=[]; opOrder.push(nm); }
+    groups[nm].push(i);
+  }
+
+  // Step 4: Sort each operator's bars by duration descending.
+  // Plotly draws bars in array order — last element on top.
+  // Long bars first, short bars last → short bars are always visible.
+  for (var k=0; k<opOrder.length; k++) {
+    groups[opOrder[k]].sort(function(a,b){
+      return GANTT_DURS[a] > GANTT_DURS[b] ? -1 : GANTT_DURS[a] < GANTT_DURS[b] ? 1 : 0;
+    });
+  }
+
+  // Step 5: Pre-compute overlap info per bar — for operators with dense bars,
+  // list all bars that overlap at the same time point so hover can show them.
+  var overlaps = {};  // barIdx → [{idx, size_kb, start, dur}, ...] or absent
+  for (var r=0; r<opOrder.length; r++) {
+    var indices = groups[opOrder[r]];
+    if (indices.length <= 1) continue;
+    // For each bar, count how many others overlap (at its midpoint)
+    for (var k=0; k<indices.length; k++) {
+      var idx = indices[k];
+      var tMid = GANTT_STARTS[idx] + GANTT_DURS[idx] / 2;
+      var ov = [];
+      for (var j=0; j<indices.length; j++) {
+        var oi = indices[j];
+        if (oi === idx) continue;
+        if (GANTT_STARTS[oi] <= tMid && GANTT_STARTS[oi] + GANTT_DURS[oi] >= tMid) {
+          ov.push(oi);
+        }
+      }
+      if (ov.length > 0) overlaps[idx] = ov;
+    }
+  }
+
+  var traces=[], yVals=[], yTexts=[], maxY=opOrder.length;
+  for (var r=0; r<opOrder.length; r++) {
+    var nm=opOrder[r], yp=maxY-1-r, cl=COLOR_MAP[nm]||'#999';
+    var indices=groups[nm];
+    var xs=[], bases=[], hts=[], cds=[];
+    for (var k=0; k<indices.length; k++) {
+      var idx=indices[k], sz=GANTT_SIZES[idx];
+      xs.push(GANTT_DURS[idx]);
+      bases.push(GANTT_STARTS[idx]);
+      cds.push(idx);
+      var ht = '<b>'+nm+'</b><br>Size: '+(sz/1024).toFixed(3)+' MB ('+sz.toFixed(1)+' KB)<br>Start: '+(GANTT_STARTS[idx]+T_OFFSET).toFixed(3)+' ms<br>Duration: '+GANTT_DURS[idx].toFixed(3)+' ms';
+      // Append overlap list if any
+      var ov = overlaps[idx];
+      if (ov && ov.length) {
+        ov.sort(function(a,b){ return GANTT_SIZES[b] - GANTT_SIZES[a]; });
+        var lines = [];
+        for (var j=0; j<Math.min(ov.length, 8); j++) {
+          var oi = ov[j];
+          lines.push((GANTT_SIZES[oi]/1024).toFixed(2) + ' MB, '
+            + (GANTT_STARTS[oi]+T_OFFSET).toFixed(0) + 'ms, '
+            + GANTT_DURS[oi].toFixed(1) + 'ms');
+        }
+        if (ov.length > 8) lines.push('... +' + (ov.length-8) + ' more');
+        ht += '<br><i>' + ov.length + ' overlapping:</i><br>'
+          + lines.join('<br>');
+      }
+      hts.push(ht);
+    }
+    yVals.push(yp); yTexts.push(nm);
+    traces.push({ x:xs, y:Array(indices.length).fill(yp), base:bases,
+      type:'bar', orientation:'h', name:nm, customdata:cds,
+      marker:{ color:cl,
+        line:{ color:'rgba(255,255,255,0)', width:6 } },
+      hovertext:hts, hoverinfo:'text',
+      hoverlabel:{ bgcolor:'#fff', bordercolor:cl, font:{ size:11 } }, showlegend:false });
+  }
+  Plotly.newPlot('chart2', traces, {
+    xaxis:{ title:'Time (ms)', range:range, showticklabels:false, showgrid:true, gridcolor:'#eaeaea', zeroline:false, fixedrange:false },
+    yaxis:{ title:'Operator', tickmode:'array', tickvals:yVals, ticktext:yTexts, autorange:'reversed', showgrid:false, zeroline:false, automargin:true, fixedrange:true },
+    barmode:'overlay', margin:{ l:280, r:30, t:10, b:50 }, height:Math.max(400,maxY*28+80), hovermode:'closest', hoverdistance:50, dragmode:'pan', showlegend:false
+  }, { displaylogo:false, displayModeBar:true, modeBarButtonsToRemove:['lasso2d','select2d'], scrollZoom:true });
+  document.getElementById('chart2').on('plotly_relayout', function(edata) {
+    if (isSyncing) return;
+    if (edata['xaxis.range[0]']!==undefined||edata['xaxis.range[1]']!==undefined) {
+      var layout = document.getElementById('chart2').layout;
+      if (layout && layout.xaxis && layout.xaxis.range) {
+        currentRange = [layout.xaxis.range[0], layout.xaxis.range[1]];
+      }
+      syncInputsFromRange(); updateChart1Range(currentRange); buildChart2(currentRange); updateRangeInfo();
+    }
+  });
+  document.getElementById('chart2').on('plotly_click', function(data) {
+    if (!data.points||!data.points.length) return; var i=data.points[0].customdata; if (i!==undefined) showBarDetail(i);
+  });
+}
+
+function showBarDetail(i) {
+  var panel=document.getElementById('detail-panel'), c=document.getElementById('detail-content');
+  var nm = OP_NAMES[GANTT_IDS[i]];
+  var csIdx = (typeof CS_IDX !== 'undefined') ? CS_IDX[i] : -1;
+  var cs = (csIdx !== undefined && csIdx >= 0 && typeof CS_POOL !== 'undefined')
+    ? CS_POOL[csIdx] : '';
+  var csHtml = cs
+    ? '<span class="label">Call Stack:</span><div class="call-stack-box">'+escHtml(cs)+'</div>'
+    : '<span class="label">Call Stack:</span><span class="value" style="color:#999">(empty)</span>';
+  // Find overlapping bars of same operator — scan all bars in this segment
+  var tMid = GANTT_STARTS[i] + GANTT_DURS[i] / 2;
+  var ovList = '';
+  var hits = [];
+  for (var k = 0; k < GANTT_STARTS.length; k++) {
+    if (k === i) continue;
+    if (OP_NAMES[GANTT_IDS[k]] !== nm) continue;
+    if (GANTT_STARTS[k] <= tMid && GANTT_STARTS[k] + GANTT_DURS[k] >= tMid) {
+      hits.push(k);
+    }
+  }
+  if (hits.length > 0) {
+    hits.sort(function(a,b){ return GANTT_SIZES[b] - GANTT_SIZES[a]; });
+    var rows = ['<br><b>' + hits.length + ' overlapping events:</b>'];
+    for (var k = 0; k < hits.length; k++) {
+      var oi = hits[k];
+      rows.push('<a href=\"javascript:void(0)\" onclick=\"showBarDetail('+oi+')\"'
+        + ' style=\"color:#4e79a7;text-decoration:none;display:block;padding:1px 0;'
+        + 'font-size:12px\">'
+        + '→ ' + (GANTT_SIZES[oi]/1024).toFixed(3) + ' MB, '
+        + (GANTT_STARTS[oi]+T_OFFSET).toFixed(0) + 'ms, '
+        + GANTT_DURS[oi].toFixed(1) + 'ms</a>');
+    }
+    ovList = rows.join('');
+  }
+  c.innerHTML='<span class="label">Operator:</span><span class="value">'+escHtml(nm)+'</span>'
+    +'<span class="label">Size:</span><span class="value">'+(GANTT_SIZES[i]/1024).toFixed(3)+' MB ('+GANTT_SIZES[i].toFixed(1)+' KB)</span>'
+    +'<span class="label">Start Time:</span><span class="value">'+(GANTT_STARTS[i]+T_OFFSET).toFixed(3)+' ms</span>'
+    +'<span class="label">Duration:</span><span class="value">'+GANTT_DURS[i].toFixed(3)+' ms</span>'
+    +'<span class="label">End Time:</span><span class="value">'+(GANTT_STARTS[i]+GANTT_DURS[i]+T_OFFSET).toFixed(3)+' ms</span>'
+    +'<span class="label">Total Allocated:</span><span class="value">'+(TOTAL_ALLOC[i]||0).toFixed(2)+' MB</span>'
+    +csHtml
+    +ovList;
+  panel.classList.add('active'); panel.scrollIntoView({ behavior:'smooth', block:'nearest' });
+}
+function escHtml(s) { return String(s).replace(/&/g,'&amp;').replace(/</g,'&lt;').replace(/>/g,'&gt;').replace(/"/g,'&quot;'); }
+
+function updateChart1Range(range) { isSyncing=true; Plotly.relayout('chart1',{ 'xaxis.range':range }); isSyncing=false; }
+function syncInputsFromRange() {
+  leftInput.value=(currentRange[0]+T_OFFSET).toFixed(3); rightInput.value=(currentRange[1]+T_OFFSET).toFixed(3);
+  leftInput.classList.remove('invalid'); rightInput.classList.remove('invalid');
+}
+function onLeftChange() {
+  if (isSyncing) return; var v=parseFloat(leftInput.value)-T_OFFSET;
+  if (isNaN(v)||v<T_MIN||v>=currentRange[1]) { leftInput.classList.add('invalid'); return; }
+  leftInput.classList.remove('invalid'); currentRange[0]=v; isSyncing=true;
+  Plotly.relayout('chart1',{ 'xaxis.range':currentRange }); buildChart2(currentRange); isSyncing=false; updateRangeInfo();
+}
+function onRightChange() {
+  if (isSyncing) return; var v=parseFloat(rightInput.value)-T_OFFSET;
+  if (isNaN(v)||v>T_MAX||v<=currentRange[0]) { rightInput.classList.add('invalid'); return; }
+  rightInput.classList.remove('invalid'); currentRange[1]=v; isSyncing=true;
+  Plotly.relayout('chart1',{ 'xaxis.range':currentRange }); buildChart2(currentRange); isSyncing=false; updateRangeInfo();
+}
+function updateRangeInfo() {
+  var cnt=0, ops={}; for (var i=0; i<GANTT_STARTS.length; i++) if (GANTT_STARTS[i]+GANTT_DURS[i]>currentRange[0]&&GANTT_STARTS[i]<currentRange[1]) {
+    cnt++; ops[OP_NAMES[GANTT_IDS[i]]]=1;
+  }
+  var nOps = Object.keys(ops).length;
+  rangeInfo.textContent='Events: '+cnt+' / '+TOTAL_OP_COUNT+'  |  Operators: '+nOps+'  |  Span: '+(currentRange[1]-currentRange[0]).toFixed(2)+' ms';
+}
+leftInput.addEventListener('change', onLeftChange); leftInput.addEventListener('keydown', function(e){if(e.key==='Enter')onLeftChange()});
+rightInput.addEventListener('change', onRightChange); rightInput.addEventListener('keydown', function(e){if(e.key==='Enter')onRightChange()});
+leftInput.value=T_OFFSET.toFixed(3); rightInput.value=(T_MAX+T_OFFSET).toFixed(3);
+buildChart1(currentRange); buildChart2(currentRange); updateRangeInfo();
+</script>
+</body>
+</html>

--- a/rl_insight/visualizer/memory_visualizer.py
+++ b/rl_insight/visualizer/memory_visualizer.py
@@ -1,0 +1,483 @@
+# Copyright (c) 2025 verl-project authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import json
+import os
+from typing import Union
+
+import numpy as np
+import pandas as pd
+from loguru import logger
+from omegaconf import DictConfig
+
+from rl_insight.config import get_config_value
+from rl_insight.data import DataEnum
+
+from .visualizer import (
+    BaseVisualizer,
+    register_cluster_visualizer,
+)
+
+
+@register_cluster_visualizer("memory_html")
+class MemoryVisualizer(BaseVisualizer):
+    """HTML memory allocation timeline; interactive Gantt chart of memory events.
+
+    Displays memory allocations over time for each (role, rank), color-coded
+    by operator name.  Includes hover details for memory size and cumulative
+    memory statistics (allocated / reserved / active).
+    """
+
+    input_type: DataEnum = DataEnum.MEMORY_SUMMARY
+
+    # ── Rendering constants ────────────────────────────────────────────
+    _MAX_TIMELINE_POINTS = 2000  # max points in Chart1 memory line
+    _MAX_SEGMENTS = 20  # upper bound on segment file count
+    _TARGET_BARS_PER_SEGMENT = 5000  # target bar count before splitting
+    _HOVER_TOP_N = 10  # Chart1 hover shows top-N by size
+    _KB_TO_MB = 1.0 / 1024.0  # KB → MB conversion factor
+
+    def __init__(self, config: Union[DictConfig, dict]):
+        super().__init__(config)
+        self.output_path = get_config_value(config, "output.path", None)
+
+    def run(self, data):
+        return self.generate_memory_timeline(data)
+
+    def generate_memory_timeline(self, data):
+        """Generate an interactive memory timeline HTML visualization.
+
+        Creates a self-contained HTML file with two synchronized charts:
+        1. Memory usage timeline — total allocated memory over time.
+        2. Operator Gantt chart — horizontal bars showing each operator's
+           memory allocation duration.
+
+        Includes interactive controls for time-range selection and operator
+        count filtering.
+
+        Args:
+            data: Preprocessed DataFrame with columns: name, size_kb,
+                  start_time_ms, duration_ms, total_allocated_mb,
+                  total_reserved_mb, total_active_mb, device_type,
+                  call_stack_top.  Only positive allocations (size_kb > 0).
+        """
+        logger.info(
+            f"Starting memory timeline generation: "
+            f"{len(data) if data is not None else 0} input records"
+        )
+
+        if data is None or data.empty:
+            logger.info("No memory allocations found — nothing to visualize.")
+            return None
+
+        # Filter to only positive allocations (skip releases)
+        data = data[data["size_kb"] > 0]
+
+        if data.empty:
+            logger.info("No positive memory allocations found — nothing to visualize.")
+            return None
+
+        logger.info(f"Filtered to {len(data)} positive allocation events")
+
+        # Compute end times and size in MB
+        data["end_time_ms"] = data["start_time_ms"] + data["duration_ms"]
+        data["size_mb"] = data["size_kb"] * self._KB_TO_MB
+
+        # ── Global time range ─────────────────────────────────────────
+        # data is pre-sorted by start_time_ms
+        t_min_abs = float(data["start_time_ms"].iloc[0])
+        t_max_abs = float((data["start_time_ms"] + data["duration_ms"]).max())
+        logger.info(
+            f"Time range: {t_min_abs:.0f} – {t_max_abs:.0f} ms "
+            f"(duration: {(t_max_abs - t_min_abs) / 1000:.2f} s)"
+        )
+
+        # ── Chart 1 data: Memory usage timeline ───────────────────────
+        # Vectorized: build start(+size) and end(-size) event columns
+        rel_starts = (data["start_time_ms"] - t_min_abs).round(2)
+        rel_ends = (data["end_time_ms"] - t_min_abs).round(2)
+        sizes = data["size_kb"].astype(float)
+
+        times = np.concatenate([rel_starts, rel_ends])
+        deltas = np.concatenate([sizes, -sizes])
+
+        events_df = pd.DataFrame({"time": times, "delta_kb": deltas})
+        events_df = events_df.groupby("time", as_index=False)["delta_kb"].sum()
+        events_df = events_df.sort_values("time")
+        events_df["total_mb"] = events_df["delta_kb"].cumsum() * self._KB_TO_MB
+
+        # Downsample memory timeline if too many points
+        orig_timeline_points = len(events_df)
+        if len(events_df) > self._MAX_TIMELINE_POINTS:
+            events_df = events_df.iloc[
+                np.linspace(0, len(events_df) - 1, self._MAX_TIMELINE_POINTS, dtype=int)
+            ]
+            logger.info(
+                f"Timeline downsampled: {orig_timeline_points} → "
+                f"{len(events_df)} points"
+            )
+
+        memory_timeline = [
+            {"time": float(row["time"]), "total_mb": round(float(row["total_mb"]), 4)}
+            for _, row in events_df.iterrows()
+        ]
+
+        # ── Chart 2 data: Operator Gantt ──────────────────────────────
+        # Split parallel arrays: compact JSON, no nested keys
+        gantt_name_ids = []  # indices into op_names
+        gantt_starts = []
+        gantt_durations = []
+        gantt_sizes = []
+        total_alloc_arr = []
+        call_stack_pool = []
+        call_stack_pool_map = {}
+        call_stack_idx_arr = []
+        op_names = []
+        name_to_id = {}
+
+        # Pre-extract columns to avoid iterrows() per-row Series overhead.
+        # Numeric fields: vectorized round() on full columns before .tolist().
+        _start_col = (data["start_time_ms"] - t_min_abs).round(2).tolist()
+        _dur_col = data["duration_ms"].round(2).tolist()
+        _size_col = data["size_kb"].round(2).tolist()
+        _alloc_col = data["total_allocated_mb"].round(2).tolist()
+        _name_col = data["name"].tolist()
+        _cs_col = data.get("call_stack", pd.Series([""] * len(data))).tolist()
+
+        for i in range(len(data)):
+            op_name = _name_col[i]
+            if op_name not in name_to_id:
+                name_to_id[op_name] = len(op_names)
+                op_names.append(op_name)
+            gantt_name_ids.append(name_to_id[op_name])
+            gantt_starts.append(_start_col[i])
+            gantt_durations.append(_dur_col[i])
+            gantt_sizes.append(_size_col[i])
+            total_alloc_arr.append(_alloc_col[i])
+            cs = _cs_col[i]
+            if not cs or (isinstance(cs, float) and pd.isna(cs)):
+                call_stack_idx_arr.append(-1)
+            else:
+                cs = str(cs)
+                if cs not in call_stack_pool_map:
+                    call_stack_pool_map[cs] = len(call_stack_pool)
+                    call_stack_pool.append(cs)
+                call_stack_idx_arr.append(call_stack_pool_map[cs])
+
+        total_bar_count = len(gantt_name_ids)
+        logger.info(
+            f"Built {total_bar_count} bar entries across "
+            f"{len(op_names)} unique operators"
+        )
+
+        # ── Split into time segments ──────────────────────────────────
+        num_segments = max(
+            1,
+            min(
+                self._MAX_SEGMENTS,
+                int(np.ceil(total_bar_count / self._TARGET_BARS_PER_SEGMENT)),
+            ),
+        )
+        logger.info(
+            f"Splitting into {num_segments} time segment(s) (max {self._MAX_SEGMENTS})"
+        )
+
+        t_rel_min = gantt_starts[0]
+        t_rel_max = max(s + d for s, d in zip(gantt_starts, gantt_durations))
+        seg_width = (t_rel_max - t_rel_min) / num_segments
+
+        # Build Chart1 data once (full timeline, shared across segments)
+        tl_xy, tl_active = self._build_chart1_data(
+            memory_timeline,
+            gantt_name_ids,
+            gantt_starts,
+            gantt_durations,
+            gantt_sizes,
+            op_names,
+        )
+
+        # Color map (shared across segments)
+        color_palette = [
+            "#4e79a7",
+            "#f28e8b",
+            "#59a14f",
+            "#b07aa1",
+            "#9c755f",
+            "#76b7b2",
+            "#edc948",
+            "#bab0ab",
+            "#8cd17d",
+            "#ff9da7",
+            "#e15759",
+            "#86bcb6",
+            "#b6992d",
+            "#d37295",
+            "#a0cbe8",
+            "#ffbe7d",
+            "#b07aa1",
+            "#d4a6c8",
+            "#8c564b",
+            "#c49c94",
+        ]
+        op_color_map = {}
+        for i, op_name in enumerate(op_names):
+            op_color_map[op_name] = color_palette[i % len(color_palette)]
+
+        output_dir = self.output_path or "."
+        if output_dir.endswith(".html"):
+            output_dir = os.path.dirname(output_dir) or "."
+        os.makedirs(output_dir, exist_ok=True)
+
+        segments = []
+        # Pre-compute all segment boundaries for the segment-map feature
+        all_segments_info = []
+        for seg_idx in range(num_segments):
+            seg_start = t_rel_min + seg_idx * seg_width
+            seg_end = t_rel_min + (seg_idx + 1) * seg_width
+            if seg_idx == num_segments - 1:
+                seg_end = t_rel_max + 1  # include all remaining
+
+            seg_label = f"{seg_start + t_min_abs:.0f} – {seg_end + t_min_abs:.0f} ms"
+            all_segments_info.append(
+                (seg_idx, round(seg_start, 2), round(seg_end, 2), seg_label)
+            )
+
+        # Segment map for JS: [idx, rel_start, rel_end] — shared by all segments
+        seg_data = [[si, rs, re] for si, rs, re, _ in all_segments_info]
+
+        for seg_idx in range(num_segments):
+            seg_start = all_segments_info[seg_idx][1]
+            seg_end = all_segments_info[seg_idx][2]
+            seg_label = all_segments_info[seg_idx][3]
+
+            # Filter bar indices that overlap with this time segment
+            bar_indices = [
+                i
+                for i in range(len(gantt_starts))
+                if gantt_starts[i] + gantt_durations[i] > seg_start
+                and gantt_starts[i] < seg_end
+            ]
+            if not bar_indices:
+                logger.info(f"  Segment {seg_idx + 1}/{num_segments} empty — skipped")
+                continue  # skip empty segments
+
+            seg_gantt_name_ids = [gantt_name_ids[i] for i in bar_indices]
+            seg_gantt_starts = [gantt_starts[i] for i in bar_indices]
+            seg_gantt_durations = [gantt_durations[i] for i in bar_indices]
+            seg_gantt_sizes = [gantt_sizes[i] for i in bar_indices]
+            seg_total_alloc = [total_alloc_arr[i] for i in bar_indices]
+            seg_call_stack_idx_arr = [call_stack_idx_arr[i] for i in bar_indices]
+
+            segments.append((seg_idx, seg_label, len(bar_indices)))
+
+            # Build per-segment HTML + detail_data.js
+            html, detail_js = self._build_memory_html(
+                t_offset=t_min_abs,
+                tl_xy=tl_xy,
+                tl_active=tl_active,
+                gantt_name_ids=seg_gantt_name_ids,
+                gantt_starts=seg_gantt_starts,
+                gantt_durations=seg_gantt_durations,
+                gantt_sizes=seg_gantt_sizes,
+                total_alloc_arr=seg_total_alloc,
+                call_stack_pool=call_stack_pool,
+                call_stack_idx_arr=seg_call_stack_idx_arr,
+                op_names=op_names,
+                op_color_map=op_color_map,
+                total_bar_count=len(seg_gantt_name_ids),
+                global_bar_count=total_bar_count,
+                seg_idx=seg_idx,
+                seg_label=seg_label,
+                num_segments=num_segments,
+                seg_data=seg_data,
+                t_rel_max=t_rel_max,
+            )
+
+            data_path = os.path.join(output_dir, f"detail_data_{seg_idx:02d}.js")
+            html_path = os.path.join(output_dir, f"memory_timeline_{seg_idx:02d}.html")
+            with open(data_path, "w", encoding="utf-8") as f:
+                f.write(detail_js)
+            with open(html_path, "w", encoding="utf-8") as f:
+                f.write(html)
+
+            logger.info(
+                f"  [{seg_idx + 1}/{num_segments}] "
+                f"memory_timeline_{seg_idx:02d}.html "
+                f"({len(html) / 1024:.0f} KB HTML + "
+                f"{len(detail_js) / 1024:.0f} KB data) "
+                f"— {len(bar_indices)} events, "
+                f"{seg_label}"
+            )
+
+        # Summary
+        logger.info(
+            f"Memory timeline generation complete: "
+            f"{len(segments)} segment(s), {total_bar_count} events, "
+            f"{len(op_names)} operators → {output_dir}"
+        )
+        return os.path.join(output_dir, "memory_timeline_00.html")
+
+    @staticmethod
+    def _build_chart1_data(
+        memory_timeline,
+        gantt_name_ids,
+        gantt_starts,
+        gantt_durations,
+        gantt_sizes,
+        op_names,
+    ):
+        """Build Chart1 (memory timeline) data from all bars.
+
+        Returns (tl_xy, tl_active) — shared across all segments.
+        """
+        all_intervals = []
+        for i in range(len(gantt_name_ids)):
+            all_intervals.append(
+                (
+                    gantt_starts[i],
+                    gantt_starts[i] + gantt_durations[i],
+                    op_names[gantt_name_ids[i]],
+                    gantt_sizes[i],
+                )
+            )
+        all_intervals.sort(key=lambda x: x[0])
+
+        tl_xy = []
+        tl_active = []
+        if memory_timeline and all_intervals:
+            interval_idx = 0
+            n_intervals = len(all_intervals)
+            active_intervals = []
+
+            for point in memory_timeline:
+                t = point["time"]
+
+                # Add intervals that start at or before t
+                while (
+                    interval_idx < n_intervals and all_intervals[interval_idx][0] <= t
+                ):
+                    active_intervals.append(all_intervals[interval_idx])
+                    interval_idx += 1
+
+                # Remove intervals that have ended
+                active_intervals = [item for item in active_intervals if item[1] > t]
+
+                tl_xy.append([round(t, 2), round(point["total_mb"], 2)])
+                if active_intervals:
+                    sorted_active = sorted(active_intervals, key=lambda x: -x[3])
+                    top_n = sorted_active[: MemoryVisualizer._HOVER_TOP_N]
+                    tl_active.append(
+                        [
+                            len(active_intervals),
+                            [[op_name, round(sz, 1)] for _, _, op_name, sz in top_n],
+                        ]
+                    )
+        return tl_xy, tl_active
+
+    def _build_memory_html(
+        self,
+        t_offset,
+        tl_xy,
+        tl_active,
+        gantt_name_ids,
+        gantt_starts,
+        gantt_durations,
+        gantt_sizes,
+        total_alloc_arr,
+        call_stack_pool,
+        call_stack_idx_arr,
+        op_names,
+        op_color_map,
+        total_bar_count,
+        global_bar_count,
+        seg_idx,
+        seg_label,
+        num_segments,
+        seg_data,
+        t_rel_max,
+    ):
+        """Build HTML + detail_data.js for one time segment.
+
+        Chart1 (tl_xy, tl_active) is global — same across all segments.
+        Chart2 arrays are per-segment filtered.
+        """
+        compact_opts = {"separators": (",", ":"), "ensure_ascii": False}
+        to_json = json.dumps
+
+        # All data goes into detail_data.js — HTML is a pure template (~3 KB)
+        detail_lines = [
+            "var TL_XY = " + to_json(tl_xy, **compact_opts) + ";",
+            "var GANTT_IDS = " + to_json(gantt_name_ids, **compact_opts) + ";",
+            "var GANTT_STARTS = " + to_json(gantt_starts, **compact_opts) + ";",
+            "var GANTT_DURS = " + to_json(gantt_durations, **compact_opts) + ";",
+            "var OP_NAMES = " + to_json(op_names, **compact_opts) + ";",
+            "var T_OFFSET = " + to_json(t_offset) + ";",
+            "var TOTAL_OP_COUNT = " + str(total_bar_count) + ";",
+            "var COLOR_MAP = " + to_json(op_color_map, **compact_opts) + ";",
+            "var GANTT_SIZES = " + to_json(gantt_sizes, **compact_opts) + ";",
+            "var TOTAL_ALLOC = " + to_json(total_alloc_arr, **compact_opts) + ";",
+            "var TL_ACTIVE = " + to_json(tl_active, **compact_opts) + ";",
+            "var CS_POOL = " + to_json(call_stack_pool, **compact_opts) + ";",
+            "var CS_IDX = " + to_json(call_stack_idx_arr, **compact_opts) + ";",
+            # Segment info for hint feature: [idx, rel_start, rel_end]
+            "var SEGMENTS = " + to_json(seg_data, **compact_opts) + ";",
+            "var T_REL_MAX = " + to_json(t_rel_max) + ";",
+            "var SEG_INDEX = " + str(seg_idx) + ";",
+        ]
+        detail_js = "\n".join(detail_lines)
+
+        # Read HTML template and inject segment navigation
+        template_path = os.path.join(os.path.dirname(__file__), "memory_template.html")
+        with open(template_path, "r", encoding="utf-8") as f:
+            html = f.read()
+
+        # Inject segment navigation and data file reference
+        data_filename = f"detail_data_{seg_idx:02d}.js"
+        nav_html = self._build_segment_nav(
+            seg_idx, seg_label, num_segments, global_bar_count
+        )
+        html = html.replace("__SEGMENT_NAV__", nav_html)
+        html = html.replace("__SEGMENT_LABEL__", seg_label)
+        html = html.replace("__DATA_FILE__", data_filename)
+
+        return html, detail_js
+
+    @staticmethod
+    def _build_segment_nav(seg_idx, seg_label, num_segments, global_bar_count):
+        """Build segment navigation HTML snippet."""
+        parts = [
+            '<div class="control-group" style="border-left:2px solid #eee;'
+            'padding-left:16px;gap:4px">'
+        ]
+        if seg_idx > 0:
+            parts.append(
+                f'<a href="memory_timeline_{seg_idx - 1:02d}.html" '
+                f'style="text-decoration:none;color:#4e79a7;font-size:13px;'
+                f'padding:4px 8px;border:1px solid #4e79a7;border-radius:4px"'
+                f">← Prev</a>"
+            )
+        parts.append(
+            f'<span style="font-size:12px;color:#888;margin:0 6px">'
+            f"Seg {seg_idx + 1}/{num_segments}: {seg_label}</span>"
+        )
+        if seg_idx < num_segments - 1:
+            parts.append(
+                f'<a href="memory_timeline_{seg_idx + 1:02d}.html" '
+                f'style="text-decoration:none;color:#4e79a7;font-size:13px;'
+                f'padding:4px 8px;border:1px solid #4e79a7;border-radius:4px"'
+                f">Next →</a>"
+            )
+        parts.append(f'<span class="unit">({global_bar_count} total events)</span>')
+        parts.append("</div>")
+        return "".join(parts)

--- a/tests/parser/__init__.py
+++ b/tests/parser/__init__.py
@@ -14,10 +14,7 @@
 
 """Data module for RL-Insight."""
 
-from .data_checker import (
-    DataChecker,
-    DataEnum
-)
+from .data_checker import DataChecker, DataEnum
 
 __all__ = [
     "DataChecker",


### PR DESCRIPTION
### What does this PR do?

Adds a Plotly-based interactive memory timeline visualizer (`memory_html`) that renders
NPU memory allocation events as an interactive Gantt chart. Key features:

- **Dual-chart layout**: Chart1 shows global memory usage trend (line + area fill); Chart2
  shows per-operator Gantt bars, color-coded by operator name with bidirectional zoom sync.
- **Time-window segmentation**: Large datasets (100k+ events) are split into at most 20
  time-window segments, each generating a standalone HTML+JS file pair with Prev/Next
  navigation. Chart1 data (global timeline) is shared across all segments.
- **Segment smart hint**: When the user zooms Chart1 into a different time range, a "Best:
  Seg N →" hint appears with a clickable link to the matching segment file.
- **Overlap detection**: When multiple bars of the same operator stack at the same time
  point, the hover tooltip and detail panel both list all overlapping events with size and
  timing info. Click any row in the detail panel to navigate between overlapping events.
- **Call stack display**: `call_stack` field is stored per event and shown in the detail
  panel on bar click (empty call stacks display as `(empty)` gracefully).
- **Absolute time display**: Chart1 x-axis tick labels and hover tooltips show absolute
  timestamps, while internal data uses relative times for compact JSON output.
- 
### Checklist Before Starting

- [ ] Search for similar PRs. Paste at least one query link here: ...
- [ ] Format the PR title as `[{modules}] {type}: {description}` (This will be checked by the CI)
  - `{modules}` include `pipeline`, `parser`, `visualizer`, `data`, `deployment`, `perf`, `algo`, `env`, `doc`, `cfg`, `ci`, `misc`
  - If this PR involves multiple modules, separate them with `,` like `[mstx, ci]`
  - `{type}` is in `feat`, `fix`, `refactor`, `chore`, `test`
  - If this PR breaks any API (CLI arguments, config, function signature, etc.), add `[BREAKING]` to the beginning of the title.
  - Example: `[BREAKING][mstx, torch_profile] feat: support timeline parsing`

### Test
python -m rl_insight.main input.path=xx   timeline.parser.type=memory  timeline.visualizer.type=memory_html output.path=xx

<img width="2998" height="1842" alt="image" src="https://github.com/user-attachments/assets/272fadeb-b445-49b8-b082-b45d968f6d67" />
<img width="2965" height="1816" alt="image" src="https://github.com/user-attachments/assets/51648fa8-119a-4f1a-8a5b-829f0456363d" />


> For changes that can not be tested by CI (e.g., algorithm implementation, new model support), validate by experiment(s) and show results like training curve plots, evaluation results, etc.

### API and Usage Example

> Demonstrate how the API changes if any, and provide usage example(s) if possible.

```python
# Add code snippet or script demonstrating how to use this
```

### Design & Code Changes

**New files:**
- `rl_insight/visualizer/memory_visualizer.py` — `MemoryVisualizer` class registered as
  `memory_html` cluster visualizer. Handles data preprocessing, segment splitting,
  JSON generation, and HTML template injection.
- `rl_insight/visualizer/memory_template.html` — Plotly-based HTML template (~3 KB)
  with all rendering logic in vanilla JS. Data lives in a separate `detail_data.js` file.

**Modified files:**
- `rl_insight/visualizer/__init__.py` — Added `from .memory_visualizer import MemoryVisualizer`
  to register the `memory_html` visualizer.

**Key design decisions:**
- Data arrays are stored in external `.js` files (not inlined in HTML), keeping the HTML
  template lightweight and cacheable.
- `call_stack` strings use a pool+index pattern (`CS_POOL` / `CS_IDX`) for deduplication,
  minimizing JSON output size.
- Operator bars are grouped into a single Plotly trace per operator using `x:[]` and
  `base:[]` arrays, reducing trace count from O(events) to O(unique_operators).
- Segment overlap uses `start + duration > seg_start AND start < seg_end` so events
  spanning segment boundaries appear in both files.

### Checklist Before Submitting

> [!IMPORTANT]
> Please check all the following items before requesting a review, otherwise the reviewer might deprioritize this PR for review.

- [ ] Read the [Contribute Guide](https://github.com/verl-project/rl-insight/blob/main/CONTRIBUTING.md).
- [ ] Apply [pre-commit checks](https://github.com/verl-project/rl-insight/blob/main/CONTRIBUTING.md#code-linting-and-formatting): `pre-commit install && pre-commit run --all-files --show-diff-on-failure --color=always`
- [ ] Add / Update [the documentation](https://github.com/verl-project/rl-insight/tree/main/docs).
- [ ] Add unit or end-to-end test(s) to [the CI workflow](https://github.com/verl-project/rl-insight/tree/main/.github/workflows) to cover all the code. If not feasible, explain why: ...