### PR TITLE
[monitor-config] fix: natural-sort state timeline lanes

### DIFF
--- a/rl_insight/config/services/grafana/dashboards/verl_tainer_v1_with_sglang_engine.json
+++ b/rl_insight/config/services/grafana/dashboards/verl_tainer_v1_with_sglang_engine.json
@@ -13249,6 +13249,18 @@
                 },
                 {
                   "kind": "Transformation",
+                  "group": "extractFields",
+                  "spec": {
+                    "options": {
+                      "source": "state_lane_id",
+                      "format": "regexp",
+                      "replace": false,
+                      "regExp": "/^(?<state_lane_prefix>.+?)(?:[_-](?<state_lane_num>\\d+))?$/"
+                    }
+                  }
+                },
+                {
+                  "kind": "Transformation",
                   "group": "convertFieldType",
                   "spec": {
                     "options": {
@@ -13260,41 +13272,13 @@
                         {
                           "destinationType": "time",
                           "targetField": "End time"
+                        },
+                        {
+                          "destinationType": "number",
+                          "targetField": "state_lane_num"
                         }
                       ],
                       "fields": {}
-                    }
-                  }
-                },
-                {
-                  "kind": "Transformation",
-                  "group": "organize",
-                  "spec": {
-                    "options": {
-                      "excludeByName": {
-                        "Duration": true,
-                        "Duration / 1000000": true,
-                        "End time": false,
-                        "Name": true,
-                        "Span ID": true,
-                        "Trace Name": false,
-                        "Trace Service": true,
-                        "traceIdHidden": true
-                      },
-                      "includeByName": {},
-                      "indexByName": {
-                        "Duration": 8,
-                        "Duration / 1000000": 9,
-                        "End time": 5,
-                        "Name": 6,
-                        "Span ID": 3,
-                        "Start time": 4,
-                        "Trace Name": 2,
-                        "Trace Service": 1,
-                        "state_lane_id": 7,
-                        "traceIdHidden": 0
-                      },
-                      "renameByName": {}
                     }
                   }
                 },
@@ -13306,9 +13290,44 @@
                       "fields": {},
                       "sort": [
                         {
-                          "field": "state_lane_id"
+                          "field": "state_lane_num"
                         }
                       ]
+                    }
+                  }
+                },
+                {
+                  "kind": "Transformation",
+                  "group": "sortBy",
+                  "spec": {
+                    "options": {
+                      "fields": {},
+                      "sort": [
+                        {
+                          "field": "state_lane_prefix"
+                        }
+                      ]
+                    }
+                  }
+                },
+                {
+                  "kind": "Transformation",
+                  "group": "organize",
+                  "spec": {
+                    "options": {
+                      "excludeByName": {
+                        "Duration": true,
+                        "Duration / 1000000": true,
+                        "Name": true,
+                        "Span ID": true,
+                        "Trace Service": true,
+                        "traceIdHidden": true,
+                        "state_lane_prefix": true,
+                        "state_lane_num": true
+                      },
+                      "includeByName": {},
+                      "indexByName": {},
+                      "renameByName": {}
                     }
                   }
                 },

--- a/rl_insight/config/services/grafana/dashboards/verl_tainer_v1_with_sglang_engine.json
+++ b/rl_insight/config/services/grafana/dashboards/verl_tainer_v1_with_sglang_engine.json
@@ -13364,7 +13364,7 @@
                   "showLegend": true
                 },
                 "mergeValues": true,
-                "perPage": 16,
+                "perPage": 64,
                 "rowHeight": 0.9,
                 "showValue": "auto",
                 "tooltip": {

--- a/rl_insight/config/services/grafana/dashboards/verl_tainer_v1_with_vllm_engine.json
+++ b/rl_insight/config/services/grafana/dashboards/verl_tainer_v1_with_vllm_engine.json
@@ -16662,7 +16662,7 @@
                   "showLegend": true
                 },
                 "mergeValues": true,
