### PR TITLE
[monitor-api] fix: trace api optim

### DIFF
--- a/rl_insight/api.py
+++ b/rl_insight/api.py
@@ -20,6 +20,7 @@ import functools
 import inspect
 import logging
 import os
+import threading
 import time
 import warnings
 from contextlib import contextmanager
@@ -127,6 +128,7 @@ def finish() -> None:
     """
     global _STATE
     _STATE = _MonitorState()
+    _LANES.clear()
 
 
 def metric_count(
@@ -174,6 +176,21 @@ def metric_distribution(
     _emit(MonitorEventKind.HISTOGRAM, name, float(value), doc, labels)
 
 
+@dataclass
+class _LaneState:
+    """Per-lane state so a lane reports one state at a time."""
+
+    occupant: str | None = None
+    count: int = 0
+    start_ns: int = 0
+    attributes: dict[str, Any] = field(default_factory=dict)
+
+
+# lane_id -> _LaneState, guarded by the lock for thread + coroutine safety.
+_LANES: dict[str, _LaneState] = {}
+_LANES_LOCK = threading.Lock()
+
+
 @contextmanager
 def trace_state(
     state_name: str,
@@ -183,9 +200,12 @@ def trace_state(
 ) -> Generator[None, None, None]:
     """Record a named runtime state as a timeline interval on a logical lane.
 
-    Each ``with trace_state(...)`` block becomes one state span. ``state_lane_id``
-    groups spans into timeline columns/lanes, so Grafana can show one row per
-    worker, replica, or process:
+    Overlapping states on the same ``state_lane_id`` are collapsed so that only
+    one state is reported at any instant: same-name overlaps merge into one span,
+    and a different-named state entered while the lane is occupied is dropped.
+
+    ``state_lane_id`` groups spans into timeline columns/lanes, so Grafana can
+    show one row per worker, replica, or process:
 
     ``time ->        t0              t1              t2              t3              t4``
     ``replica_0     | [generate responses---------------------------] [sync weights-----]``
