### PR TITLE
[perf] feat: add TransferQueue cost statistics via monkey patchDev tq profiling

### DIFF
--- a/patch/tq_profiling/patch_tq.py
+++ b/patch/tq_profiling/patch_tq.py
@@ -24,7 +24,7 @@ def tq_timer(func):
 
         cost = time.time() - start_time
         formatted_time = time.strftime("%Y-%m-%d %H:%M:%S", time.localtime(start_time))
-        print(f"=====[TQ timer]{func.__name__} start at {formatted_time} and cost:{cost}s")
+        print(f"[TQ timer]{func.__name__} start at {formatted_time} and cost:{cost}s")
         return result
 
     @wraps(func)
@@ -34,7 +34,7 @@ def tq_timer(func):
 
         cost = time.time() - start_time
         formatted_time = time.strftime("%Y-%m-%d %H:%M:%S", time.localtime(start_time))
-        print(f"=====[TQ timer]{func.__name__} start at {formatted_time} and cost:{cost}s")
+        print(f"[TQ timer]{func.__name__} start at {formatted_time} and cost:{cost}s")
         return await_result
     return async_wrapper if inspect.iscoroutinefunction(func) else wrapper
 
@@ -62,7 +62,7 @@ def patch_tq():
             original = getattr(tq, name)
             setattr(tq, name, tq_timer(original))
 
-def patch_class(cls):
+def patch_tq_timer(cls):
     original_init = cls.__init__
 
     def new_init(self, *args, **kwargs):

--- a/patch/tq_profiling/patch_tq.py
+++ b/patch/tq_profiling/patch_tq.py
@@ -1,0 +1,75 @@
+# Copyright (c) 2025 verl-project authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import time
+from functools import wraps
+import inspect
+
+def tq_timer(func):
+    @wraps(func)
+    def wrapper(*args, **kwargs):
+        start_time = time.time()
+        result = func(*args, **kwargs)
+
+        cost = time.time() - start_time
+        formatted_time = time.strftime("%Y-%m-%d %H:%M:%S", time.localtime(start_time))
+        print(f"=====[TQ timer]{func.__name__} start at {formatted_time} and cost:{cost}s")
+        return result
+
+    @wraps(func)
+    async def async_wrapper(*args, **kwargs):
+        start_time = time.time()
+        await_result = await func(*args, **kwargs)
+
+        cost = time.time() - start_time
+        formatted_time = time.strftime("%Y-%m-%d %H:%M:%S", time.localtime(start_time))
+        print(f"=====[TQ timer]{func.__name__} start at {formatted_time} and cost:{cost}s")
+        return await_result
+    return async_wrapper if inspect.iscoroutinefunction(func) else wrapper
+
+def patch_tq():
+    tq_funcs = [
+        "init",
+        "close",
+        "get_metrics_endpoint",
+        "kv_put",
+        "kv_batch_put",
+        "kv_batch_get",
+        "kv_batch_get_by_meta",
+        "kv_list",
+        "kv_clear",
+        "async_kv_put",
+        "async_kv_batch_put",
+        "async_kv_batch_get",
+        "async_kv_batch_get_by_meta",
+        "async_kv_list",
+        "async_kv_clear",
+        "KVBatchMeta",
+    ]
+    for name in tq_funcs:
+        if hasattr(tq, name):
+            original = getattr(tq, name)
+            setattr(tq, name, tq_timer(original))
+
+def patch_class(cls):
+    original_init = cls.__init__
+
+    def new_init(self, *args, **kwargs):
+        original_init(self, *args, **kwargs)
+
+        patch_tq()
+    cls.__init__ = new_init
+
+    return cls
+

--- a/patch/tq_profiling/patch_tq.py
+++ b/patch/tq_profiling/patch_tq.py
@@ -16,6 +16,7 @@ import time
 from functools import wraps
 import inspect
 import transfer_queue as tq
+import rl_insight
 
 def tq_timer(func):
     @wraps(func)
@@ -24,8 +25,7 @@ def tq_timer(func):
         result = func(*args, **kwargs)
 
         cost = time.time() - start_time
-        formatted_time = time.strftime("%Y-%m-%d %H:%M:%S", time.localtime(start_time))
-        print(f"[TQ timer]{func.__name__} start at {formatted_time} and cost:{cost}s")
+        rl_insight.metric_value(f"TQ_TIME_{func.__name__}", float(cost))
         return result
 
     @wraps(func)
@@ -34,8 +34,7 @@ def tq_timer(func):
         await_result = await func(*args, **kwargs)
 
         cost = time.time() - start_time
-        formatted_time = time.strftime("%Y-%m-%d %H:%M:%S", time.localtime(start_time))
-        print(f"[TQ timer]{func.__name__} start at {formatted_time} and cost:{cost}s")
+        rl_insight.metric_value(f"TQ_TIME_{func.__name__}", float(cost))
         return await_result
     return async_wrapper if inspect.iscoroutinefunction(func) else wrapper
 