-                "perPage": 16,
+                "perPage": 64,
                 "rowHeight": 0.9,
                 "showValue": "auto",
                 "tooltip": {

--- a/rl_insight/config/services/grafana/dashboards/verl_tainer_v1_with_vllm_engine.json
+++ b/rl_insight/config/services/grafana/dashboards/verl_tainer_v1_with_vllm_engine.json
@@ -16547,6 +16547,18 @@
                 },
                 {
                   "kind": "Transformation",
+                  "group": "extractFields",
+                  "spec": {
+                    "options": {
+                      "source": "state_lane_id",
+                      "format": "regexp",
+                      "replace": false,
+                      "regExp": "/^(?<state_lane_prefix>.+?)(?:[_-](?<state_lane_num>\\d+))?$/"
+                    }
+                  }
+                },
+                {
+                  "kind": "Transformation",
                   "group": "convertFieldType",
                   "spec": {
                     "options": {
@@ -16558,41 +16570,13 @@
                         {
                           "destinationType": "time",
                           "targetField": "End time"
+                        },
+                        {
+                          "destinationType": "number",
+                          "targetField": "state_lane_num"
                         }
                       ],
                       "fields": {}
-                    }
-                  }
-                },
-                {
-                  "kind": "Transformation",
-                  "group": "organize",
-                  "spec": {
-                    "options": {
-                      "excludeByName": {
-                        "Duration": true,
-                        "Duration / 1000000": true,
-                        "End time": false,
-                        "Name": true,
-                        "Span ID": true,
-                        "Trace Name": false,
-                        "Trace Service": true,
-                        "traceIdHidden": true
-                      },
-                      "includeByName": {},
-                      "indexByName": {
-                        "Duration": 8,
-                        "Duration / 1000000": 9,
-                        "End time": 5,
-                        "Name": 6,
-                        "Span ID": 3,
-                        "Start time": 4,
-                        "Trace Name": 2,
-                        "Trace Service": 1,
-                        "state_lane_id": 7,
-                        "traceIdHidden": 0
-                      },
-                      "renameByName": {}
                     }
                   }
                 },
@@ -16604,9 +16588,44 @@
                       "fields": {},
                       "sort": [
                         {
-                          "field": "state_lane_id"
+                          "field": "state_lane_num"
                         }
                       ]
+                    }
+                  }
+                },
+                {
+                  "kind": "Transformation",
+                  "group": "sortBy",
+                  "spec": {
+                    "options": {
+                      "fields": {},
+                      "sort": [
+                        {
+                          "field": "state_lane_prefix"
+                        }
+                      ]
+                    }
+                  }
+                },
+                {
+                  "kind": "Transformation",
+                  "group": "organize",
+                  "spec": {
+                    "options": {
+                      "excludeByName": {
+                        "Duration": true,
+                        "Duration / 1000000": true,
+                        "Name": true,
+                        "Span ID": true,
+                        "Trace Service": true,
+                        "traceIdHidden": true,
+                        "state_lane_prefix": true,
+                        "state_lane_num": true
+                      },
+                      "includeByName": {},
+                      "indexByName": {},
+                      "renameByName": {}
                     }
                   }
                 },


### PR DESCRIPTION
### What does this PR do?

fix: natural-sort state timeline lanes

### Checklist Before Starting

- [x] Search for similar PRs. Paste at least one query link here: ...
- [x] Format the PR title as `[{modules}] {type}: {description}` (This will be checked by the CI)
  - `{modules}` include:
    - `monitor-api`, `monitor-cli`, `monitor-collector`, `monitor-server`, `monitor-config` for online monitor changes
    - `recipe` for offline analysis changes, including pipeline, parser, visualizer, data checker, recipe config, examples, and sample data
    - `doc`, `ci`, `perf`, `deployment`, `misc` for cross-cutting changes
  - If this PR involves multiple modules, separate them with `,` like `[recipe, ci]` or `[monitor-server, monitor-config]`
  - `{type}` is in `feat`, `fix`, `refactor`, `chore`, `test`
  - If this PR breaks any API (CLI arguments, config, function signature, etc.), add `[BREAKING]` to the beginning of the title.
  - Example: `[BREAKING][mstx, torch_profile] feat: support timeline parsing`

### Test

https://github.com/user-attachments/assets/34b83bf7-95f6-4587-a798-0d778bbe6463



### API and Usage Example

> Demonstrate how the API changes if any, and provide usage example(s) if possible.

```python
# Add code snippet or script demonstrating how to use this
```

### Design & Code Changes

> Demonstrate the high-level design if this PR is complex, and list the specific changes.

### Checklist Before Submitting

> [!IMPORTANT]
> Please check all the following items before requesting a review, otherwise the reviewer might deprioritize this PR for review.

- [x] Read the [Contribute Guide](https://github.com/verl-project/rl-insight/blob/main/CONTRIBUTING.md).
- [x] Apply [pre-commit checks](https://github.com/verl-project/rl-insight/blob/main/CONTRIBUTING.md#code-linting-and-formatting): `pre-commit install && pre-commit run --all-files --show-diff-on-failure --color=always`
- [x] Add / Update [the documentation](https://github.com/verl-project/rl-insight/tree/main/docs).
- [x] Add unit or end-to-end test(s) to [the CI workflow](https://github.com/verl-project/rl-insight/tree/main/.github/workflows) to cover all the code. If not feasible, explain why: ...