@@ -203,18 +223,19 @@ def trace_state(
         state_name: Span name and human-readable state label (e.g. ``"rollout"``).
         state_lane_id: Optional id for grouping state intervals in trace UIs (swim lane).
             Defaults to the current OS process id: one lane per process unless you pass
-            a custom id (e.g. Ray worker). Overlapping ``trace_state`` calls for the same
-            lane show as overlapping intervals.
+            a custom id (e.g. Ray worker).
         **labels: Extra span attributes. Keys ``state_name``, ``state_lane_id``, and
             ``monitor.trace_segment`` cannot be overridden; they are set after merging.
 
     Yields:
-        Control during the covered code block; emits the span in ``finally``.
+        Control during the covered code block; the span is emitted on exit.
     """
 
-    lane_id = state_lane_id if state_lane_id is not None else _STATE.process_id
+    if not _STATE.enabled or _STATE.client is None:
+        yield
+        return
 
-    start_time_ns = time.time_ns()
+    lane_id = state_lane_id if state_lane_id is not None else _STATE.process_id
     attributes = {
         **labels,
         "monitor.trace_segment": "state_interval",
@@ -222,15 +243,44 @@ def trace_state(
         "state_lane_id": lane_id,
     }
 
+    with _LANES_LOCK:
+        lane = _LANES.setdefault(lane_id, _LaneState())
+        if lane.occupant is None:  # idle lane: take it and open the interval
+            lane.occupant = state_name
+            lane.count = 1
+            lane.start_ns = time.time_ns()
+            lane.attributes = attributes
+            counted = True
+        elif state_name == lane.occupant:  # same-name overlap: keep the union open
+            lane.count += 1
+            counted = True
+        else:  # different name while occupied: shadowed, not reported
+            counted = False
+
     try:
         yield
     finally:
-        _emit_trace_span(
-            name=state_name,
-            start_time_ns=start_time_ns,
-            end_time_ns=time.time_ns(),
-            attributes=attributes,
-        )
+        emit_args: tuple[str, int, int, dict[str, Any]] | None = None
+        with _LANES_LOCK:
+            # Identity check guards against finish() replacing the lane mid-block.
+            if counted and _LANES.get(lane_id) is lane:
+                lane.count -= 1
+                if lane.count == 0:  # occupant closed: emit merged span, free lane
+                    emit_args = (
+                        state_name,
+                        lane.start_ns,
+                        time.time_ns(),
+                        lane.attributes,
+                    )
+                    _LANES.pop(lane_id, None)
+        # Emit outside the lock so the backend submit never blocks other callers.
+        if emit_args is not None:
+            _emit_trace_span(
+                name=emit_args[0],
+                start_time_ns=emit_args[1],
+                end_time_ns=emit_args[2],
+                attributes=emit_args[3],
+            )
 
 
 def trace_op(
@@ -269,6 +319,9 @@ def trace_op(
         @functools.wraps(func)
         def wrapper(*args: Any, **kwargs: Any) -> Any:
             """Call the wrapped function and record one duration span around it."""
+            if not _STATE.enabled or _STATE.client is None:
+                return func(*args, **kwargs)
+
             span_name = name or func.__qualname__
             merged: dict[str, Any] = dict(static_labels)
             if extra_labels is not None and args:

--- a/rl_insight/collector/ray_monitor_hub.py
+++ b/rl_insight/collector/ray_monitor_hub.py
@@ -69,7 +69,6 @@ class MonitorHubActor(MonitorCollector):
             endpoint=trace_endpoint,
         )
 
-        self._state_pending: dict[tuple[str, str], dict[str, Any]] = {}
         self._events_applied = 0
         self._node_ip = ray.util.get_node_ip_address()
         self._metrics_port = int(self._conf.prometheus.metrics_report_port)
@@ -159,49 +158,16 @@ class MonitorHubActor(MonitorCollector):
         )
 
     def _handle_trace(self, event: dict[str, Any]) -> None:
-        """Dispatch trace events; state_interval spans are merged before export."""
+        """Export one trace span via OTLP (no-op if collector disabled)."""
         if not self._trace_collector.enabled:
             return
         attrs = dict(event.get("attributes") or {})
-        if attrs.get("monitor.trace_segment") == "state_interval":
-            self._handle_state_interval_trace(event, attrs)
-            return
         self._export_trace_span(
             event["name"],
             int(event["start_time_ns"]),
             int(event["end_time_ns"]),
             attrs,
         )
-
-    def _handle_state_interval_trace(
-        self, event: dict[str, Any], attrs: dict[str, Any]
-    ) -> None:
-        """Merge overlapping state intervals per (lane, name); flush on gap."""
-        key = (str(attrs["state_lane_id"]), event["name"])
-        start_ns = int(event["start_time_ns"])
-        end_ns = int(event["end_time_ns"])
-
-        pending = self._state_pending.get(key)
-        if pending is not None and start_ns > pending["end_ns"]:
-            self._export_trace_span(
-                pending["name"],
-                pending["start_ns"],
-                pending["end_ns"],
-                pending["attributes"],
-            )
-            pending = None
-
-        if pending is None:
-            self._state_pending[key] = {
-                "name": event["name"],
-                "start_ns": start_ns,
-                "end_ns": end_ns,
-                "attributes": attrs,
-            }
-            return
-
-        pending["start_ns"] = min(pending["start_ns"], start_ns)
-        pending["end_ns"] = max(pending["end_ns"], end_ns)
 
     def _export_trace_span(
         self,


### PR DESCRIPTION
### What does this PR do?

Optimizes trace_state reporting: collapses spans per lane on the client side so a given state_lane_id reports only one state at any instant. This fixes the Grafana State Timeline issue where overlapping spans on the same lane visually chop each other. Also adds a zero-overhead fast path when monitoring is disabled.

**Problem (Before)**
actual:   actor_update [======================================]
                                  train_batch [====]   (nested inside)
grafana:  [update][train_batch][update]     <- outer span chopped
actual:   vllm_generate [====] [====] [====] (concurrent on one replica)
grafana:  [gen][gap][gen][gap][gen]          <- should be continuous
**After**
same-name overlap  -> merged into one span:   [vllm_generate=============]
diff-name nesting  -> inner shadowed/dropped: [actor_update=============]
**Benefits**
Correct timeline: same-name overlaps merge, nested diff-name spans no longer chop the outer one.
Fewer emits: N overlapping spans collapse into 1.
Zero overhead when disabled: trace_state / trace_op pass through without locking or bookkeeping.
Concurrency-safe: lock + identity check for threads/coroutines; emit happens outside the lock.
**Key change**
rl_insight/api.py: add _LaneState / _LANES / _LANES_LOCK, rewrite trace_state collapsing logic, adapt trace_op and finish().

### Checklist Before Starting

- [x] Search for similar PRs. Paste at least one query link here: ...
- [x] Format the PR title as `[{modules}] {type}: {description}` (This will be checked by the CI)
  - `{modules}` include:
    - `monitor-api`, `monitor-cli`, `monitor-collector`, `monitor-server`, `monitor-config` for online monitor changes
    - `recipe` for offline analysis changes, including pipeline, parser, visualizer, data checker, recipe config, examples, and sample data
    - `doc`, `ci`, `perf`, `deployment`, `misc` for cross-cutting changes
  - If this PR involves multiple modules, separate them with `,` like `[recipe, ci]` or `[monitor-server, monitor-config]`
  - `{type}` is in `feat`, `fix`, `refactor`, `chore`, `test`
  - If this PR breaks any API (CLI arguments, config, function signature, etc.), add `[BREAKING]` to the beginning of the title.
  - Example: `[BREAKING][mstx, torch_profile] feat: support timeline parsing`

### Test
demo每轮通过ray上报次数从300+ -> 20+


before：
<img width="1294" height="595" alt="image" src="https://github.com/user-attachments/assets/06d71697-18ae-4987-a39b-2911dbf1c6e6" />
<img width="890" height="585" alt="image" src="https://github.com/user-attachments/assets/bfe6787c-8721-48e6-83c9-0459c99a9536" />
<img width="873" height="288" alt="image" src="https://github.com/user-attachments/assets/7c83f8d3-d6d9-404f-96b0-0b7a57aa1638" />


after：
成功显示actor update
<img width="554" height="443" alt="image" src="https://github.com/user-attachments/assets/a90f2653-6c17-4de2-85b5-f9e4dce00fe3" />

未见上报错乱败导致的超短generate：
<img width="1076" height="259" alt="image" src="https://github.com/user-attachments/assets/a032cccc-8f85-4960-a9dd-bba751132ec1" />

上报次数相同的情况下，时间任为微妙级别：
<img width="816" height="206" alt="image" src="https://github.com/user-attachments/assets/02924763-504c-443b-8d3f-ad317d5597c6" />



### API and Usage Example

> Demonstrate how the API changes if any, and provide usage example(s) if possible.

```python
# Add code snippet or script demonstrating how to use this
```

### Design & Code Changes

> Demonstrate the high-level design if this PR is complex, and list the specific changes.

### Checklist Before Submitting

> [!IMPORTANT]
> Please check all the following items before requesting a review, otherwise the reviewer might deprioritize this PR for review.

- [ ] Read the [Contribute Guide](https://github.com/verl-project/rl-insight/blob/main/CONTRIBUTING.md).
- [ ] Apply [pre-commit checks](https://github.com/verl-project/rl-insight/blob/main/CONTRIBUTING.md#code-linting-and-formatting): `pre-commit install && pre-commit run --all-files --show-diff-on-failure --color=always`
- [ ] Add / Update [the documentation](https://github.com/verl-project/rl-insight/tree/main/docs).
- [ ] Add unit or end-to-end test(s) to [the CI workflow](https://github.com/verl-project/rl-insight/tree/main/.github/workflows) to cover all the code. If not feasible, explain why: ...
