### PR TITLE
[ci] test: monitor add ut

### DIFF
--- a/.github/workflows/monitor_unit_test.yml
+++ b/.github/workflows/monitor_unit_test.yml
@@ -1,0 +1,47 @@
+name: Unit Test Monitor
+
+on:
+  push:
+    branches:
+      - main
+      - v0.*
+  pull_request:
+    branches:
+      - main
+      - v0.*
+    paths:
+      - "rl_insight/api.py"
+      - "rl_insight/client/**"
+      - "rl_insight/collector/**"
+      - "rl_insight/utils/**"
+      - "tests/monitor/ut/**"
+      - ".github/workflows/monitor_unit_test.yml"
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: ${{ github.ref != 'refs/heads/main' }}
+
+permissions:
+  contents: read
+
+jobs:
+  unit_test_monitor:
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    strategy:
+      matrix:
+        python-version: ["3.11"]
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+
+      - name: Set up Python ${{ matrix.python-version }}
+        uses: actions/setup-python@0b93645e9fea7318ecaed2b359559ac225c90a2b # v5.3.0
+        with:
+          python-version: ${{ matrix.python-version }}
+
+      - name: Install monitor test dependencies
+        run: pip install -e .
+
+      - name: Run monitor unit tests
+        run: pytest -s -x tests/monitor/ut

