### PR TITLE
[ci] test: rl-insight monitor add ci

### DIFF
--- a/.github/workflows/monitor_smoke_test.yml
+++ b/.github/workflows/monitor_smoke_test.yml
@@ -27,7 +27,7 @@ permissions:
 jobs:
   special_e2e_monitor_smoke_test:
     runs-on: ubuntu-latest
-    timeout-minutes: 15
+    timeout-minutes: 30
     strategy:
       matrix:
         python-version: ["3.11"]
@@ -49,6 +49,7 @@ jobs:
         run: rl-insight --help
 
       - name: Install server services (Prometheus, Tempo, Grafana)
+        timeout-minutes: 20
         run: |
           rl-insight server install
           echo "Installed server binaries under ~/.rl-insight/services"
@@ -61,15 +62,16 @@ jobs:
 
       - name: Wait for services to be ready
         run: |
-          echo "Waiting for RL-Insight hub (port 18080)..."
+          echo "Waiting for RL-Insight server (port 18080)..."
           for i in $(seq 1 30); do
-            if curl -sf http://127.0.0.1:18080/ > /dev/null 2>&1; then
-              echo "Hub is ready."
+            if curl -sf http://127.0.0.1:18080/healthz > /dev/null 2>&1; then
+              echo "RL-Insight server is ready."
               break
             fi
             echo "  attempt $i/30: hub not ready yet, waiting..."
             sleep 2
           done
+          curl -sf http://127.0.0.1:18080/healthz > /dev/null
 
           echo "Waiting for Prometheus (port 9090)..."
           for i in $(seq 1 30); do
@@ -80,6 +82,18 @@ jobs:
             echo "  attempt $i/30: Prometheus not ready yet, waiting..."
             sleep 2
           done
+          curl -sf http://127.0.0.1:9090/-/ready > /dev/null
+
+          echo "Waiting for Tempo (port 3200)..."
+          for i in $(seq 1 30); do
+            if curl -sf http://127.0.0.1:3200/ready > /dev/null 2>&1; then
+              echo "Tempo is ready."
+              break
+            fi
+            echo "  attempt $i/30: Tempo not ready yet, waiting..."
+            sleep 2
+          done
+          curl -sf http://127.0.0.1:3200/ready > /dev/null
 
           echo "Waiting for Grafana (port 3000)..."
           for i in $(seq 1 30); do
@@ -90,20 +104,10 @@ jobs:
             echo "  attempt $i/30: Grafana not ready yet, waiting..."
             sleep 2
           done
+          curl -sf http://127.0.0.1:3000/api/health > /dev/null
 
       - name: Run monitor smoke test
-        run: |
-          python tests/monitor/special_e2e/test_monitor_smoke.py
-
-      - name: Verify metrics in Prometheus
-        run: |
-          echo "Querying Prometheus for smoke test metrics..."
-          # Check that the train_step_total counter was reported.
-          curl -sf "http://127.0.0.1:9090/api/v1/query?query=train_step_total" | python -m json.tool
-          # Check that the reward_mean gauge was reported.
-          curl -sf "http://127.0.0.1:9090/api/v1/query?query=reward_mean" | python -m json.tool
-          # Check that the step_latency_ms histogram was reported.
-          curl -sf "http://127.0.0.1:9090/api/v1/query?query=step_latency_ms_bucket" | python -m json.tool
+        run: pytest -s -v tests/monitor/special_e2e/test_monitor_smoke.py
 
       - name: Stop server stack
         if: always()
@@ -112,3 +116,4 @@ jobs:
           rl-insight server stop || true
           # Clean up any lingering Ray processes.
           ray stop --force 2>/dev/null || true
+          rm -rf ~/.rl-insight/services

--- a/tests/monitor/special_e2e/test_monitor_smoke.py
+++ b/tests/monitor/special_e2e/test_monitor_smoke.py
@@ -12,57 +12,176 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-"""Smoke test for RL-Insight Monitor.
-
-Runs a short instrumentation loop against a running RL-Insight server stack
-(Prometheus + Tempo + Grafana + hub) and verifies metrics are being collected.
-"""
+"""Data-path tests for a monitor stack managed by the CI workflow."""
 
 from __future__ import annotations
 
+import json
 import os
+import sys
 import time
+import uuid
+from collections.abc import Callable, Generator
+from typing import Any, cast
 
+import pytest
 import ray
+import requests
+
 import rl_insight as insight