@@ -57,6 +56,7 @@ def patch_tq():
         "async_kv_list",
         "async_kv_clear",
     ]
+    rl_insight.init()
     for name in tq_funcs:
         if hasattr(tq, name):
             original = getattr(tq, name)

--- a/patch/tq_profiling/patch_tq.py
+++ b/patch/tq_profiling/patch_tq.py
@@ -15,6 +15,7 @@
 import time
 from functools import wraps
 import inspect
+import transfer_queue as tq
 
 def tq_timer(func):
     @wraps(func)
@@ -55,7 +56,6 @@ def patch_tq():
         "async_kv_batch_get_by_meta",
         "async_kv_list",
         "async_kv_clear",
-        "KVBatchMeta",
     ]
     for name in tq_funcs:
         if hasattr(tq, name):

--- a/patch/tq_profiling/patch_tq.py
+++ b/patch/tq_profiling/patch_tq.py
@@ -40,21 +40,10 @@ def tq_timer(func):
 
 def patch_tq():
     tq_funcs = [
-        "init",
-        "close",
-        "get_metrics_endpoint",
-        "kv_put",
         "kv_batch_put",
         "kv_batch_get",
-        "kv_batch_get_by_meta",
-        "kv_list",
         "kv_clear",
-        "async_kv_put",
         "async_kv_batch_put",
-        "async_kv_batch_get",
-        "async_kv_batch_get_by_meta",
-        "async_kv_list",
-        "async_kv_clear",
     ]
     rl_insight.init()
     for name in tq_funcs:


### PR DESCRIPTION
### What does this PR do?
This PR is to record the execution time of TransferQueue via monkey patch
<img width="1581" height="510" alt="0089c6e5b7010fc664793d9bf9fe36fe" src="https://github.com/user-attachments/assets/5348b271-005b-4d9d-8af8-b73a0a0b22bc" />


### Checklist Before Starting

- [x] Search for similar PRs. Paste at least one query link here: ...
- [x] Format the PR title as `[{modules}] {type}: {description}` (This will be checked by the CI)
  - `{modules}` include `pipeline`, `parser`, `visualizer`, `data`, `deployment`, `perf`, `algo`, `env`, `doc`, `cfg`, `ci`, `misc`
  - If this PR involves multiple modules, separate them with `,` like `[mstx, ci]`
  - `{type}` is in `feat`, `fix`, `refactor`, `chore`, `test`
  - If this PR breaks any API (CLI arguments, config, function signature, etc.), add `[BREAKING]` to the beginning of the title.
  - Example: `[BREAKING][mstx, torch_profile] feat: support timeline parsing`

### Test

This PR adds latency tracking patches to selected TQ APIs. To avoid performance overhead from full API patching, we ran tests to filter critical high-cost APIs used in VERL, with the findings as follows:
1、kv_put, async_kv_batch_get, async_kv_list, async_kv_clear: Zero invocations in verl code.
2、kv_batch_get_by_meta / async_kv_batch_get_by_meta: Thin high-level wrappers of kv_batch_get with only parameter parsing and minimal tensor copy cost; unused in VERL, skip persistent monitoring.
API performance breakdown:
1、kv_list: Frequent background polling with low single-operation latency. Meanwhile, background-only execution means we don’t need online metrics for it.
2、async_kv_put: Single-entry write with no tensor transmission; trivial per-call latency, no online monitoring needed.
3、async_kv_batch_put, kv_batch_put, kv_batch_get, kv_clear: Core read/write operations with major latency footprint; we need long-term performance tracking for these APIs.
Detailed analysis can be found in the attachment.
[verl_tq耗时分析.docx](https://github.com/user-attachments/files/29284959/verl_tq.docx)


### API and Usage Example

> Demonstrate how the API changes if any, and provide usage example(s) if possible.

```python
# Add code snippet or script demonstrating how to use this
```

### Design & Code Changes

> Demonstrate the high-level design if this PR is complex, and list the specific changes.

### Checklist Before Submitting

> [!IMPORTANT]
> Please check all the following items before requesting a review, otherwise the reviewer might deprioritize this PR for review.

- [x] Read the [Contribute Guide](https://github.com/verl-project/rl-insight/blob/main/CONTRIBUTING.md).
- [ ] Apply [pre-commit checks](https://github.com/verl-project/rl-insight/blob/main/CONTRIBUTING.md#code-linting-and-formatting): `pre-commit install && pre-commit run --all-files --show-diff-on-failure --color=always`
- [ ] Add / Update [the documentation](https://github.com/verl-project/rl-insight/tree/main/docs).
- [ ] Add unit or end-to-end test(s) to [the CI workflow](https://github.com/verl-project/rl-insight/tree/main/.github/workflows) to cover all the code. If not feasible, explain why: ...