--- a/tests/monitor/ut/client/test_base.py
+++ b/tests/monitor/ut/client/test_base.py
@@ -1,0 +1,62 @@
+# Copyright (c) 2026 verl-project authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Unit tests for monitor client registration and selection."""
+
+from __future__ import annotations
+
+from typing import Any
+
+import pytest
+from omegaconf import OmegaConf
+
+from rl_insight.client import base
+
+
+class DummyClient(base.MonitorClient):
+    def apply_event(self, event: dict[str, Any]) -> None:
+        pass
+
+
+def test_create_monitor_client_should_use_registered_factory_when_backend_exists(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    expected = DummyClient()
+    conf = OmegaConf.create({"server": {"backend": "test"}})
+    monkeypatch.setattr(base, "MONITOR_CLIENT_REGISTRY", {})
+    base.register_monitor_client(
+        "test", lambda received: expected if received is conf else None
+    )
+
+    assert base.create_monitor_client(conf) is expected
+
+
+@pytest.mark.parametrize("backend", [None, "", "   "])
+def test_create_monitor_client_should_raise_when_backend_is_missing(
+    backend: str | None,
+) -> None:
+    conf = OmegaConf.create({"server": {"backend": backend}})
+
+    with pytest.raises(ValueError, match="server.backend is required"):
+        base.create_monitor_client(conf)
+
+
+def test_create_monitor_client_should_list_supported_backends_when_backend_is_unknown(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    conf = OmegaConf.create({"server": {"backend": "missing"}})
+    monkeypatch.setattr(base, "MONITOR_CLIENT_REGISTRY", {"ray": lambda _conf: None})
+
+    with pytest.raises(ValueError, match="supported: ray"):
+        base.create_monitor_client(conf)

--- a/tests/monitor/ut/client/test_ray_monitor_client.py
+++ b/tests/monitor/ut/client/test_ray_monitor_client.py
@@ -1,0 +1,94 @@
+# Copyright (c) 2026 verl-project authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Unit tests for the Ray monitor client."""
+
+from __future__ import annotations
+
+from unittest.mock import MagicMock
+
+import pytest
+from omegaconf import OmegaConf
+
+from rl_insight.client import ray_monitor_client as client_module
+from rl_insight.utils.constants import MonitorRayActor
+
+
+def test_create_ray_monitor_client_should_return_none_when_ray_is_not_initialized(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setattr(client_module.ray, "is_initialized", lambda: False)
+
+    assert client_module.create_ray_monitor_client(OmegaConf.create({})) is None
+
+
+def test_get_or_create_monitor_hub_should_reuse_actor_when_actor_exists(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    actor = object()
+    get_actor = MagicMock(return_value=actor)
+    monkeypatch.setattr(client_module.ray, "get_actor", get_actor)
+
+    assert client_module.get_or_create_monitor_hub(OmegaConf.create({})) is actor
+    get_actor.assert_called_once_with(
+        MonitorRayActor.NAME, namespace=MonitorRayActor.NAMESPACE
+    )
+
+
+def test_get_or_create_monitor_hub_should_create_detached_actor_when_actor_is_missing(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    conf = OmegaConf.create({"server": {"url": "http://server"}})
+    actor = object()
+    remote = MagicMock(return_value=actor)
+    options = MagicMock(return_value=MagicMock(remote=remote))
+    monkeypatch.setattr(
+        client_module.ray, "get_actor", MagicMock(side_effect=ValueError)
+    )
+    monkeypatch.setattr(client_module, "MonitorHubActor", MagicMock(options=options))
+
+    assert client_module.get_or_create_monitor_hub(conf) is actor
+    options.assert_called_once_with(
+        name=MonitorRayActor.NAME,
+        namespace=MonitorRayActor.NAMESPACE,
+        lifetime="detached",
+    )
+    remote.assert_called_once_with(conf)
+
+
+def test_get_or_create_monitor_hub_should_reuse_winner_when_creation_races(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    winner = object()
+    get_actor = MagicMock(side_effect=[ValueError, winner])
+    remote = MagicMock(side_effect=ValueError)
+    monkeypatch.setattr(client_module.ray, "get_actor", get_actor)
+    monkeypatch.setattr(
+        client_module,
+        "MonitorHubActor",
+        MagicMock(options=MagicMock(return_value=MagicMock(remote=remote))),
+    )
+
+    assert client_module.get_or_create_monitor_hub(OmegaConf.create({})) is winner
+    assert get_actor.call_count == 2
+
+
+def test_apply_event_should_submit_without_waiting_when_client_has_actor() -> None:
+    actor = MagicMock()
+    client = client_module.MonitorRayClient(actor)
+    event = {"kind": "counter", "name": "steps", "value": 1}
+
+    client.apply_event(event)
+
+    actor.apply_event.remote.assert_called_once_with(event)

--- a/tests/monitor/ut/collector/test_ray_monitor_hub.py
+++ b/tests/monitor/ut/collector/test_ray_monitor_hub.py
@@ -1,0 +1,164 @@
+# Copyright (c) 2026 verl-project authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Unit tests for the Ray monitor hub implementation."""
+
+from __future__ import annotations
+
+from typing import Any, cast
+from unittest.mock import MagicMock, call
+
+import pytest
+from omegaconf import OmegaConf
+
+from rl_insight.collector import ray_monitor_hub as hub_module
+from rl_insight.utils.constants import MonitorEventKind, MonitorRayActor
+
+
+HubImplementation = cast(
+    Any, hub_module.MonitorHubActor
+).__ray_metadata__.modified_class
+
+
+@pytest.fixture
+def hub() -> Any:
+    instance = HubImplementation.__new__(HubImplementation)
+    instance._registry = MagicMock()
+    instance._trace_collector = MagicMock(enabled=True)
+    instance._events_applied = 0
+    instance._event_handlers = {
+        MonitorEventKind.COUNTER: instance._handle_counter,
+        MonitorEventKind.GAUGE: instance._handle_gauge,
+        MonitorEventKind.HISTOGRAM: instance._handle_histogram,
+        MonitorEventKind.TRACE: instance._handle_trace,
+    }
+    return instance
+
+
+def test_init_should_configure_collectors_and_register_scrape_target_when_created(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    registry = MagicMock()
+    trace_collector = MagicMock(enabled=True)
+    start_server = MagicMock()
+    update_config = MagicMock()
+    monkeypatch.setattr(hub_module, "get_server_services", lambda: {"otlp_port": 4318})
+    registry_factory = MagicMock(return_value=registry)
+    monkeypatch.setattr(hub_module, "MetricRegistry", registry_factory)
+    trace_factory = MagicMock(return_value=trace_collector)
+    monkeypatch.setattr(hub_module, "OpenTelemetryTraceCollector", trace_factory)
+    monkeypatch.setattr(hub_module, "start_metrics_http_server", start_server)
+    monkeypatch.setattr(hub_module, "update_prometheus_config", update_config)
+    monkeypatch.setattr(hub_module.ray.util, "get_node_ip_address", lambda: "10.0.0.8")
+    conf = OmegaConf.create(
+        {
+            "server": {"namespace": "trainer", "url": "http://host:18080"},
+            "prometheus": {"metrics_report_port": 9092},
+        }
+    )
+
+    instance = HubImplementation.__new__(HubImplementation)
+    instance.__init__(conf)
+
+    registry_factory.assert_called_once_with(namespace="trainer")
+    trace_factory.assert_called_once_with(
+        namespace="trainer", endpoint="http://host:4318/v1/traces"
+    )
+    start_server.assert_called_once_with(9092, addr="10.0.0.8")
+    update_config.assert_called_once_with(["10.0.0.8:9092"])
+    assert instance._registry is registry
+
+
+@pytest.mark.parametrize(
+    ("event", "method", "expected_call"),
+    [
+        (
+            {"kind": "counter", "name": "steps", "value": "2", "labels": {"w": 1}},
+            "count",
+            call("steps", "", 2.0, {}, {"w": 1}),
+        ),
+        (
+            {
+                "kind": "gauge",
+                "name": "reward",
+                "value": 1.5,
+                "documentation": "reward doc",
+            },
+            "value",
+            call("reward", "reward doc", 1.5, {}, {}),
+        ),
+        (
+            {"kind": "histogram", "name": "latency", "value": 12},
+            "distribution",
+            call("latency", "", 12.0, {}, {}, buckets=None),
+        ),
+    ],
+)
+def test_apply_event_should_dispatch_metric_when_kind_is_supported(
+    hub: Any,
+    event: dict[str, object],
+    method: str,
+    expected_call: Any,
+) -> None:
+    hub.apply_event(event)
+
+    assert hub._events_applied == 1
+    assert getattr(hub._registry, method).call_args == expected_call
+
+
+def test_apply_event_should_export_trace_when_trace_collection_is_enabled(
+    hub: Any,
+) -> None:
+    event = {
+        "kind": "trace",
+        "name": "rollout",
+        "start_time_ns": "10",
+        "end_time_ns": 25,
+        "attributes": {"step": 3},
+    }
+
+    hub.apply_event(event)
+
+    hub._trace_collector.record_span.assert_called_once_with(
+        "rollout", 10, 25, attributes={"step": 3}
+    )
+
+
+@pytest.mark.parametrize(
+    ("event", "message"),
+    [({}, "missing required field"), ({"kind": "unknown"}, "Unknown event kind")],
+)
+def test_apply_event_should_raise_value_error_when_event_is_invalid(
+    hub: Any, event: dict[str, object], message: str
+) -> None:
+    with pytest.raises(ValueError, match=message):
+        hub.apply_event(event)
+
+
+def test_get_status_should_describe_endpoint_when_hub_is_initialized(hub: Any) -> None:
+    hub._node_ip = "10.0.0.8"
+    hub._metrics_port = 9092
+    hub._events_applied = 4
+
+    status = hub.get_status()
+
+    assert status == {
+        "actor_name": MonitorRayActor.NAME,
+        "namespace": MonitorRayActor.NAMESPACE,
+        "node_ip": "10.0.0.8",
+        "metrics_endpoint": "http://10.0.0.8:9092/metrics",
+        "prometheus_metrics_enabled": True,
+        "otel_traces_enabled": True,
+        "events_applied": 4,
+    }

--- a/tests/monitor/ut/test_api.py
+++ b/tests/monitor/ut/test_api.py
@@ -1,0 +1,168 @@
+# Copyright (c) 2026 verl-project authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Unit tests for the public monitor API."""
+
+from __future__ import annotations
+
+from collections.abc import Generator
+from typing import Any
+
+import pytest
+
+from rl_insight import api
+from rl_insight.utils.constants import MonitorEventKind
+
+
+class RecordingClient:
+    """Small client double that preserves every submitted event."""
+
+    def __init__(self) -> None:
+        self.events: list[dict[str, Any]] = []
+
+    def apply_event(self, event: dict[str, Any]) -> None:
+        self.events.append(event)
+
+
+@pytest.fixture(autouse=True)
+def reset_monitor_state() -> Generator[None, None, None]:
+    api.finish()
+    yield
+    api.finish()
+
+
+@pytest.fixture
+def recording_client(monkeypatch: pytest.MonkeyPatch) -> RecordingClient:
+    client = RecordingClient()
+    monkeypatch.setattr(api, "create_monitor_client", lambda _conf: client)
+    api.init(
+        project="project-a",
+        experiment_name="experiment-a",
+        config={"server": {"url": "http://monitor:18080"}},
+    )
+    return client
+
+
+def test_init_should_enable_monitoring_when_server_and_client_are_available(
+    recording_client: RecordingClient,
+) -> None:
+    assert api._STATE.enabled is True
+    assert api._STATE.client is recording_client
+    assert api._STATE.labels == {
+        "project": "project-a",
+        "experiment_name": "experiment-a",
+    }
+
+
+def test_init_should_leave_monitoring_disabled_when_server_url_is_missing(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    factory_called = False
+
+    def create_client(_conf: Any) -> RecordingClient:
+        nonlocal factory_called
+        factory_called = True
+        return RecordingClient()
+
+    monkeypatch.delenv("RL_INSIGHT_SERVER_URL", raising=False)
+    monkeypatch.setattr(api, "create_monitor_client", create_client)
+
+    api.init(config={"server": {"url": ""}})
+
+    assert api._STATE.enabled is False
+    assert factory_called is False
+
+
+def test_metric_helpers_should_emit_typed_events_when_monitoring_is_enabled(
+    recording_client: RecordingClient,
+) -> None:
+    api.metric_count("steps", amount=2, worker="w0")
+    api.metric_gauge("reward", value=1.5, documentation="Latest reward", worker="w0")
+    api.metric_histogram("latency", value=12, worker="w0")
+
+    assert [event["kind"] for event in recording_client.events] == [
+        MonitorEventKind.COUNTER,
+        MonitorEventKind.GAUGE,
+        MonitorEventKind.HISTOGRAM,
+    ]
+    assert [event["value"] for event in recording_client.events] == [2.0, 1.5, 12.0]
+    assert recording_client.events[0]["documentation"] == "Counter steps"
+    assert recording_client.events[1]["documentation"] == "Latest reward"
+    assert recording_client.events[2]["documentation"] == "Histogram latency"
+    assert recording_client.events[0]["labels"] == {
+        "project": "project-a",
+        "experiment_name": "experiment-a",
+        "worker": "w0",
+    }
+
+
+def test_trace_state_should_merge_same_state_and_ignore_shadow_when_lane_is_busy(
+    recording_client: RecordingClient,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    timestamps = iter([100, 200])
+    monkeypatch.setattr(api.time, "time_ns", lambda: next(timestamps))
+
+    with api.trace_state("rollout", state_lane_id="replica-0", step=3):
+        with api.trace_state("rollout", state_lane_id="replica-0"):
+            pass
+        with api.trace_state("shadowed", state_lane_id="replica-0"):
+            pass
+
+    assert len(recording_client.events) == 1
+    event = recording_client.events[0]
+    assert event["kind"] == MonitorEventKind.TRACE
+    assert event["name"] == "rollout"
+    assert (event["start_time_ns"], event["end_time_ns"]) == (100, 200)
+    assert event["attributes"] == {
+        "process_id": api._STATE.process_id,
+        "project": "project-a",
+        "experiment_name": "experiment-a",
+        "step": 3,
+        "monitor.trace_segment": "state_interval",
+        "state_name": "rollout",
+        "state_lane_id": "replica-0",
+    }
+
+
+def test_trace_op_should_report_duration_when_wrapped_function_raises(
+    recording_client: RecordingClient,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    timestamps = iter([300, 450])
+    monkeypatch.setattr(api.time, "time_ns", lambda: next(timestamps))
+
+    @api.trace_op("train", extra_labels=lambda item: {"worker": item}, phase="update")
+    def train(worker: str) -> None:
+        raise RuntimeError("training failed")
+
+    with pytest.raises(RuntimeError, match="training failed"):
+        train("w1")
+
+    event = recording_client.events[0]
+    assert event["name"] == "train"
+    assert (event["start_time_ns"], event["end_time_ns"]) == (300, 450)
+    assert event["attributes"]["worker"] == "w1"
+    assert event["attributes"]["phase"] == "update"
+    assert event["attributes"]["monitor.trace_segment"] == "duration"
+
+
+def test_finish_should_disable_future_events_when_monitoring_was_enabled(
+    recording_client: RecordingClient,
+) -> None:
+    api.finish()
+    api.metric_count("ignored")
+
+    assert recording_client.events == []
+    assert api._STATE.enabled is False

--- a/tests/monitor/ut/utils/test_opentelemetry_utils.py
+++ b/tests/monitor/ut/utils/test_opentelemetry_utils.py
@@ -1,0 +1,64 @@
+# Copyright (c) 2026 verl-project authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Unit tests for OpenTelemetry trace collection."""
+
+from __future__ import annotations
+
+from unittest.mock import MagicMock
+
+import pytest
+from opentelemetry.sdk.resources import SERVICE_NAME
+from opentelemetry.sdk.trace.export import SimpleSpanProcessor
+from opentelemetry.sdk.trace.export.in_memory_span_exporter import InMemorySpanExporter
+
+from rl_insight.utils import opentelemetry_utils as otel_module
+
+
+def test_init_should_disable_collection_when_endpoint_is_missing(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    exporter = MagicMock()
+    monkeypatch.setattr(otel_module, "OTLPSpanExporter", exporter)
+
+    collector = otel_module.OpenTelemetryTraceCollector(
+        namespace="trainer", endpoint=None
+    )
+    collector.record_span("ignored", 10, 20, attributes={"step": 1})
+
+    assert collector.enabled is False
+    exporter.assert_not_called()
+
+
+def test_record_span_should_export_timing_attributes_and_resource_when_enabled(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    exporter = InMemorySpanExporter()
+    monkeypatch.setattr(otel_module, "OTLPSpanExporter", lambda endpoint: exporter)
+    monkeypatch.setattr(otel_module, "BatchSpanProcessor", SimpleSpanProcessor)
+    collector = otel_module.OpenTelemetryTraceCollector(
+        namespace="trainer-monitor", endpoint="http://tempo:4318/v1/traces"
+    )
+
+    collector.record_span(
+        "rollout", 1_000_000, 2_500_000, attributes={"step": 7, "worker": "w0"}
+    )
+
+    spans = exporter.get_finished_spans()
+    assert collector.enabled is True
+    assert len(spans) == 1
+    assert spans[0].name == "rollout"
+    assert (spans[0].start_time, spans[0].end_time) == (1_000_000, 2_500_000)
+    assert spans[0].attributes == {"step": 7, "worker": "w0"}
+    assert spans[0].resource.attributes[SERVICE_NAME] == "trainer-monitor"

--- a/tests/monitor/ut/utils/test_prometheus_utils.py
+++ b/tests/monitor/ut/utils/test_prometheus_utils.py
@@ -1,0 +1,144 @@
+# Copyright (c) 2026 verl-project authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Unit tests for Prometheus metrics and target registration."""
+
+from __future__ import annotations
+
+from typing import Any
+from unittest.mock import MagicMock
+
+import pytest
+import yaml
+
+from rl_insight.utils import prometheus_utils as prometheus_module
+
+
+def _samples(collector: Any) -> dict[str, Any]:
+    return {
+        sample.name: sample
+        for metric in collector.collect()
+        for sample in metric.samples
+    }
+
+
+def test_metric_registry_should_store_real_samples_when_all_metric_types_are_recorded() -> (
+    None
+):
+    registry = prometheus_module.MetricRegistry(namespace="monitor_ut")
+    registry.count(
+        "steps", "Steps", 2, defaults={"worker": "old"}, labels={"worker": "w0"}
+    )
+    registry.value("reward", "Reward", 1.5, labels={"worker": "w0"})
+    registry.distribution(
+        "latency", "Latency", 12, labels={"worker": "w0"}, buckets=(10, 20)
+    )
+
+    counter = _samples(next(iter(registry._counters.values())))
+    gauge = _samples(next(iter(registry._gauges.values())))
+    histogram = _samples(next(iter(registry._histograms.values())))
+    assert counter["monitor_ut_steps_total"].value == 2
+    assert counter["monitor_ut_steps_total"].labels == {"worker": "w0"}
+    assert gauge["monitor_ut_reward"].value == 1.5
+    assert histogram["monitor_ut_latency_count"].value == 1
+    assert histogram["monitor_ut_latency_sum"].value == 12
+
+
+def test_register_should_merge_and_sort_targets_when_config_already_exists(
+    tmp_path,
+) -> None:
+    config_file = tmp_path / "prometheus.yml"
+    config_file.write_text(
+        yaml.safe_dump(
+            {
+                "scrape_configs": [
+                    {
+                        "job_name": "trainers",
+                        "static_configs": [{"targets": ["host-b:9000"]}],
+                    }
+                ]
+            }
+        ),
+        encoding="utf-8",
+    )
+    store = prometheus_module.PrometheusTargetStore(config_file, 9090)
+
+    result = store.register(
+        "trainers",
+        [
+            prometheus_module.PrometheusTarget("host-a:9000", {"rank": 0}),
+            prometheus_module.PrometheusTarget("host-b:9000", {"rank": 1}),
+        ],
+    )
+
+    saved = yaml.safe_load(config_file.read_text(encoding="utf-8"))
+    groups = saved["scrape_configs"][0]["static_configs"]
+    assert result["target_count"] == 2
+    assert groups == [
+        {"targets": ["host-a:9000"], "labels": {"rank": "0"}},
+        {"targets": ["host-b:9000"], "labels": {"rank": "1"}},
+    ]
+
+
+def test_reload_should_post_to_local_prometheus_when_store_is_configured(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Any
+) -> None:
+    response = MagicMock()
+    post = MagicMock(return_value=response)
+    monkeypatch.setattr(prometheus_module.requests, "post", post)
+    monkeypatch.setattr(
+        prometheus_module, "local_addresses", lambda: {"loopback": "127.0.0.1"}
+    )
+    store = prometheus_module.PrometheusTargetStore(tmp_path / "prometheus.yml", 9090)
+
+    assert store.reload() is True
+    post.assert_called_once_with("http://127.0.0.1:9090/-/reload", timeout=5)
+    response.raise_for_status.assert_called_once_with()
+
+
+def test_update_prometheus_config_should_send_normalized_targets_when_server_is_set(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    response = MagicMock()
+    post = MagicMock(return_value=response)
+    monkeypatch.setenv("RL_INSIGHT_SERVER_URL", "http://server:18080/")
+    monkeypatch.setattr(prometheus_module.requests, "post", post)
+
+    prometheus_module.update_prometheus_config(
+        ["host-a:9000", "host-b:9000"],
+        job_name="workers",
+        labels=[{"rank": 0}, None],
+    )
+
+    post.assert_called_once_with(
+        "http://server:18080/api/v1/prometheus/targets",
+        json={
+            "job_name": "workers",
+            "targets": [
+                {"target": "host-a:9000", "labels": {"rank": "0"}},
+                {"target": "host-b:9000"},
+            ],
+        },
+        timeout=10,
+    )
+    response.raise_for_status.assert_called_once_with()
+
+
+def test_update_prometheus_config_should_reject_mismatched_labels_when_lengths_differ() -> (
+    None
+):
+    with pytest.raises(ValueError, match="labels length must match"):
+        prometheus_module.update_prometheus_config(
+            ["host-a:9000", "host-b:9000"], labels=[{"rank": 0}]
+        )


### PR DESCRIPTION
### What does this PR do?

monitor add ut

### Checklist Before Starting

- [x] Search for similar PRs. Paste at least one query link here: ...
- [x] Format the PR title as `[{modules}] {type}: {description}` (This will be checked by the CI)
  - `{modules}` include:
    - `monitor-api`, `monitor-cli`, `monitor-collector`, `monitor-server`, `monitor-config` for online monitor changes
    - `recipe` for offline analysis changes, including pipeline, parser, visualizer, data checker, recipe config, examples, and sample data
    - `doc`, `ci`, `perf`, `deployment`, `misc` for cross-cutting changes
  - If this PR involves multiple modules, separate them with `,` like `[recipe, ci]` or `[monitor-server, monitor-config]`
  - `{type}` is in `feat`, `fix`, `refactor`, `chore`, `test`
  - If this PR breaks any API (CLI arguments, config, function signature, etc.), add `[BREAKING]` to the beginning of the title.
  - Example: `[BREAKING][mstx, torch_profile] feat: support timeline parsing`

### Test

<img width="831" height="357" alt="image" src="https://github.com/user-attachments/assets/707d57b0-bbae-4ff0-ace8-586521dcb19c" />

### API and Usage Example

> Demonstrate how the API changes if any, and provide usage example(s) if possible.

```python
# Add code snippet or script demonstrating how to use this
```

### Design & Code Changes

> Demonstrate the high-level design if this PR is complex, and list the specific changes.

### Checklist Before Submitting

> [!IMPORTANT]
> Please check all the following items before requesting a review, otherwise the reviewer might deprioritize this PR for review.

- [x] Read the [Contribute Guide](https://github.com/verl-project/rl-insight/blob/main/CONTRIBUTING.md).
- [x] Apply [pre-commit checks](https://github.com/verl-project/rl-insight/blob/main/CONTRIBUTING.md#code-linting-and-formatting): `pre-commit install && pre-commit run --all-files --show-diff-on-failure --color=always`
- [x] Add / Update [the documentation](https://github.com/verl-project/rl-insight/tree/main/docs).
- [x] Add unit or end-to-end test(s) to [the CI workflow](https://github.com/verl-project/rl-insight/tree/main/.github/workflows) to cover all the code. If not feasible, explain why: ...