+from rl_insight.utils.constants import MonitorRayActor
 
 
-def main() -> None:
-    """Run a finite instrumentation loop for smoke-testing the monitor stack."""
-    server_url = os.environ.setdefault(
-        "RL_INSIGHT_SERVER_URL", "http://127.0.0.1:18080"
+pytestmark = pytest.mark.skipif(
+    sys.platform != "linux", reason="the managed server stack only runs on Linux"
+)
+
+SERVER_URL = os.environ.get("RL_INSIGHT_SERVER_URL", "http://127.0.0.1:18080")
+TEMPO_QUERY_URL = os.environ.get("RL_INSIGHT_TEMPO_QUERY_URL", "http://127.0.0.1:3200")
+READY_TIMEOUT_SECONDS = 60
+TEST_RUN_ID = uuid.uuid4().hex
+
+
+def _wait_for_json(
+    url: str,
+    *,
+    params: dict[str, str] | None = None,
+    ready: Callable[[dict[str, Any]], bool] = bool,
+) -> dict[str, Any]:
+    deadline = time.monotonic() + READY_TIMEOUT_SECONDS
+    last_error: Exception | None = None
+    while time.monotonic() < deadline:
+        try:
+            response = requests.get(url, params=params, timeout=3)
+            response.raise_for_status()
+            payload = response.json()
+            if ready(payload):
+                return payload
+        except (requests.RequestException, ValueError) as exc:
+            last_error = exc
+        time.sleep(1)
+    raise AssertionError(
+        f"{url} was not ready within {READY_TIMEOUT_SECONDS}s: {last_error}"
     )
 
-    ray.init(namespace="rl-insight-monitor", ignore_reinit_error=True)
-    insight.init(project="verl", experiment_name="monitor_smoke_test")
 
-    labels = {"worker": "trainer_0"}
-    num_iterations = 10
-
-    print(
-        f"Running {num_iterations} instrumentation iterations against {server_url}..."
+@pytest.fixture(scope="module")
+def monitor_stack() -> Generator[dict[str, str], None, None]:
+    """Connect the reporting client to the stack started by the workflow."""
+    os.environ["RL_INSIGHT_SERVER_URL"] = SERVER_URL
+    services = _wait_for_json(
+        f"{SERVER_URL}/api/v1/services",
+        ready=lambda data: data.get("status") == "ok",
     )
+    endpoints = {
+        "prometheus": f"http://127.0.0.1:{services['prometheus_port']}",
+        "otlp": f"http://127.0.0.1:{services['otlp_port']}",
+        "tempo": TEMPO_QUERY_URL,
+    }
 
-    for step in range(num_iterations):
-        with insight.trace_state(
-            "rollout_generate", state_lane_id="replica_0", step=step
-        ):
-            time.sleep(0.5)
+    ray.init(namespace=MonitorRayActor.NAMESPACE, ignore_reinit_error=True)
+    insight.init(project="rl-insight-e2e", experiment_name="monitor-smoke")
+    try:
+        yield endpoints
+    finally:
+        insight.finish()
+        try:
+            hub = ray.get_actor(
+                MonitorRayActor.NAME, namespace=MonitorRayActor.NAMESPACE
+            )
+            ray.kill(hub, no_restart=True)
+        except ValueError:
+            pass
+        ray.shutdown()
 
-        insight.metric_count("train_step_total", amount=1, **labels)
-        insight.metric_gauge("reward_mean", value=1.0 + step * 0.01, **labels)
+
+def test_monitor_services_should_be_reachable_when_stack_is_running(
+    monitor_stack: dict[str, str],
+) -> None:
+    """Verify the control, metrics, and trace data paths are reachable."""
+    health = requests.get(f"{SERVER_URL}/healthz", timeout=3)
+    prometheus = requests.get(f"{monitor_stack['prometheus']}/-/ready", timeout=3)
+    tempo = requests.get(f"{monitor_stack['tempo']}/ready", timeout=3)
+    otlp = requests.get(f"{monitor_stack['otlp']}/v1/traces", timeout=3)
+    hub = ray.get_actor(MonitorRayActor.NAME, namespace=MonitorRayActor.NAMESPACE)
+    hub_status = cast(dict[str, Any], ray.get(hub.get_status.remote()))
+
+    assert health.json() == {"status": "ok"}
+    assert prometheus.ok
+    assert tempo.ok
+    assert otlp.status_code < 500
+    assert requests.get(hub_status["metrics_endpoint"], timeout=3).ok
+    assert hub_status["otel_traces_enabled"] is True
+
+
+def test_monitor_metrics_should_match_reported_values_when_events_are_emitted(
+    monitor_stack: dict[str, str],
+) -> None:
+    """Report counter, gauge, and histogram events and verify stored values."""
+    for step in range(3):
+        insight.metric_count(
+            "train_step", amount=1, worker="trainer_0", test_run=TEST_RUN_ID
+        )
+        insight.metric_gauge(
+            "reward_mean",
+            value=1.0 + step * 0.01,
+            worker="trainer_0",
+            test_run=TEST_RUN_ID,
+        )
         insight.metric_histogram(
-            "step_latency_ms", value=200 + (step % 5) * 20, **labels
+            "step_latency_ms",
+            value=200 + step * 20,
+            worker="trainer_0",
+            test_run=TEST_RUN_ID,
         )
 
-        print(f"  Step {step + 1}/{num_iterations} complete")
+    hub = ray.get_actor(MonitorRayActor.NAME, namespace=MonitorRayActor.NAMESPACE)
+    ray.get(hub.get_status.remote())
 
-    # Allow a short window for Prometheus to scrape the latest metrics.
-    time.sleep(5)
-    print("Smoke test instrumentation complete.")
+    expected_values = {
+        "rl_insight_monitor_train_step_total": 3.0,
+        "rl_insight_monitor_reward_mean": 1.02,
+        "rl_insight_monitor_step_latency_ms_count": 3.0,
+        "rl_insight_monitor_step_latency_ms_sum": 660.0,
+    }
+    for metric_name, expected in expected_values.items():
+        payload = _wait_for_json(
+            f"{monitor_stack['prometheus']}/api/v1/query",
+            params={
+                "query": (f'{metric_name}{{test_run="{TEST_RUN_ID}"}} == {expected}')
+            },
+            ready=lambda data: bool(data.get("data", {}).get("result")),
+        )
+        result = payload["data"]["result"]
+        assert result[0]["metric"]["worker"] == "trainer_0"
+        assert float(result[0]["value"][1]) == pytest.approx(expected)
 
-    ray.shutdown()
 
+def test_monitor_trace_should_be_queryable_when_trace_is_reported(
+    monitor_stack: dict[str, str],
+) -> None:
+    """Report a state trace and verify Tempo stores its name and attributes."""
+    trace_name = "monitor_e2e_rollout_generate"
+    with insight.trace_state(
+        trace_name,
+        state_lane_id="replica_0",
+        step=7,
+        test_run=TEST_RUN_ID,
+    ):
+        time.sleep(0.1)
 
-if __name__ == "__main__":
-    main()
+    hub = ray.get_actor(MonitorRayActor.NAME, namespace=MonitorRayActor.NAMESPACE)
+    status = cast(dict[str, Any], ray.get(hub.get_status.remote()))
+    assert status["otel_traces_enabled"] is True
+
+    search = _wait_for_json(
+        f"{monitor_stack['tempo']}/api/search",
+        params={"q": f'{{ name = "{trace_name}" && span.test_run = "{TEST_RUN_ID}" }}'},
+        ready=lambda data: bool(data.get("traces")),
+    )
+    trace_id = search["traces"][0]["traceID"]
+    trace = _wait_for_json(f"{monitor_stack['tempo']}/api/traces/{trace_id}")
+    serialized_trace = json.dumps(trace)
+
+    assert trace_name in serialized_trace
+    assert TEST_RUN_ID in serialized_trace


### PR DESCRIPTION
### What does this PR do?

monitor add ci

last pr of https://github.com/verl-project/rl-insight/issues/83

### Checklist Before Starting

- [x] Search for similar PRs. Paste at least one query link here: ...
- [x] Format the PR title as `[{modules}] {type}: {description}` (This will be checked by the CI)
  - `{modules}` include:
    - `monitor-api`, `monitor-cli`, `monitor-collector`, `monitor-server`, `monitor-config` for online monitor changes
    - `recipe` for offline analysis changes, including pipeline, parser, visualizer, data checker, recipe config, examples, and sample data
    - `doc`, `ci`, `perf`, `deployment`, `misc` for cross-cutting changes
  - If this PR involves multiple modules, separate them with `,` like `[recipe, ci]` or `[monitor-server, monitor-config]`
  - `{type}` is in `feat`, `fix`, `refactor`, `chore`, `test`
  - If this PR breaks any API (CLI arguments, config, function signature, etc.), add `[BREAKING]` to the beginning of the title.
  - Example: `[BREAKING][mstx, torch_profile] feat: support timeline parsing`

### Test

<img width="1114" height="799" alt="image" src="https://github.com/user-attachments/assets/58333888-585d-4c0b-a1d7-3d7d8f00df13" />

### API and Usage Example

> Demonstrate how the API changes if any, and provide usage example(s) if possible.

```python
# Add code snippet or script demonstrating how to use this
```

### Design & Code Changes

> Demonstrate the high-level design if this PR is complex, and list the specific changes.

### Checklist Before Submitting

> [!IMPORTANT]
> Please check all the following items before requesting a review, otherwise the reviewer might deprioritize this PR for review.

- [x] Read the [Contribute Guide](https://github.com/verl-project/rl-insight/blob/main/CONTRIBUTING.md).
- [x] Apply [pre-commit checks](https://github.com/verl-project/rl-insight/blob/main/CONTRIBUTING.md#code-linting-and-formatting): `pre-commit install && pre-commit run --all-files --show-diff-on-failure --color=always`
- [x] Add / Update [the documentation](https://github.com/verl-project/rl-insight/tree/main/docs).
- [x] Add unit or end-to-end test(s) to [the CI workflow](https://github.com/verl-project/rl-insight/tree/main/.github/workflows) to cover all the code. If not feasible, explain why: ...
