### PR TITLE
[monitor-config] feat: reduce training metric panel row height

### DIFF
--- a/rl_insight/config/services/grafana/dashboards/verl_tainer_v1_with_sglang_engine.json
+++ b/rl_insight/config/services/grafana/dashboards/verl_tainer_v1_with_sglang_engine.json
@@ -1662,7 +1662,7 @@
                       "spec": {
                         "editorMode": "builder",
                         "expr": "rl_insight_monitor_critic_advantages_max",
-                        "legendFormat": "__auto",
+                        "legendFormat": "{{__name__}}",
                         "range": true
                       }
                     },
@@ -1777,7 +1777,7 @@
                       "spec": {
                         "editorMode": "builder",
                         "expr": "rl_insight_monitor_critic_advantages_mean",
-                        "legendFormat": "__auto",
+                        "legendFormat": "{{__name__}}",
                         "range": true
                       }
                     },
@@ -1892,7 +1892,7 @@
                       "spec": {
                         "editorMode": "builder",
                         "expr": "rl_insight_monitor_critic_advantages_min",
-                        "legendFormat": "__auto",
+                        "legendFormat": "{{__name__}}",
                         "range": true
                       }
                     },
@@ -2007,7 +2007,7 @@
                       "spec": {
                         "editorMode": "builder",
                         "expr": "rl_insight_monitor_critic_returns_max",
-                        "legendFormat": "__auto",
+                        "legendFormat": "{{__name__}}",
                         "range": true
                       }
                     },
@@ -2122,7 +2122,7 @@
                       "spec": {
                         "editorMode": "builder",
                         "expr": "rl_insight_monitor_critic_returns_mean",
-                        "legendFormat": "__auto",
+                        "legendFormat": "{{__name__}}",
                         "range": true
                       }
                     },
@@ -2237,7 +2237,7 @@
                       "spec": {
                         "editorMode": "builder",
                         "expr": "rl_insight_monitor_critic_returns_min",
-                        "legendFormat": "__auto",
+                        "legendFormat": "{{__name__}}",
                         "range": true
                       }
                     },
@@ -2352,7 +2352,7 @@
                       "spec": {
                         "editorMode": "builder",
                         "expr": "rl_insight_monitor_critic_rewards_max",
-                        "legendFormat": "__auto",
+                        "legendFormat": "{{__name__}}",
                         "range": true
                       }
                     },
@@ -2467,7 +2467,7 @@
                       "spec": {
                         "editorMode": "builder",
                         "expr": "rl_insight_monitor_critic_rewards_mean",
-                        "legendFormat": "__auto",
+                        "legendFormat": "{{__name__}}",
                         "range": true
                       }
                     },
@@ -2582,7 +2582,7 @@
                       "spec": {
                         "editorMode": "builder",
                         "expr": "rl_insight_monitor_critic_rewards_min",
-                        "legendFormat": "__auto",
+                        "legendFormat": "{{__name__}}",
                         "range": true
                       }
                     },
@@ -2697,7 +2697,7 @@
                       "spec": {
                         "editorMode": "builder",
                         "expr": "rl_insight_monitor_critic_score_max",
-                        "legendFormat": "__auto",
+                        "legendFormat": "{{__name__}}",
                         "range": true
                       }
                     },
@@ -2812,7 +2812,7 @@
                       "spec": {
                         "editorMode": "builder",
                         "expr": "rl_insight_monitor_critic_score_mean",
-                        "legendFormat": "__auto",
+                        "legendFormat": "{{__name__}}",
                         "range": true
                       }
                     },
@@ -2927,7 +2927,7 @@
                       "spec": {
                         "editorMode": "builder",
                         "expr": "rl_insight_monitor_critic_score_min",
-                        "legendFormat": "__auto",
+                        "legendFormat": "{{__name__}}",
                         "range": true
                       }
                     },
@@ -8562,7 +8562,7 @@
                       "spec": {
                         "editorMode": "builder",
                         "expr": "rl_insight_monitor_training_epoch",
-                        "legendFormat": "__auto",
+                        "legendFormat": "{{__name__}}",
                         "range": true
                       }
                     },
@@ -8654,7 +8654,7 @@
                       "spec": {
                         "editorMode": "builder",
                         "expr": "rl_insight_monitor_training_global_step",
-                        "legendFormat": "__auto",
+                        "legendFormat": "{{__name__}}",
                         "range": true
                       }
                     },

--- a/rl_insight/config/services/grafana/dashboards/verl_tainer_v1_with_sglang_engine.json
+++ b/rl_insight/config/services/grafana/dashboards/verl_tainer_v1_with_sglang_engine.json
@@ -15136,7 +15136,7 @@
                                   "x": 0,
                                   "y": 0,
                                   "width": 8,
-                                  "height": 9,
+                                  "height": 8,
                                   "element": {
                                     "kind": "ElementReference",
                                     "name": "panel-184"
@@ -15149,7 +15149,7 @@
                                   "x": 8,
                                   "y": 0,
                                   "width": 8,
-                                  "height": 9,
+                                  "height": 8,
                                   "element": {
                                     "kind": "ElementReference",
                                     "name": "panel-185"
@@ -15162,7 +15162,7 @@
                                   "x": 16,
                                   "y": 0,
                                   "width": 8,
-                                  "height": 9,
+                                  "height": 8,
                                   "element": {
                                     "kind": "ElementReference",
                                     "name": "panel-186"
@@ -15173,7 +15173,7 @@
                                 "kind": "GridLayoutItem",
                                 "spec": {
                                   "x": 0,
-                                  "y": 9,
+                                  "y": 8,
                                   "width": 8,
                                   "height": 8,
                                   "element": {
@@ -15186,7 +15186,7 @@
                                 "kind": "GridLayoutItem",
                                 "spec": {
                                   "x": 8,
-                                  "y": 9,
+                                  "y": 8,
                                   "width": 8,
                                   "height": 8,
                                   "element": {
@@ -15199,7 +15199,7 @@
                                 "kind": "GridLayoutItem",
                                 "spec": {
                                   "x": 16,
-                                  "y": 9,
+                                  "y": 8,
                                   "width": 8,
                                   "height": 8,
                                   "element": {
@@ -15212,7 +15212,7 @@
                                 "kind": "GridLayoutItem",
                                 "spec": {
                                   "x": 0,
-                                  "y": 17,
+                                  "y": 16,
                                   "width": 8,
                                   "height": 8,
                                   "element": {
@@ -15225,7 +15225,7 @@
                                 "kind": "GridLayoutItem",
                                 "spec": {
                                   "x": 8,
-                                  "y": 17,
+                                  "y": 16,
                                   "width": 8,
                                   "height": 8,
                                   "element": {
@@ -15238,7 +15238,7 @@
                                 "kind": "GridLayoutItem",
                                 "spec": {
                                   "x": 16,
-                                  "y": 17,
+                                  "y": 16,
                                   "width": 8,
                                   "height": 8,
                                   "element": {
@@ -15251,7 +15251,7 @@
                                 "kind": "GridLayoutItem",
                                 "spec": {
                                   "x": 0,
-                                  "y": 25,
+                                  "y": 24,
                                   "width": 8,
                                   "height": 8,
                                   "element": {
@@ -15264,7 +15264,7 @@
                                 "kind": "GridLayoutItem",
                                 "spec": {
                                   "x": 8,
-                                  "y": 25,
+                                  "y": 24,
                                   "width": 8,
                                   "height": 8,
                                   "element": {
@@ -15277,7 +15277,7 @@
                                 "kind": "GridLayoutItem",
                                 "spec": {
                                   "x": 16,
-                                  "y": 25,
+                                  "y": 24,
                                   "width": 8,
                                   "height": 8,
                                   "element": {
@@ -15290,7 +15290,7 @@
                                 "kind": "GridLayoutItem",
                                 "spec": {
                                   "x": 0,
-                                  "y": 33,
+                                  "y": 32,
                                   "width": 8,
                                   "height": 8,
                                   "element": {
@@ -15303,7 +15303,7 @@
                                 "kind": "GridLayoutItem",
                                 "spec": {
                                   "x": 8,
-                                  "y": 33,
+                                  "y": 32,
                                   "width": 8,
                                   "height": 8,
                                   "element": {
@@ -15332,7 +15332,7 @@
                                   "x": 0,
                                   "y": 0,
                                   "width": 8,
-                                  "height": 9,
+                                  "height": 8,
                                   "element": {
                                     "kind": "ElementReference",
                                     "name": "panel-198"
@@ -15345,7 +15345,7 @@
                                   "x": 8,
                                   "y": 0,
                                   "width": 8,
-                                  "height": 9,
+                                  "height": 8,
                                   "element": {
                                     "kind": "ElementReference",
                                     "name": "panel-199"
@@ -15358,7 +15358,7 @@
                                   "x": 16,
                                   "y": 0,
                                   "width": 8,
-                                  "height": 9,
+                                  "height": 8,
                                   "element": {
                                     "kind": "ElementReference",
                                     "name": "panel-200"
@@ -15369,9 +15369,9 @@
                                 "kind": "GridLayoutItem",
                                 "spec": {
                                   "x": 0,
-                                  "y": 9,
+                                  "y": 8,
                                   "width": 8,
-                                  "height": 9,
+                                  "height": 8,
                                   "element": {
                                     "kind": "ElementReference",
                                     "name": "panel-201"
@@ -15382,9 +15382,9 @@
                                 "kind": "GridLayoutItem",
                                 "spec": {
                                   "x": 8,
-                                  "y": 9,
+                                  "y": 8,
                                   "width": 8,
-                                  "height": 9,
+                                  "height": 8,
                                   "element": {
                                     "kind": "ElementReference",
                                     "name": "panel-202"
@@ -15395,9 +15395,9 @@
                                 "kind": "GridLayoutItem",
                                 "spec": {
                                   "x": 16,
-                                  "y": 9,
+                                  "y": 8,
                                   "width": 8,
-                                  "height": 9,
+                                  "height": 8,
                                   "element": {
                                     "kind": "ElementReference",
                                     "name": "panel-203"
@@ -15408,9 +15408,9 @@
                                 "kind": "GridLayoutItem",
                                 "spec": {
                                   "x": 0,
-                                  "y": 18,
+                                  "y": 16,
                                   "width": 8,
-                                  "height": 9,
+                                  "height": 8,
                                   "element": {
                                     "kind": "ElementReference",
                                     "name": "panel-204"
@@ -15421,9 +15421,9 @@
                                 "kind": "GridLayoutItem",
                                 "spec": {
                                   "x": 8,
-                                  "y": 18,
+                                  "y": 16,
                                   "width": 8,
-                                  "height": 9,
+                                  "height": 8,
                                   "element": {
                                     "kind": "ElementReference",
                                     "name": "panel-205"
@@ -15434,9 +15434,9 @@
                                 "kind": "GridLayoutItem",
                                 "spec": {
                                   "x": 16,
-                                  "y": 18,
+                                  "y": 16,
                                   "width": 8,
-                                  "height": 9,
+                                  "height": 8,
                                   "element": {
                                     "kind": "ElementReference",
                                     "name": "panel-206"
@@ -15447,9 +15447,9 @@
                                 "kind": "GridLayoutItem",
                                 "spec": {
                                   "x": 0,
-                                  "y": 27,
+                                  "y": 24,
                                   "width": 8,
-                                  "height": 9,
+                                  "height": 8,
                                   "element": {
                                     "kind": "ElementReference",
                                     "name": "panel-207"
@@ -15460,9 +15460,9 @@
                                 "kind": "GridLayoutItem",
                                 "spec": {
                                   "x": 8,
-                                  "y": 27,
+                                  "y": 24,
                                   "width": 8,
-                                  "height": 9,
+                                  "height": 8,
                                   "element": {
                                     "kind": "ElementReference",
                                     "name": "panel-208"
@@ -15473,9 +15473,9 @@
                                 "kind": "GridLayoutItem",
                                 "spec": {
                                   "x": 16,
-                                  "y": 27,
+                                  "y": 24,
                                   "width": 8,
-                                  "height": 9,
+                                  "height": 8,
                                   "element": {
                                     "kind": "ElementReference",
                                     "name": "panel-209"
@@ -15502,7 +15502,7 @@
                                   "x": 0,
                                   "y": 0,
                                   "width": 8,
-                                  "height": 9,
+                                  "height": 8,
                                   "element": {
                                     "kind": "ElementReference",
                                     "name": "panel-210"
@@ -15515,7 +15515,7 @@
                                   "x": 8,
                                   "y": 0,
                                   "width": 8,
-                                  "height": 9,
+                                  "height": 8,
                                   "element": {
                                     "kind": "ElementReference",
                                     "name": "panel-211"
@@ -15528,7 +15528,7 @@
                                   "x": 16,
                                   "y": 0,
                                   "width": 8,
-                                  "height": 9,
+                                  "height": 8,
                                   "element": {
                                     "kind": "ElementReference",
                                     "name": "panel-212"
@@ -15539,9 +15539,9 @@
                                 "kind": "GridLayoutItem",
                                 "spec": {
                                   "x": 0,
-                                  "y": 9,
+                                  "y": 8,
                                   "width": 8,
-                                  "height": 9,
+                                  "height": 8,
                                   "element": {
                                     "kind": "ElementReference",
                                     "name": "panel-213"
@@ -15552,9 +15552,9 @@
                                 "kind": "GridLayoutItem",
                                 "spec": {
                                   "x": 8,
-                                  "y": 9,
+                                  "y": 8,
                                   "width": 8,
-                                  "height": 9,
+                                  "height": 8,
                                   "element": {
                                     "kind": "ElementReference",
                                     "name": "panel-214"
@@ -15565,9 +15565,9 @@
                                 "kind": "GridLayoutItem",
                                 "spec": {
                                   "x": 16,
-                                  "y": 9,
+                                  "y": 8,
                                   "width": 8,
-                                  "height": 9,
+                                  "height": 8,
                                   "element": {
                                     "kind": "ElementReference",
                                     "name": "panel-215"
@@ -15594,7 +15594,7 @@
                                   "x": 0,
                                   "y": 0,
                                   "width": 8,
-                                  "height": 9,
+                                  "height": 8,
                                   "element": {
                                     "kind": "ElementReference",
                                     "name": "panel-219"
@@ -15607,7 +15607,7 @@
                                   "x": 8,
                                   "y": 0,
                                   "width": 8,
-                                  "height": 9,
+                                  "height": 8,
                                   "element": {
                                     "kind": "ElementReference",
                                     "name": "panel-223"
@@ -15620,7 +15620,7 @@
                                   "x": 16,
                                   "y": 0,
                                   "width": 8,
-                                  "height": 9,
+                                  "height": 8,
                                   "element": {
                                     "kind": "ElementReference",
                                     "name": "panel-221"
@@ -15631,9 +15631,9 @@
                                 "kind": "GridLayoutItem",
                                 "spec": {
                                   "x": 0,
-                                  "y": 9,
+                                  "y": 8,
                                   "width": 8,
-                                  "height": 9,
+                                  "height": 8,
                                   "element": {
                                     "kind": "ElementReference",
                                     "name": "panel-222"
@@ -15660,7 +15660,7 @@
                                   "x": 0,
                                   "y": 0,
                                   "width": 8,
-                                  "height": 9,
+                                  "height": 8,
                                   "element": {
                                     "kind": "ElementReference",
                                     "name": "panel-224"
@@ -15673,7 +15673,7 @@
                                   "x": 8,
                                   "y": 0,
                                   "width": 8,
-                                  "height": 9,
+                                  "height": 8,
                                   "element": {
                                     "kind": "ElementReference",
                                     "name": "panel-225"
@@ -15686,7 +15686,7 @@
                                   "x": 16,
                                   "y": 0,
                                   "width": 8,
-                                  "height": 9,
+                                  "height": 8,
                                   "element": {
                                     "kind": "ElementReference",
                                     "name": "panel-226"
@@ -15697,9 +15697,9 @@
                                 "kind": "GridLayoutItem",
                                 "spec": {
                                   "x": 0,
-                                  "y": 9,
+                                  "y": 8,
                                   "width": 8,
-                                  "height": 9,
+                                  "height": 8,
                                   "element": {
                                     "kind": "ElementReference",
                                     "name": "panel-227"
@@ -15726,7 +15726,7 @@
                                   "x": 0,
                                   "y": 0,
                                   "width": 8,
-                                  "height": 9,
+                                  "height": 8,
                                   "element": {
                                     "kind": "ElementReference",
                                     "name": "panel-228"
@@ -15739,7 +15739,7 @@
                                   "x": 8,
                                   "y": 0,
                                   "width": 8,
-                                  "height": 9,
+                                  "height": 8,
                                   "element": {
                                     "kind": "ElementReference",
                                     "name": "panel-229"
@@ -15752,7 +15752,7 @@
                                   "x": 16,
                                   "y": 0,
                                   "width": 8,
-                                  "height": 9,
+                                  "height": 8,
                                   "element": {
                                     "kind": "ElementReference",
                                     "name": "panel-230"
@@ -15763,9 +15763,9 @@
                                 "kind": "GridLayoutItem",
                                 "spec": {
                                   "x": 0,
-                                  "y": 9,
+                                  "y": 8,
                                   "width": 8,
-                                  "height": 9,
+                                  "height": 8,
                                   "element": {
                                     "kind": "ElementReference",
                                     "name": "panel-231"
@@ -15776,9 +15776,9 @@
                                 "kind": "GridLayoutItem",
                                 "spec": {
                                   "x": 8,
-                                  "y": 9,
+                                  "y": 8,
                                   "width": 8,
-                                  "height": 9,
+                                  "height": 8,
                                   "element": {
                                     "kind": "ElementReference",
                                     "name": "panel-232"
@@ -15789,9 +15789,9 @@
                                 "kind": "GridLayoutItem",
                                 "spec": {
                                   "x": 16,
-                                  "y": 9,
+                                  "y": 8,
                                   "width": 8,
-                                  "height": 9,
+                                  "height": 8,
                                   "element": {
                                     "kind": "ElementReference",
                                     "name": "panel-233"
@@ -15802,9 +15802,9 @@
                                 "kind": "GridLayoutItem",
                                 "spec": {
                                   "x": 0,
-                                  "y": 18,
+                                  "y": 16,
                                   "width": 8,
-                                  "height": 9,
+                                  "height": 8,
                                   "element": {
                                     "kind": "ElementReference",
                                     "name": "panel-234"
@@ -15815,9 +15815,9 @@
                                 "kind": "GridLayoutItem",
                                 "spec": {
                                   "x": 8,
-                                  "y": 18,
+                                  "y": 16,
                                   "width": 8,
-                                  "height": 9,
+                                  "height": 8,
                                   "element": {
                                     "kind": "ElementReference",
                                     "name": "panel-235"
@@ -15828,9 +15828,9 @@
                                 "kind": "GridLayoutItem",
                                 "spec": {
                                   "x": 16,
-                                  "y": 18,
+                                  "y": 16,
                                   "width": 8,
-                                  "height": 9,
+                                  "height": 8,
                                   "element": {
                                     "kind": "ElementReference",
                                     "name": "panel-236"
@@ -15857,7 +15857,7 @@
                                   "x": 0,
                                   "y": 0,
                                   "width": 8,
-                                  "height": 9,
+                                  "height": 8,
                                   "element": {
                                     "kind": "ElementReference",
                                     "name": "panel-237"
@@ -15870,7 +15870,7 @@
                                   "x": 8,
                                   "y": 0,
                                   "width": 8,
-                                  "height": 9,
+                                  "height": 8,
                                   "element": {
                                     "kind": "ElementReference",
                                     "name": "panel-238"
@@ -15883,7 +15883,7 @@
                                   "x": 16,
                                   "y": 0,
                                   "width": 8,
-                                  "height": 9,
+                                  "height": 8,
                                   "element": {
                                     "kind": "ElementReference",
                                     "name": "panel-239"
@@ -15894,9 +15894,9 @@
                                 "kind": "GridLayoutItem",
                                 "spec": {
                                   "x": 0,
-                                  "y": 9,
+                                  "y": 8,
                                   "width": 8,
-                                  "height": 9,
+                                  "height": 8,
                                   "element": {
                                     "kind": "ElementReference",
                                     "name": "panel-240"
@@ -15907,9 +15907,9 @@
                                 "kind": "GridLayoutItem",
                                 "spec": {
                                   "x": 8,
-                                  "y": 9,
+                                  "y": 8,
                                   "width": 8,
-                                  "height": 9,
+                                  "height": 8,
                                   "element": {
                                     "kind": "ElementReference",
                                     "name": "panel-241"
@@ -15920,9 +15920,9 @@
                                 "kind": "GridLayoutItem",
                                 "spec": {
                                   "x": 16,
-                                  "y": 9,
+                                  "y": 8,
                                   "width": 8,
-                                  "height": 9,
+                                  "height": 8,
                                   "element": {
                                     "kind": "ElementReference",
                                     "name": "panel-242"
@@ -15933,9 +15933,9 @@
                                 "kind": "GridLayoutItem",
                                 "spec": {
                                   "x": 0,
-                                  "y": 18,
+                                  "y": 16,
                                   "width": 8,
-                                  "height": 9,
+                                  "height": 8,
                                   "element": {
                                     "kind": "ElementReference",
                                     "name": "panel-243"
@@ -15946,9 +15946,9 @@
                                 "kind": "GridLayoutItem",
                                 "spec": {
                                   "x": 8,
-                                  "y": 18,
+                                  "y": 16,
                                   "width": 8,
-                                  "height": 9,
+                                  "height": 8,
                                   "element": {
                                     "kind": "ElementReference",
                                     "name": "panel-244"
@@ -15959,9 +15959,9 @@
                                 "kind": "GridLayoutItem",
                                 "spec": {
                                   "x": 16,
-                                  "y": 18,
+                                  "y": 16,
                                   "width": 8,
-                                  "height": 9,
+                                  "height": 8,
                                   "element": {
                                     "kind": "ElementReference",
                                     "name": "panel-245"
@@ -15972,9 +15972,9 @@
                                 "kind": "GridLayoutItem",
                                 "spec": {
                                   "x": 0,
-                                  "y": 27,
+                                  "y": 24,
                                   "width": 8,
-                                  "height": 9,
+                                  "height": 8,
                                   "element": {
                                     "kind": "ElementReference",
                                     "name": "panel-246"
@@ -15985,9 +15985,9 @@
                                 "kind": "GridLayoutItem",
                                 "spec": {
                                   "x": 8,
-                                  "y": 27,
+                                  "y": 24,
                                   "width": 8,
-                                  "height": 9,
+                                  "height": 8,
                                   "element": {
                                     "kind": "ElementReference",
                                     "name": "panel-247"
@@ -15998,9 +15998,9 @@
                                 "kind": "GridLayoutItem",
                                 "spec": {
                                   "x": 16,
-                                  "y": 27,
+                                  "y": 24,
                                   "width": 8,
-                                  "height": 9,
+                                  "height": 8,
                                   "element": {
                                     "kind": "ElementReference",
                                     "name": "panel-248"
@@ -16011,9 +16011,9 @@
                                 "kind": "GridLayoutItem",
                                 "spec": {
                                   "x": 0,
-                                  "y": 36,
+                                  "y": 32,
                                   "width": 8,
-                                  "height": 9,
+                                  "height": 8,
                                   "element": {
                                     "kind": "ElementReference",
                                     "name": "panel-249"
@@ -16040,7 +16040,7 @@
                                   "x": 0,
                                   "y": 0,
                                   "width": 8,
-                                  "height": 9,
+                                  "height": 8,
                                   "element": {
                                     "kind": "ElementReference",
                                     "name": "panel-250"
@@ -16053,7 +16053,7 @@
                                   "x": 8,
                                   "y": 0,
                                   "width": 8,
-                                  "height": 9,
+                                  "height": 8,
                                   "element": {
                                     "kind": "ElementReference",
                                     "name": "panel-251"
@@ -16066,7 +16066,7 @@
                                   "x": 16,
                                   "y": 0,
                                   "width": 8,
-                                  "height": 9,
+                                  "height": 8,
                                   "element": {
                                     "kind": "ElementReference",
                                     "name": "panel-252"
@@ -16077,9 +16077,9 @@
                                 "kind": "GridLayoutItem",
                                 "spec": {
                                   "x": 0,
-                                  "y": 9,
+                                  "y": 8,
                                   "width": 8,
-                                  "height": 9,
+                                  "height": 8,
                                   "element": {
                                     "kind": "ElementReference",
                                     "name": "panel-253"
@@ -16090,9 +16090,9 @@
                                 "kind": "GridLayoutItem",
                                 "spec": {
                                   "x": 8,
-                                  "y": 9,
+                                  "y": 8,
                                   "width": 8,
-                                  "height": 9,
+                                  "height": 8,
                                   "element": {
                                     "kind": "ElementReference",
                                     "name": "panel-254"
@@ -16103,9 +16103,9 @@
                                 "kind": "GridLayoutItem",
                                 "spec": {
                                   "x": 16,
-                                  "y": 9,
+                                  "y": 8,
                                   "width": 8,
-                                  "height": 9,
+                                  "height": 8,
                                   "element": {
                                     "kind": "ElementReference",
                                     "name": "panel-273"
@@ -16116,9 +16116,9 @@
                                 "kind": "GridLayoutItem",
                                 "spec": {
                                   "x": 0,
-                                  "y": 18,
+                                  "y": 16,
                                   "width": 8,
-                                  "height": 9,
+                                  "height": 8,
                                   "element": {
                                     "kind": "ElementReference",
                                     "name": "panel-274"
@@ -16129,9 +16129,9 @@
                                 "kind": "GridLayoutItem",
                                 "spec": {
                                   "x": 8,
-                                  "y": 18,
+                                  "y": 16,
                                   "width": 8,
-                                  "height": 9,
+                                  "height": 8,
                                   "element": {
                                     "kind": "ElementReference",
                                     "name": "panel-275"
@@ -16142,9 +16142,9 @@
                                 "kind": "GridLayoutItem",
                                 "spec": {
                                   "x": 16,
-                                  "y": 18,
+                                  "y": 16,
                                   "width": 8,
-                                  "height": 9,
+                                  "height": 8,
                                   "element": {
                                     "kind": "ElementReference",
                                     "name": "panel-281"
@@ -16155,9 +16155,9 @@
                                 "kind": "GridLayoutItem",
                                 "spec": {
                                   "x": 0,
-                                  "y": 27,
+                                  "y": 24,
                                   "width": 8,
-                                  "height": 9,
+                                  "height": 8,
                                   "element": {
                                     "kind": "ElementReference",
                                     "name": "panel-282"
@@ -16168,9 +16168,9 @@
                                 "kind": "GridLayoutItem",
                                 "spec": {
                                   "x": 8,
-                                  "y": 27,
+                                  "y": 24,
                                   "width": 8,
-                                  "height": 9,
+                                  "height": 8,
                                   "element": {
                                     "kind": "ElementReference",
                                     "name": "panel-278"
@@ -16181,9 +16181,9 @@
                                 "kind": "GridLayoutItem",
                                 "spec": {
                                   "x": 16,
-                                  "y": 27,
+                                  "y": 24,
                                   "width": 8,
-                                  "height": 9,
+                                  "height": 8,
                                   "element": {
                                     "kind": "ElementReference",
                                     "name": "panel-280"
@@ -16210,7 +16210,7 @@
                                   "x": 0,
                                   "y": 0,
                                   "width": 8,
-                                  "height": 9,
+                                  "height": 8,
                                   "element": {
                                     "kind": "ElementReference",
                                     "name": "panel-283"
@@ -16223,7 +16223,7 @@
                                   "x": 8,
                                   "y": 0,
                                   "width": 8,
-                                  "height": 9,
+                                  "height": 8,
                                   "element": {
                                     "kind": "ElementReference",
                                     "name": "panel-284"
@@ -16236,7 +16236,7 @@
                                   "x": 16,
                                   "y": 0,
                                   "width": 8,
-                                  "height": 9,
+                                  "height": 8,
                                   "element": {
                                     "kind": "ElementReference",
                                     "name": "panel-314"
@@ -16247,9 +16247,9 @@
                                 "kind": "GridLayoutItem",
                                 "spec": {
                                   "x": 0,
-                                  "y": 9,
+                                  "y": 8,
                                   "width": 8,
-                                  "height": 9,
+                                  "height": 8,
                                   "element": {
                                     "kind": "ElementReference",
                                     "name": "panel-316"
@@ -16260,9 +16260,9 @@
                                 "kind": "GridLayoutItem",
                                 "spec": {
                                   "x": 8,
-                                  "y": 9,
+                                  "y": 8,
                                   "width": 8,
-                                  "height": 9,
+                                  "height": 8,
                                   "element": {
                                     "kind": "ElementReference",
                                     "name": "panel-320"
@@ -16273,9 +16273,9 @@
                                 "kind": "GridLayoutItem",
                                 "spec": {
                                   "x": 16,
-                                  "y": 9,
+                                  "y": 8,
                                   "width": 8,
-                                  "height": 9,
+                                  "height": 8,
                                   "element": {
                                     "kind": "ElementReference",
                                     "name": "panel-285"
@@ -16286,9 +16286,9 @@
                                 "kind": "GridLayoutItem",
                                 "spec": {
                                   "x": 0,
-                                  "y": 18,
+                                  "y": 16,
                                   "width": 8,
-                                  "height": 9,
+                                  "height": 8,
                                   "element": {
                                     "kind": "ElementReference",
                                     "name": "panel-286"
@@ -16299,9 +16299,9 @@
                                 "kind": "GridLayoutItem",
                                 "spec": {
                                   "x": 8,
-                                  "y": 18,
+                                  "y": 16,
                                   "width": 8,
-                                  "height": 9,
+                                  "height": 8,
                                   "element": {
                                     "kind": "ElementReference",
                                     "name": "panel-287"
@@ -16312,9 +16312,9 @@
                                 "kind": "GridLayoutItem",
                                 "spec": {
                                   "x": 16,
-                                  "y": 18,
+                                  "y": 16,
                                   "width": 8,
-                                  "height": 9,
+                                  "height": 8,
                                   "element": {
                                     "kind": "ElementReference",
                                     "name": "panel-288"
@@ -16325,9 +16325,9 @@
                                 "kind": "GridLayoutItem",
                                 "spec": {
                                   "x": 0,
-                                  "y": 27,
+                                  "y": 24,
                                   "width": 8,
-                                  "height": 9,
+                                  "height": 8,
                                   "element": {
                                     "kind": "ElementReference",
                                     "name": "panel-289"
@@ -16338,9 +16338,9 @@
                                 "kind": "GridLayoutItem",
                                 "spec": {
                                   "x": 8,
-                                  "y": 27,
+                                  "y": 24,
                                   "width": 8,
-                                  "height": 9,
+                                  "height": 8,
                                   "element": {
                                     "kind": "ElementReference",
                                     "name": "panel-322"
@@ -16351,9 +16351,9 @@
                                 "kind": "GridLayoutItem",
                                 "spec": {
                                   "x": 16,
-                                  "y": 27,
+                                  "y": 24,
                                   "width": 8,
-                                  "height": 9,
+                                  "height": 8,
                                   "element": {
                                     "kind": "ElementReference",
                                     "name": "panel-315"
@@ -16364,7 +16364,7 @@
                                 "kind": "GridLayoutItem",
                                 "spec": {
                                   "x": 0,
-                                  "y": 36,
+                                  "y": 32,
                                   "width": 8,
                                   "height": 8,
                                   "element": {
@@ -16377,7 +16377,7 @@
                                 "kind": "GridLayoutItem",
                                 "spec": {
                                   "x": 8,
-                                  "y": 36,
+                                  "y": 32,
                                   "width": 8,
                                   "height": 8,
                                   "element": {
@@ -16390,7 +16390,7 @@
                                 "kind": "GridLayoutItem",
                                 "spec": {
                                   "x": 16,
-                                  "y": 36,
+                                  "y": 32,
                                   "width": 8,
                                   "height": 8,
                                   "element": {
@@ -16403,7 +16403,7 @@
                                 "kind": "GridLayoutItem",
                                 "spec": {
                                   "x": 0,
-                                  "y": 44,
+                                  "y": 40,
                                   "width": 8,
                                   "height": 8,
                                   "element": {
@@ -16416,7 +16416,7 @@
                                 "kind": "GridLayoutItem",
                                 "spec": {
                                   "x": 8,
-                                  "y": 44,
+                                  "y": 40,
                                   "width": 8,
                                   "height": 8,
                                   "element": {
@@ -16429,7 +16429,7 @@
                                 "kind": "GridLayoutItem",
                                 "spec": {
                                   "x": 16,
-                                  "y": 44,
+                                  "y": 40,
                                   "width": 8,
                                   "height": 8,
                                   "element": {
@@ -16458,7 +16458,7 @@
                                   "x": 0,
                                   "y": 0,
                                   "width": 8,
-                                  "height": 9,
+                                  "height": 8,
                                   "element": {
                                     "kind": "ElementReference",
                                     "name": "panel-290"
@@ -16471,7 +16471,7 @@
                                   "x": 8,
                                   "y": 0,
                                   "width": 8,
-                                  "height": 9,
+                                  "height": 8,
                                   "element": {
                                     "kind": "ElementReference",
                                     "name": "panel-291"
@@ -16484,7 +16484,7 @@
                                   "x": 16,
                                   "y": 0,
                                   "width": 8,
-                                  "height": 9,
+                                  "height": 8,
                                   "element": {
                                     "kind": "ElementReference",
                                     "name": "panel-292"
@@ -16495,9 +16495,9 @@
                                 "kind": "GridLayoutItem",
                                 "spec": {
                                   "x": 0,
-                                  "y": 9,
+                                  "y": 8,
                                   "width": 8,
-                                  "height": 9,
+                                  "height": 8,
                                   "element": {
                                     "kind": "ElementReference",
                                     "name": "panel-293"
@@ -16508,9 +16508,9 @@
                                 "kind": "GridLayoutItem",
                                 "spec": {
                                   "x": 8,
-                                  "y": 9,
+                                  "y": 8,
                                   "width": 8,
-                                  "height": 9,
+                                  "height": 8,
                                   "element": {
                                     "kind": "ElementReference",
                                     "name": "panel-294"
@@ -16669,7 +16669,7 @@
                                   "x": 0,
                                   "y": 0,
                                   "width": 4,
-                                  "height": 4,
+                                  "height": 8,
                                   "element": {
                                     "kind": "ElementReference",
                                     "name": "panel-295"
@@ -16682,7 +16682,7 @@
                                   "x": 4,
                                   "y": 0,
                                   "width": 4,
-                                  "height": 4,
+                                  "height": 8,
                                   "element": {
                                     "kind": "ElementReference",
                                     "name": "panel-296"
@@ -16695,7 +16695,7 @@
                                   "x": 8,
                                   "y": 0,
                                   "width": 4,
-                                  "height": 4,
+                                  "height": 8,
                                   "element": {
                                     "kind": "ElementReference",
                                     "name": "panel-297"
@@ -16708,7 +16708,7 @@
                                   "x": 12,
                                   "y": 0,
                                   "width": 4,
-                                  "height": 4,
+                                  "height": 8,
                                   "element": {
                                     "kind": "ElementReference",
                                     "name": "panel-298"
@@ -16721,7 +16721,7 @@
                                   "x": 16,
                                   "y": 0,
                                   "width": 4,
-                                  "height": 4,
+                                  "height": 8,
                                   "element": {
                                     "kind": "ElementReference",
                                     "name": "panel-299"
@@ -16841,7 +16841,7 @@
                                   "x": 0,
                                   "y": 0,
                                   "width": 24,
-                                  "height": 6,
+                                  "height": 8,
                                   "element": {
                                     "kind": "ElementReference",
                                     "name": "panel-305"
@@ -16852,7 +16852,7 @@
                                 "kind": "GridLayoutItem",
                                 "spec": {
                                   "x": 0,
-                                  "y": 6,
+                                  "y": 8,
                                   "width": 12,
                                   "height": 8,
                                   "element": {
@@ -16865,7 +16865,7 @@
                                 "kind": "GridLayoutItem",
                                 "spec": {
                                   "x": 12,
-                                  "y": 6,
+                                  "y": 8,
                                   "width": 12,
                                   "height": 8,
                                   "element": {
@@ -16878,7 +16878,7 @@
                                 "kind": "GridLayoutItem",
                                 "spec": {
                                   "x": 0,
-                                  "y": 14,
+                                  "y": 16,
                                   "width": 12,
                                   "height": 8,
                                   "element": {
@@ -16891,7 +16891,7 @@
                                 "kind": "GridLayoutItem",
                                 "spec": {
                                   "x": 12,
-                                  "y": 14,
+                                  "y": 16,
                                   "width": 12,
                                   "height": 8,
                                   "element": {
@@ -16904,7 +16904,7 @@
                                 "kind": "GridLayoutItem",
                                 "spec": {
                                   "x": 0,
-                                  "y": 22,
+                                  "y": 24,
                                   "width": 12,
                                   "height": 8,
                                   "element": {
@@ -16917,7 +16917,7 @@
                                 "kind": "GridLayoutItem",
                                 "spec": {
                                   "x": 0,
-                                  "y": 30,
+                                  "y": 32,
                                   "width": 12,
                                   "height": 8,
                                   "element": {
@@ -16930,7 +16930,7 @@
                                 "kind": "GridLayoutItem",
                                 "spec": {
                                   "x": 0,
-                                  "y": 38,
+                                  "y": 40,
                                   "width": 24,
                                   "height": 8,
                                   "element": {

--- a/rl_insight/config/services/grafana/dashboards/verl_tainer_v1_with_sglang_engine.json
+++ b/rl_insight/config/services/grafana/dashboards/verl_tainer_v1_with_sglang_engine.json
@@ -114,7 +114,7 @@
                     "barAlignment": 0,
                     "barWidthFactor": 0.6,
                     "drawStyle": "line",
-                    "fillOpacity": 0,
+                    "fillOpacity": 8,
                     "gradientMode": "none",
                     "hideFrom": {
                       "legend": false,
@@ -123,12 +123,12 @@
                     },
                     "insertNulls": false,
                     "lineInterpolation": "linear",
-                    "lineWidth": 1,
+                    "lineWidth": 2,
                     "pointSize": 5,
                     "scaleDistribution": {
                       "type": "linear"
                     },
-                    "showPoints": "auto",
+                    "showPoints": "never",
                     "showValues": false,
                     "spanNulls": false,
                     "stacking": {
@@ -229,7 +229,7 @@
                     "barAlignment": 0,
                     "barWidthFactor": 0.6,
                     "drawStyle": "line",
-                    "fillOpacity": 0,
+                    "fillOpacity": 8,
                     "gradientMode": "none",
                     "hideFrom": {
                       "legend": false,
@@ -238,12 +238,12 @@
                     },
                     "insertNulls": false,
                     "lineInterpolation": "linear",
-                    "lineWidth": 1,
+                    "lineWidth": 2,
                     "pointSize": 5,
                     "scaleDistribution": {
                       "type": "linear"
                     },
-                    "showPoints": "auto",
+                    "showPoints": "never",
                     "showValues": false,
                     "spanNulls": false,
                     "stacking": {
@@ -344,7 +344,7 @@
                     "barAlignment": 0,
                     "barWidthFactor": 0.6,
                     "drawStyle": "line",
-                    "fillOpacity": 0,
+                    "fillOpacity": 8,
                     "gradientMode": "none",
                     "hideFrom": {
                       "legend": false,
@@ -353,12 +353,12 @@
                     },
                     "insertNulls": false,
                     "lineInterpolation": "linear",
-                    "lineWidth": 1,
+                    "lineWidth": 2,
                     "pointSize": 5,
                     "scaleDistribution": {
                       "type": "linear"
                     },
-                    "showPoints": "auto",
+                    "showPoints": "never",
                     "showValues": false,
                     "spanNulls": false,
                     "stacking": {
@@ -459,7 +459,7 @@
                     "barAlignment": 0,
                     "barWidthFactor": 0.6,
                     "drawStyle": "line",
-                    "fillOpacity": 0,
+                    "fillOpacity": 8,
                     "gradientMode": "none",
                     "hideFrom": {
                       "legend": false,
@@ -468,12 +468,12 @@
                     },
                     "insertNulls": false,
                     "lineInterpolation": "linear",
-                    "lineWidth": 1,
+                    "lineWidth": 2,
                     "pointSize": 5,
                     "scaleDistribution": {
                       "type": "linear"
                     },
-                    "showPoints": "auto",
+                    "showPoints": "never",
                     "showValues": false,
                     "spanNulls": false,
                     "stacking": {
@@ -574,7 +574,7 @@
                     "barAlignment": 0,
                     "barWidthFactor": 0.6,
                     "drawStyle": "line",
-                    "fillOpacity": 0,
+                    "fillOpacity": 8,
                     "gradientMode": "none",
                     "hideFrom": {
                       "legend": false,
@@ -583,12 +583,12 @@
                     },
                     "insertNulls": false,
                     "lineInterpolation": "linear",
-                    "lineWidth": 1,
+                    "lineWidth": 2,
                     "pointSize": 5,
                     "scaleDistribution": {
                       "type": "linear"
                     },
-                    "showPoints": "auto",
+                    "showPoints": "never",
                     "showValues": false,
                     "spanNulls": false,
                     "stacking": {
@@ -689,7 +689,7 @@
                     "barAlignment": 0,
                     "barWidthFactor": 0.6,
                     "drawStyle": "line",
-                    "fillOpacity": 0,
+                    "fillOpacity": 8,
                     "gradientMode": "none",
                     "hideFrom": {
                       "legend": false,
@@ -698,12 +698,12 @@
                     },
                     "insertNulls": false,
                     "lineInterpolation": "linear",
-                    "lineWidth": 1,
+                    "lineWidth": 2,
                     "pointSize": 5,
                     "scaleDistribution": {
                       "type": "linear"
                     },
-                    "showPoints": "auto",
+                    "showPoints": "never",
                     "showValues": false,
                     "spanNulls": false,
                     "stacking": {
@@ -804,7 +804,7 @@
                     "barAlignment": 0,
                     "barWidthFactor": 0.6,
                     "drawStyle": "line",
-                    "fillOpacity": 0,
+                    "fillOpacity": 8,
                     "gradientMode": "none",
                     "hideFrom": {
                       "legend": false,
@@ -813,12 +813,12 @@
                     },
                     "insertNulls": false,
                     "lineInterpolation": "linear",
-                    "lineWidth": 1,
+                    "lineWidth": 2,
                     "pointSize": 5,
                     "scaleDistribution": {
                       "type": "linear"
                     },
-                    "showPoints": "auto",
+                    "showPoints": "never",
                     "showValues": false,
                     "spanNulls": false,
                     "stacking": {
@@ -919,7 +919,7 @@
                     "barAlignment": 0,
                     "barWidthFactor": 0.6,
                     "drawStyle": "line",
-                    "fillOpacity": 0,
+                    "fillOpacity": 8,
                     "gradientMode": "none",
                     "hideFrom": {
                       "legend": false,
@@ -928,12 +928,12 @@
                     },
                     "insertNulls": false,
                     "lineInterpolation": "linear",
-                    "lineWidth": 1,
+                    "lineWidth": 2,
                     "pointSize": 5,
                     "scaleDistribution": {
                       "type": "linear"
                     },
-                    "showPoints": "auto",
+                    "showPoints": "never",
                     "showValues": false,
                     "spanNulls": false,
                     "stacking": {
@@ -1034,7 +1034,7 @@
                     "barAlignment": 0,
                     "barWidthFactor": 0.6,
                     "drawStyle": "line",
-                    "fillOpacity": 0,
+                    "fillOpacity": 8,
                     "gradientMode": "none",
                     "hideFrom": {
                       "legend": false,
@@ -1043,12 +1043,12 @@
                     },
                     "insertNulls": false,
                     "lineInterpolation": "linear",
-                    "lineWidth": 1,
+                    "lineWidth": 2,
                     "pointSize": 5,
                     "scaleDistribution": {
                       "type": "linear"
                     },
-                    "showPoints": "auto",
+                    "showPoints": "never",
                     "showValues": false,
                     "spanNulls": false,
                     "stacking": {
@@ -1149,7 +1149,7 @@
                     "barAlignment": 0,
                     "barWidthFactor": 0.6,
                     "drawStyle": "line",
-                    "fillOpacity": 0,
+                    "fillOpacity": 8,
                     "gradientMode": "none",
                     "hideFrom": {
                       "legend": false,
@@ -1158,12 +1158,12 @@
                     },
                     "insertNulls": false,
                     "lineInterpolation": "linear",
-                    "lineWidth": 1,
+                    "lineWidth": 2,
                     "pointSize": 5,
                     "scaleDistribution": {
                       "type": "linear"
                     },
-                    "showPoints": "auto",
+                    "showPoints": "never",
                     "showValues": false,
                     "spanNulls": false,
                     "stacking": {
@@ -1264,7 +1264,7 @@
                     "barAlignment": 0,
                     "barWidthFactor": 0.6,
                     "drawStyle": "line",
-                    "fillOpacity": 0,
+                    "fillOpacity": 8,
                     "gradientMode": "none",
                     "hideFrom": {
                       "legend": false,
@@ -1273,12 +1273,12 @@
                     },
                     "insertNulls": false,
                     "lineInterpolation": "linear",
-                    "lineWidth": 1,
+                    "lineWidth": 2,
                     "pointSize": 5,
                     "scaleDistribution": {
                       "type": "linear"
                     },
-                    "showPoints": "auto",
+                    "showPoints": "never",
                     "showValues": false,
                     "spanNulls": false,
                     "stacking": {
@@ -1379,7 +1379,7 @@
                     "barAlignment": 0,
                     "barWidthFactor": 0.6,
                     "drawStyle": "line",
-                    "fillOpacity": 0,
+                    "fillOpacity": 8,
                     "gradientMode": "none",
                     "hideFrom": {
                       "legend": false,
@@ -1388,12 +1388,12 @@
                     },
                     "insertNulls": false,
                     "lineInterpolation": "linear",
-                    "lineWidth": 1,
+                    "lineWidth": 2,
                     "pointSize": 5,
                     "scaleDistribution": {
                       "type": "linear"
                     },
-                    "showPoints": "auto",
+                    "showPoints": "never",
                     "showValues": false,
                     "spanNulls": false,
                     "stacking": {
@@ -1494,7 +1494,7 @@
                     "barAlignment": 0,
                     "barWidthFactor": 0.6,
                     "drawStyle": "line",
-                    "fillOpacity": 0,
+                    "fillOpacity": 8,
                     "gradientMode": "none",
                     "hideFrom": {
                       "legend": false,
@@ -1503,12 +1503,12 @@
                     },
                     "insertNulls": false,
                     "lineInterpolation": "linear",
-                    "lineWidth": 1,
+                    "lineWidth": 2,
                     "pointSize": 5,
                     "scaleDistribution": {
                       "type": "linear"
                     },
-                    "showPoints": "auto",
+                    "showPoints": "never",
                     "showValues": false,
                     "spanNulls": false,
                     "stacking": {
@@ -1609,7 +1609,7 @@
                     "barAlignment": 0,
                     "barWidthFactor": 0.6,
                     "drawStyle": "line",
-                    "fillOpacity": 0,
+                    "fillOpacity": 8,
                     "gradientMode": "none",
                     "hideFrom": {
                       "legend": false,
@@ -1618,12 +1618,12 @@
                     },
                     "insertNulls": false,
                     "lineInterpolation": "linear",
-                    "lineWidth": 1,
+                    "lineWidth": 2,
                     "pointSize": 5,
                     "scaleDistribution": {
                       "type": "linear"
                     },
-                    "showPoints": "auto",
+                    "showPoints": "never",
                     "showValues": false,
                     "spanNulls": false,
                     "stacking": {
@@ -1724,7 +1724,7 @@
                     "barAlignment": 0,
                     "barWidthFactor": 0.6,
                     "drawStyle": "line",
-                    "fillOpacity": 0,
+                    "fillOpacity": 8,
                     "gradientMode": "none",
                     "hideFrom": {
                       "legend": false,
@@ -1733,12 +1733,12 @@
                     },
                     "insertNulls": false,
                     "lineInterpolation": "linear",
-                    "lineWidth": 1,
+                    "lineWidth": 2,
                     "pointSize": 5,
                     "scaleDistribution": {
                       "type": "linear"
                     },
-                    "showPoints": "auto",
+                    "showPoints": "never",
                     "showValues": false,
                     "spanNulls": false,
                     "stacking": {
@@ -1839,7 +1839,7 @@
                     "barAlignment": 0,
                     "barWidthFactor": 0.6,
                     "drawStyle": "line",
-                    "fillOpacity": 0,
+                    "fillOpacity": 8,
                     "gradientMode": "none",
                     "hideFrom": {
                       "legend": false,
@@ -1848,12 +1848,12 @@
                     },
                     "insertNulls": false,
                     "lineInterpolation": "linear",
-                    "lineWidth": 1,
+                    "lineWidth": 2,
                     "pointSize": 5,
                     "scaleDistribution": {
                       "type": "linear"
                     },
-                    "showPoints": "auto",
+                    "showPoints": "never",
                     "showValues": false,
                     "spanNulls": false,
                     "stacking": {
@@ -1954,7 +1954,7 @@
                     "barAlignment": 0,
                     "barWidthFactor": 0.6,
                     "drawStyle": "line",
-                    "fillOpacity": 0,
+                    "fillOpacity": 8,
                     "gradientMode": "none",
                     "hideFrom": {
                       "legend": false,
@@ -1963,12 +1963,12 @@
                     },
                     "insertNulls": false,
                     "lineInterpolation": "linear",
-                    "lineWidth": 1,
+                    "lineWidth": 2,
                     "pointSize": 5,
                     "scaleDistribution": {
                       "type": "linear"
                     },
-                    "showPoints": "auto",
+                    "showPoints": "never",
                     "showValues": false,
                     "spanNulls": false,
                     "stacking": {
@@ -2069,7 +2069,7 @@
                     "barAlignment": 0,
                     "barWidthFactor": 0.6,
                     "drawStyle": "line",
-                    "fillOpacity": 0,
+                    "fillOpacity": 8,
                     "gradientMode": "none",
                     "hideFrom": {
                       "legend": false,
@@ -2078,12 +2078,12 @@
                     },
                     "insertNulls": false,
                     "lineInterpolation": "linear",
-                    "lineWidth": 1,
+                    "lineWidth": 2,
                     "pointSize": 5,
                     "scaleDistribution": {
                       "type": "linear"
                     },
-                    "showPoints": "auto",
+                    "showPoints": "never",
                     "showValues": false,
                     "spanNulls": false,
                     "stacking": {
@@ -2184,7 +2184,7 @@
                     "barAlignment": 0,
                     "barWidthFactor": 0.6,
                     "drawStyle": "line",
-                    "fillOpacity": 0,
+                    "fillOpacity": 8,
                     "gradientMode": "none",
                     "hideFrom": {
                       "legend": false,
@@ -2193,12 +2193,12 @@
                     },
                     "insertNulls": false,
                     "lineInterpolation": "linear",
-                    "lineWidth": 1,
+                    "lineWidth": 2,
                     "pointSize": 5,
                     "scaleDistribution": {
                       "type": "linear"
                     },
-                    "showPoints": "auto",
+                    "showPoints": "never",
                     "showValues": false,
                     "spanNulls": false,
                     "stacking": {
@@ -2299,7 +2299,7 @@
                     "barAlignment": 0,
                     "barWidthFactor": 0.6,
                     "drawStyle": "line",
-                    "fillOpacity": 0,
+                    "fillOpacity": 8,
                     "gradientMode": "none",
                     "hideFrom": {
                       "legend": false,
@@ -2308,12 +2308,12 @@
                     },
                     "insertNulls": false,
                     "lineInterpolation": "linear",
-                    "lineWidth": 1,
+                    "lineWidth": 2,
                     "pointSize": 5,
                     "scaleDistribution": {
                       "type": "linear"
                     },
-                    "showPoints": "auto",
+                    "showPoints": "never",
                     "showValues": false,
                     "spanNulls": false,
                     "stacking": {
@@ -2414,7 +2414,7 @@
                     "barAlignment": 0,
                     "barWidthFactor": 0.6,
                     "drawStyle": "line",
-                    "fillOpacity": 0,
+                    "fillOpacity": 8,
                     "gradientMode": "none",
                     "hideFrom": {
                       "legend": false,
@@ -2423,12 +2423,12 @@
                     },
                     "insertNulls": false,
                     "lineInterpolation": "linear",
-                    "lineWidth": 1,
+                    "lineWidth": 2,
                     "pointSize": 5,
                     "scaleDistribution": {
                       "type": "linear"
                     },
-                    "showPoints": "auto",
+                    "showPoints": "never",
                     "showValues": false,
                     "spanNulls": false,
                     "stacking": {
@@ -2529,7 +2529,7 @@
                     "barAlignment": 0,
                     "barWidthFactor": 0.6,
                     "drawStyle": "line",
-                    "fillOpacity": 0,
+                    "fillOpacity": 8,
                     "gradientMode": "none",
                     "hideFrom": {
                       "legend": false,
@@ -2538,12 +2538,12 @@
                     },
                     "insertNulls": false,
                     "lineInterpolation": "linear",
-                    "lineWidth": 1,
+                    "lineWidth": 2,
                     "pointSize": 5,
                     "scaleDistribution": {
                       "type": "linear"
                     },
-                    "showPoints": "auto",
+                    "showPoints": "never",
                     "showValues": false,
                     "spanNulls": false,
                     "stacking": {
@@ -2644,7 +2644,7 @@
                     "barAlignment": 0,
                     "barWidthFactor": 0.6,
                     "drawStyle": "line",
-                    "fillOpacity": 0,
+                    "fillOpacity": 8,
                     "gradientMode": "none",
                     "hideFrom": {
                       "legend": false,
@@ -2653,12 +2653,12 @@
                     },
                     "insertNulls": false,
                     "lineInterpolation": "linear",
-                    "lineWidth": 1,
+                    "lineWidth": 2,
                     "pointSize": 5,
                     "scaleDistribution": {
                       "type": "linear"
                     },
-                    "showPoints": "auto",
+                    "showPoints": "never",
                     "showValues": false,
                     "spanNulls": false,
                     "stacking": {
@@ -2759,7 +2759,7 @@
                     "barAlignment": 0,
                     "barWidthFactor": 0.6,
                     "drawStyle": "line",
-                    "fillOpacity": 0,
+                    "fillOpacity": 8,
                     "gradientMode": "none",
                     "hideFrom": {
                       "legend": false,
@@ -2768,12 +2768,12 @@
                     },
                     "insertNulls": false,
                     "lineInterpolation": "linear",
-                    "lineWidth": 1,
+                    "lineWidth": 2,
                     "pointSize": 5,
                     "scaleDistribution": {
                       "type": "linear"
                     },
-                    "showPoints": "auto",
+                    "showPoints": "never",
                     "showValues": false,
                     "spanNulls": false,
                     "stacking": {
@@ -2874,7 +2874,7 @@
                     "barAlignment": 0,
                     "barWidthFactor": 0.6,
                     "drawStyle": "line",
-                    "fillOpacity": 0,
+                    "fillOpacity": 8,
                     "gradientMode": "none",
                     "hideFrom": {
                       "legend": false,
@@ -2883,12 +2883,12 @@
                     },
                     "insertNulls": false,
                     "lineInterpolation": "linear",
-                    "lineWidth": 1,
+                    "lineWidth": 2,
                     "pointSize": 5,
                     "scaleDistribution": {
                       "type": "linear"
                     },
-                    "showPoints": "auto",
+                    "showPoints": "never",
                     "showValues": false,
                     "spanNulls": false,
                     "stacking": {
@@ -2989,7 +2989,7 @@
                     "barAlignment": 0,
                     "barWidthFactor": 0.6,
                     "drawStyle": "line",
-                    "fillOpacity": 0,
+                    "fillOpacity": 8,
                     "gradientMode": "none",
                     "hideFrom": {
                       "legend": false,
@@ -2998,12 +2998,12 @@
                     },
                     "insertNulls": false,
                     "lineInterpolation": "linear",
-                    "lineWidth": 1,
+                    "lineWidth": 2,
                     "pointSize": 5,
                     "scaleDistribution": {
                       "type": "linear"
                     },
-                    "showPoints": "auto",
+                    "showPoints": "never",
                     "showValues": false,
                     "spanNulls": false,
                     "stacking": {
@@ -3104,7 +3104,7 @@
                     "barAlignment": 0,
                     "barWidthFactor": 0.6,
                     "drawStyle": "line",
-                    "fillOpacity": 0,
+                    "fillOpacity": 8,
                     "gradientMode": "none",
                     "hideFrom": {
                       "legend": false,
@@ -3113,12 +3113,12 @@
                     },
                     "insertNulls": false,
                     "lineInterpolation": "linear",
-                    "lineWidth": 1,
+                    "lineWidth": 2,
                     "pointSize": 5,
                     "scaleDistribution": {
                       "type": "linear"
                     },
-                    "showPoints": "auto",
+                    "showPoints": "never",
                     "showValues": false,
                     "spanNulls": false,
                     "stacking": {
@@ -3219,7 +3219,7 @@
                     "barAlignment": 0,
                     "barWidthFactor": 0.6,
                     "drawStyle": "line",
-                    "fillOpacity": 0,
+                    "fillOpacity": 8,
                     "gradientMode": "none",
                     "hideFrom": {
                       "legend": false,
@@ -3228,12 +3228,12 @@
                     },
                     "insertNulls": false,
                     "lineInterpolation": "linear",
-                    "lineWidth": 1,
+                    "lineWidth": 2,
                     "pointSize": 5,
                     "scaleDistribution": {
                       "type": "linear"
                     },
-                    "showPoints": "auto",
+                    "showPoints": "never",
                     "showValues": false,
                     "spanNulls": false,
                     "stacking": {
@@ -3334,7 +3334,7 @@
                     "barAlignment": 0,
                     "barWidthFactor": 0.6,
                     "drawStyle": "line",
-                    "fillOpacity": 0,
+                    "fillOpacity": 8,
                     "gradientMode": "none",
                     "hideFrom": {
                       "legend": false,
@@ -3343,12 +3343,12 @@
                     },
                     "insertNulls": false,
                     "lineInterpolation": "linear",
-                    "lineWidth": 1,
+                    "lineWidth": 2,
                     "pointSize": 5,
                     "scaleDistribution": {
                       "type": "linear"
                     },
-                    "showPoints": "auto",
+                    "showPoints": "never",
                     "showValues": false,
                     "spanNulls": false,
                     "stacking": {
@@ -3449,7 +3449,7 @@
                     "barAlignment": 0,
                     "barWidthFactor": 0.6,
                     "drawStyle": "line",
-                    "fillOpacity": 0,
+                    "fillOpacity": 8,
                     "gradientMode": "none",
                     "hideFrom": {
                       "legend": false,
@@ -3458,12 +3458,12 @@
                     },
                     "insertNulls": false,
                     "lineInterpolation": "linear",
-                    "lineWidth": 1,
+                    "lineWidth": 2,
                     "pointSize": 5,
                     "scaleDistribution": {
                       "type": "linear"
                     },
-                    "showPoints": "auto",
+                    "showPoints": "never",
                     "showValues": false,
                     "spanNulls": false,
                     "stacking": {
@@ -3564,7 +3564,7 @@
                     "barAlignment": 0,
                     "barWidthFactor": 0.6,
                     "drawStyle": "line",
-                    "fillOpacity": 0,
+                    "fillOpacity": 8,
                     "gradientMode": "none",
                     "hideFrom": {
                       "legend": false,
@@ -3573,12 +3573,12 @@
                     },
                     "insertNulls": false,
                     "lineInterpolation": "linear",
-                    "lineWidth": 1,
+                    "lineWidth": 2,
                     "pointSize": 5,
                     "scaleDistribution": {
                       "type": "linear"
                     },
-                    "showPoints": "auto",
+                    "showPoints": "never",
                     "showValues": false,
                     "spanNulls": false,
                     "stacking": {
@@ -3679,7 +3679,7 @@
                     "barAlignment": 0,
                     "barWidthFactor": 0.6,
                     "drawStyle": "line",
-                    "fillOpacity": 0,
+                    "fillOpacity": 8,
                     "gradientMode": "none",
                     "hideFrom": {
                       "legend": false,
@@ -3688,12 +3688,12 @@
                     },
                     "insertNulls": false,
                     "lineInterpolation": "linear",
-                    "lineWidth": 1,
+                    "lineWidth": 2,
                     "pointSize": 5,
                     "scaleDistribution": {
                       "type": "linear"
                     },
-                    "showPoints": "auto",
+                    "showPoints": "never",
                     "showValues": false,
                     "spanNulls": false,
                     "stacking": {
@@ -3794,7 +3794,7 @@
                     "barAlignment": 0,
                     "barWidthFactor": 0.6,
                     "drawStyle": "line",
-                    "fillOpacity": 0,
+                    "fillOpacity": 8,
                     "gradientMode": "none",
                     "hideFrom": {
                       "legend": false,
@@ -3803,12 +3803,12 @@
                     },
                     "insertNulls": false,
                     "lineInterpolation": "linear",
-                    "lineWidth": 1,
+                    "lineWidth": 2,
                     "pointSize": 5,
                     "scaleDistribution": {
                       "type": "linear"
                     },
-                    "showPoints": "auto",
+                    "showPoints": "never",
                     "showValues": false,
                     "spanNulls": false,
                     "stacking": {
@@ -3909,7 +3909,7 @@
                     "barAlignment": 0,
                     "barWidthFactor": 0.6,
                     "drawStyle": "line",
-                    "fillOpacity": 0,
+                    "fillOpacity": 8,
                     "gradientMode": "none",
                     "hideFrom": {
                       "legend": false,
@@ -3918,12 +3918,12 @@
                     },
                     "insertNulls": false,
                     "lineInterpolation": "linear",
-                    "lineWidth": 1,
+                    "lineWidth": 2,
                     "pointSize": 5,
                     "scaleDistribution": {
                       "type": "linear"
                     },
-                    "showPoints": "auto",
+                    "showPoints": "never",
                     "showValues": false,
                     "spanNulls": false,
                     "stacking": {
@@ -4024,7 +4024,7 @@
                     "barAlignment": 0,
                     "barWidthFactor": 0.6,
                     "drawStyle": "line",
-                    "fillOpacity": 0,
+                    "fillOpacity": 8,
                     "gradientMode": "none",
                     "hideFrom": {
                       "legend": false,
@@ -4033,12 +4033,12 @@
                     },
                     "insertNulls": false,
                     "lineInterpolation": "linear",
-                    "lineWidth": 1,
+                    "lineWidth": 2,
                     "pointSize": 5,
                     "scaleDistribution": {
                       "type": "linear"
                     },
-                    "showPoints": "auto",
+                    "showPoints": "never",
                     "showValues": false,
                     "spanNulls": false,
                     "stacking": {
@@ -4139,7 +4139,7 @@
                     "barAlignment": 0,
                     "barWidthFactor": 0.6,
                     "drawStyle": "line",
-                    "fillOpacity": 0,
+                    "fillOpacity": 8,
                     "gradientMode": "none",
                     "hideFrom": {
                       "legend": false,
@@ -4148,12 +4148,12 @@
                     },
                     "insertNulls": false,
                     "lineInterpolation": "linear",
-                    "lineWidth": 1,
+                    "lineWidth": 2,
                     "pointSize": 5,
                     "scaleDistribution": {
                       "type": "linear"
                     },
-                    "showPoints": "auto",
+                    "showPoints": "never",
                     "showValues": false,
                     "spanNulls": false,
                     "stacking": {
@@ -4254,7 +4254,7 @@
                     "barAlignment": 0,
                     "barWidthFactor": 0.6,
                     "drawStyle": "line",
-                    "fillOpacity": 0,
+                    "fillOpacity": 8,
                     "gradientMode": "none",
                     "hideFrom": {
                       "legend": false,
@@ -4263,12 +4263,12 @@
                     },
                     "insertNulls": false,
                     "lineInterpolation": "linear",
-                    "lineWidth": 1,
+                    "lineWidth": 2,
                     "pointSize": 5,
                     "scaleDistribution": {
                       "type": "linear"
                     },
-                    "showPoints": "auto",
+                    "showPoints": "never",
                     "showValues": false,
                     "spanNulls": false,
                     "stacking": {
@@ -4369,7 +4369,7 @@
                     "barAlignment": 0,
                     "barWidthFactor": 0.6,
                     "drawStyle": "line",
-                    "fillOpacity": 0,
+                    "fillOpacity": 8,
                     "gradientMode": "none",
                     "hideFrom": {
                       "legend": false,
@@ -4378,12 +4378,12 @@
                     },
                     "insertNulls": false,
                     "lineInterpolation": "linear",
-                    "lineWidth": 1,
+                    "lineWidth": 2,
                     "pointSize": 5,
                     "scaleDistribution": {
                       "type": "linear"
                     },
-                    "showPoints": "auto",
+                    "showPoints": "never",
                     "showValues": false,
                     "spanNulls": false,
                     "stacking": {
@@ -4484,7 +4484,7 @@
                     "barAlignment": 0,
                     "barWidthFactor": 0.6,
                     "drawStyle": "line",
-                    "fillOpacity": 0,
+                    "fillOpacity": 8,
                     "gradientMode": "none",
                     "hideFrom": {
                       "legend": false,
@@ -4493,12 +4493,12 @@
                     },
                     "insertNulls": false,
                     "lineInterpolation": "linear",
-                    "lineWidth": 1,
+                    "lineWidth": 2,
                     "pointSize": 5,
                     "scaleDistribution": {
                       "type": "linear"
                     },
-                    "showPoints": "auto",
+                    "showPoints": "never",
                     "showValues": false,
                     "spanNulls": false,
                     "stacking": {
@@ -4599,7 +4599,7 @@
                     "barAlignment": 0,
                     "barWidthFactor": 0.6,
                     "drawStyle": "line",
-                    "fillOpacity": 0,
+                    "fillOpacity": 8,
                     "gradientMode": "none",
                     "hideFrom": {
                       "legend": false,
@@ -4608,12 +4608,12 @@
                     },
                     "insertNulls": false,
                     "lineInterpolation": "linear",
-                    "lineWidth": 1,
+                    "lineWidth": 2,
                     "pointSize": 5,
                     "scaleDistribution": {
                       "type": "linear"
                     },
-                    "showPoints": "auto",
+                    "showPoints": "never",
                     "showValues": false,
                     "spanNulls": false,
                     "stacking": {
@@ -4714,7 +4714,7 @@
                     "barAlignment": 0,
                     "barWidthFactor": 0.6,
                     "drawStyle": "line",
-                    "fillOpacity": 0,
+                    "fillOpacity": 8,
                     "gradientMode": "none",
                     "hideFrom": {
                       "legend": false,
@@ -4723,12 +4723,12 @@
                     },
                     "insertNulls": false,
                     "lineInterpolation": "linear",
-                    "lineWidth": 1,
+                    "lineWidth": 2,
                     "pointSize": 5,
                     "scaleDistribution": {
                       "type": "linear"
                     },
-                    "showPoints": "auto",
+                    "showPoints": "never",
                     "showValues": false,
                     "spanNulls": false,
                     "stacking": {
@@ -4829,7 +4829,7 @@
                     "barAlignment": 0,
                     "barWidthFactor": 0.6,
                     "drawStyle": "line",
-                    "fillOpacity": 0,
+                    "fillOpacity": 8,
                     "gradientMode": "none",
                     "hideFrom": {
                       "legend": false,
@@ -4838,12 +4838,12 @@
                     },
                     "insertNulls": false,
                     "lineInterpolation": "linear",
-                    "lineWidth": 1,
+                    "lineWidth": 2,
                     "pointSize": 5,
                     "scaleDistribution": {
                       "type": "linear"
                     },
-                    "showPoints": "auto",
+                    "showPoints": "never",
                     "showValues": false,
                     "spanNulls": false,
                     "stacking": {
@@ -4944,7 +4944,7 @@
                     "barAlignment": 0,
                     "barWidthFactor": 0.6,
                     "drawStyle": "line",
-                    "fillOpacity": 0,
+                    "fillOpacity": 8,
                     "gradientMode": "none",
                     "hideFrom": {
                       "legend": false,
@@ -4953,12 +4953,12 @@
                     },
                     "insertNulls": false,
                     "lineInterpolation": "linear",
-                    "lineWidth": 1,
+                    "lineWidth": 2,
                     "pointSize": 5,
                     "scaleDistribution": {
                       "type": "linear"
                     },
-                    "showPoints": "auto",
+                    "showPoints": "never",
                     "showValues": false,
                     "spanNulls": false,
                     "stacking": {
@@ -5059,7 +5059,7 @@
                     "barAlignment": 0,
                     "barWidthFactor": 0.6,
                     "drawStyle": "line",
-                    "fillOpacity": 0,
+                    "fillOpacity": 8,
                     "gradientMode": "none",
                     "hideFrom": {
                       "legend": false,
@@ -5068,12 +5068,12 @@
                     },
                     "insertNulls": false,
                     "lineInterpolation": "linear",
-                    "lineWidth": 1,
+                    "lineWidth": 2,
                     "pointSize": 5,
                     "scaleDistribution": {
                       "type": "linear"
                     },
-                    "showPoints": "auto",
+                    "showPoints": "never",
                     "showValues": false,
                     "spanNulls": false,
                     "stacking": {
@@ -5174,7 +5174,7 @@
                     "barAlignment": 0,
                     "barWidthFactor": 0.6,
                     "drawStyle": "line",
-                    "fillOpacity": 0,
+                    "fillOpacity": 8,
                     "gradientMode": "none",
                     "hideFrom": {
                       "legend": false,
@@ -5183,12 +5183,12 @@
                     },
                     "insertNulls": false,
                     "lineInterpolation": "linear",
-                    "lineWidth": 1,
+                    "lineWidth": 2,
                     "pointSize": 5,
                     "scaleDistribution": {
                       "type": "linear"
                     },
-                    "showPoints": "auto",
+                    "showPoints": "never",
                     "showValues": false,
                     "spanNulls": false,
                     "stacking": {
@@ -5289,7 +5289,7 @@
                     "barAlignment": 0,
                     "barWidthFactor": 0.6,
                     "drawStyle": "line",
-                    "fillOpacity": 0,
+                    "fillOpacity": 8,
                     "gradientMode": "none",
                     "hideFrom": {
                       "legend": false,
@@ -5298,12 +5298,12 @@
                     },
                     "insertNulls": false,
                     "lineInterpolation": "linear",
-                    "lineWidth": 1,
+                    "lineWidth": 2,
                     "pointSize": 5,
                     "scaleDistribution": {
                       "type": "linear"
                     },
-                    "showPoints": "auto",
+                    "showPoints": "never",
                     "showValues": false,
                     "spanNulls": false,
                     "stacking": {
@@ -5404,7 +5404,7 @@
                     "barAlignment": 0,
                     "barWidthFactor": 0.6,
                     "drawStyle": "line",
-                    "fillOpacity": 0,
+                    "fillOpacity": 8,
                     "gradientMode": "none",
                     "hideFrom": {
                       "legend": false,
@@ -5413,12 +5413,12 @@
                     },
                     "insertNulls": false,
                     "lineInterpolation": "linear",
-                    "lineWidth": 1,
+                    "lineWidth": 2,
                     "pointSize": 5,
                     "scaleDistribution": {
                       "type": "linear"
                     },
-                    "showPoints": "auto",
+                    "showPoints": "never",
                     "showValues": false,
                     "spanNulls": false,
                     "stacking": {
@@ -5519,7 +5519,7 @@
                     "barAlignment": 0,
                     "barWidthFactor": 0.6,
                     "drawStyle": "line",
-                    "fillOpacity": 0,
+                    "fillOpacity": 8,
                     "gradientMode": "none",
                     "hideFrom": {
                       "legend": false,
@@ -5528,12 +5528,12 @@
                     },
                     "insertNulls": false,
                     "lineInterpolation": "linear",
-                    "lineWidth": 1,
+                    "lineWidth": 2,
                     "pointSize": 5,
                     "scaleDistribution": {
                       "type": "linear"
                     },
-                    "showPoints": "auto",
+                    "showPoints": "never",
                     "showValues": false,
                     "spanNulls": false,
                     "stacking": {
@@ -5634,7 +5634,7 @@
                     "barAlignment": 0,
                     "barWidthFactor": 0.6,
                     "drawStyle": "line",
-                    "fillOpacity": 0,
+                    "fillOpacity": 8,
                     "gradientMode": "none",
                     "hideFrom": {
                       "legend": false,
@@ -5643,12 +5643,12 @@
                     },
                     "insertNulls": false,
                     "lineInterpolation": "linear",
-                    "lineWidth": 1,
+                    "lineWidth": 2,
                     "pointSize": 5,
                     "scaleDistribution": {
                       "type": "linear"
                     },
-                    "showPoints": "auto",
+                    "showPoints": "never",
                     "showValues": false,
                     "spanNulls": false,
                     "stacking": {
@@ -5749,7 +5749,7 @@
                     "barAlignment": 0,
                     "barWidthFactor": 0.6,
                     "drawStyle": "line",
-                    "fillOpacity": 0,
+                    "fillOpacity": 8,
                     "gradientMode": "none",
                     "hideFrom": {
                       "legend": false,
@@ -5758,12 +5758,12 @@
                     },
                     "insertNulls": false,
                     "lineInterpolation": "linear",
-                    "lineWidth": 1,
+                    "lineWidth": 2,
                     "pointSize": 5,
                     "scaleDistribution": {
                       "type": "linear"
                     },
-                    "showPoints": "auto",
+                    "showPoints": "never",
                     "showValues": false,
                     "spanNulls": false,
                     "stacking": {
@@ -5864,7 +5864,7 @@
                     "barAlignment": 0,
                     "barWidthFactor": 0.6,
                     "drawStyle": "line",
-                    "fillOpacity": 0,
+                    "fillOpacity": 8,
                     "gradientMode": "none",
                     "hideFrom": {
                       "legend": false,
@@ -5873,12 +5873,12 @@
                     },
                     "insertNulls": false,
                     "lineInterpolation": "linear",
-                    "lineWidth": 1,
+                    "lineWidth": 2,
                     "pointSize": 5,
                     "scaleDistribution": {
                       "type": "linear"
                     },
-                    "showPoints": "auto",
+                    "showPoints": "never",
                     "showValues": false,
                     "spanNulls": false,
                     "stacking": {
@@ -5979,7 +5979,7 @@
                     "barAlignment": 0,
                     "barWidthFactor": 0.6,
                     "drawStyle": "line",
-                    "fillOpacity": 0,
+                    "fillOpacity": 8,
                     "gradientMode": "none",
                     "hideFrom": {
                       "legend": false,
@@ -5988,12 +5988,12 @@
                     },
                     "insertNulls": false,
                     "lineInterpolation": "linear",
-                    "lineWidth": 1,
+                    "lineWidth": 2,
                     "pointSize": 5,
                     "scaleDistribution": {
                       "type": "linear"
                     },
-                    "showPoints": "auto",
+                    "showPoints": "never",
                     "showValues": false,
                     "spanNulls": false,
                     "stacking": {
@@ -6094,7 +6094,7 @@
                     "barAlignment": 0,
                     "barWidthFactor": 0.6,
                     "drawStyle": "line",
-                    "fillOpacity": 0,
+                    "fillOpacity": 8,
                     "gradientMode": "none",
                     "hideFrom": {
                       "legend": false,
@@ -6103,12 +6103,12 @@
                     },
                     "insertNulls": false,
                     "lineInterpolation": "linear",
-                    "lineWidth": 1,
+                    "lineWidth": 2,
                     "pointSize": 5,
                     "scaleDistribution": {
                       "type": "linear"
                     },
-                    "showPoints": "auto",
+                    "showPoints": "never",
                     "showValues": false,
                     "spanNulls": false,
                     "stacking": {
@@ -6209,7 +6209,7 @@
                     "barAlignment": 0,
                     "barWidthFactor": 0.6,
                     "drawStyle": "line",
-                    "fillOpacity": 0,
+                    "fillOpacity": 8,
                     "gradientMode": "none",
                     "hideFrom": {
                       "legend": false,
@@ -6218,12 +6218,12 @@
                     },
                     "insertNulls": false,
                     "lineInterpolation": "linear",
-                    "lineWidth": 1,
+                    "lineWidth": 2,
                     "pointSize": 5,
                     "scaleDistribution": {
                       "type": "linear"
                     },
-                    "showPoints": "auto",
+                    "showPoints": "never",
                     "showValues": false,
                     "spanNulls": false,
                     "stacking": {
@@ -6324,7 +6324,7 @@
                     "barAlignment": 0,
                     "barWidthFactor": 0.6,
                     "drawStyle": "line",
-                    "fillOpacity": 0,
+                    "fillOpacity": 8,
                     "gradientMode": "none",
                     "hideFrom": {
                       "legend": false,
@@ -6333,12 +6333,12 @@
                     },
                     "insertNulls": false,
                     "lineInterpolation": "linear",
-                    "lineWidth": 1,
+                    "lineWidth": 2,
                     "pointSize": 5,
                     "scaleDistribution": {
                       "type": "linear"
                     },
-                    "showPoints": "auto",
+                    "showPoints": "never",
                     "showValues": false,
                     "spanNulls": false,
                     "stacking": {
@@ -6439,7 +6439,7 @@
                     "barAlignment": 0,
                     "barWidthFactor": 0.6,
                     "drawStyle": "line",
-                    "fillOpacity": 0,
+                    "fillOpacity": 8,
                     "gradientMode": "none",
                     "hideFrom": {
                       "legend": false,
@@ -6448,12 +6448,12 @@
                     },
                     "insertNulls": false,
                     "lineInterpolation": "linear",
-                    "lineWidth": 1,
+                    "lineWidth": 2,
                     "pointSize": 5,
                     "scaleDistribution": {
                       "type": "linear"
                     },
-                    "showPoints": "auto",
+                    "showPoints": "never",
                     "showValues": false,
                     "spanNulls": false,
                     "stacking": {
@@ -6554,7 +6554,7 @@
                     "barAlignment": 0,
                     "barWidthFactor": 0.6,
                     "drawStyle": "line",
-                    "fillOpacity": 0,
+                    "fillOpacity": 8,
                     "gradientMode": "none",
                     "hideFrom": {
                       "legend": false,
@@ -6563,12 +6563,12 @@
                     },
                     "insertNulls": false,
                     "lineInterpolation": "linear",
-                    "lineWidth": 1,
+                    "lineWidth": 2,
                     "pointSize": 5,
                     "scaleDistribution": {
                       "type": "linear"
                     },
-                    "showPoints": "auto",
+                    "showPoints": "never",
                     "showValues": false,
                     "spanNulls": false,
                     "stacking": {
@@ -6669,7 +6669,7 @@
                     "barAlignment": 0,
                     "barWidthFactor": 0.6,
                     "drawStyle": "line",
-                    "fillOpacity": 0,
+                    "fillOpacity": 8,
                     "gradientMode": "none",
                     "hideFrom": {
                       "legend": false,
@@ -6678,12 +6678,12 @@
                     },
                     "insertNulls": false,
                     "lineInterpolation": "linear",
-                    "lineWidth": 1,
+                    "lineWidth": 2,
                     "pointSize": 5,
                     "scaleDistribution": {
                       "type": "linear"
                     },
-                    "showPoints": "auto",
+                    "showPoints": "never",
                     "showValues": false,
                     "spanNulls": false,
                     "stacking": {
@@ -6784,7 +6784,7 @@
                     "barAlignment": 0,
                     "barWidthFactor": 0.6,
                     "drawStyle": "line",
-                    "fillOpacity": 0,
+                    "fillOpacity": 8,
                     "gradientMode": "none",
                     "hideFrom": {
                       "legend": false,
@@ -6793,12 +6793,12 @@
                     },
                     "insertNulls": false,
                     "lineInterpolation": "linear",
-                    "lineWidth": 1,
+                    "lineWidth": 2,
                     "pointSize": 5,
                     "scaleDistribution": {
                       "type": "linear"
                     },
-                    "showPoints": "auto",
+                    "showPoints": "never",
                     "showValues": false,
                     "spanNulls": false,
                     "stacking": {
@@ -6899,7 +6899,7 @@
                     "barAlignment": 0,
                     "barWidthFactor": 0.6,
                     "drawStyle": "line",
-                    "fillOpacity": 0,
+                    "fillOpacity": 8,
                     "gradientMode": "none",
                     "hideFrom": {
                       "legend": false,
@@ -6908,12 +6908,12 @@
                     },
                     "insertNulls": false,
                     "lineInterpolation": "linear",
-                    "lineWidth": 1,
+                    "lineWidth": 2,
                     "pointSize": 5,
                     "scaleDistribution": {
                       "type": "linear"
                     },
-                    "showPoints": "auto",
+                    "showPoints": "never",
                     "showValues": false,
                     "spanNulls": false,
                     "stacking": {
@@ -7014,7 +7014,7 @@
                     "barAlignment": 0,
                     "barWidthFactor": 0.6,
                     "drawStyle": "line",
-                    "fillOpacity": 0,
+                    "fillOpacity": 8,
                     "gradientMode": "none",
                     "hideFrom": {
                       "legend": false,
@@ -7023,12 +7023,12 @@
                     },
                     "insertNulls": false,
                     "lineInterpolation": "linear",
-                    "lineWidth": 1,
+                    "lineWidth": 2,
                     "pointSize": 5,
                     "scaleDistribution": {
                       "type": "linear"
                     },
-                    "showPoints": "auto",
+                    "showPoints": "never",
                     "showValues": false,
                     "spanNulls": false,
                     "stacking": {
@@ -7129,7 +7129,7 @@
                     "barAlignment": 0,
                     "barWidthFactor": 0.6,
                     "drawStyle": "line",
-                    "fillOpacity": 0,
+                    "fillOpacity": 8,
                     "gradientMode": "none",
                     "hideFrom": {
                       "legend": false,
@@ -7138,12 +7138,12 @@
                     },
                     "insertNulls": false,
                     "lineInterpolation": "linear",
-                    "lineWidth": 1,
+                    "lineWidth": 2,
                     "pointSize": 5,
                     "scaleDistribution": {
                       "type": "linear"
                     },
-                    "showPoints": "auto",
+                    "showPoints": "never",
                     "showValues": false,
                     "spanNulls": false,
                     "stacking": {
@@ -7244,7 +7244,7 @@
                     "barAlignment": 0,
                     "barWidthFactor": 0.6,
                     "drawStyle": "line",
-                    "fillOpacity": 0,
+                    "fillOpacity": 8,
                     "gradientMode": "none",
                     "hideFrom": {
                       "legend": false,
@@ -7253,12 +7253,12 @@
                     },
                     "insertNulls": false,
                     "lineInterpolation": "linear",
-                    "lineWidth": 1,
+                    "lineWidth": 2,
                     "pointSize": 5,
                     "scaleDistribution": {
                       "type": "linear"
                     },
-                    "showPoints": "auto",
+                    "showPoints": "never",
                     "showValues": false,
                     "spanNulls": false,
                     "stacking": {
@@ -7359,7 +7359,7 @@
                     "barAlignment": 0,
                     "barWidthFactor": 0.6,
                     "drawStyle": "line",
-                    "fillOpacity": 0,
+                    "fillOpacity": 8,
                     "gradientMode": "none",
                     "hideFrom": {
                       "legend": false,
@@ -7368,12 +7368,12 @@
                     },
                     "insertNulls": false,
                     "lineInterpolation": "linear",
-                    "lineWidth": 1,
+                    "lineWidth": 2,
                     "pointSize": 5,
                     "scaleDistribution": {
                       "type": "linear"
                     },
-                    "showPoints": "auto",
+                    "showPoints": "never",
                     "showValues": false,
                     "spanNulls": false,
                     "stacking": {
@@ -7474,7 +7474,7 @@
                     "barAlignment": 0,
                     "barWidthFactor": 0.6,
                     "drawStyle": "line",
-                    "fillOpacity": 0,
+                    "fillOpacity": 8,
                     "gradientMode": "none",
                     "hideFrom": {
                       "legend": false,
@@ -7483,12 +7483,12 @@
                     },
                     "insertNulls": false,
                     "lineInterpolation": "linear",
-                    "lineWidth": 1,
+                    "lineWidth": 2,
                     "pointSize": 5,
                     "scaleDistribution": {
                       "type": "linear"
                     },
-                    "showPoints": "auto",
+                    "showPoints": "never",
                     "showValues": false,
                     "spanNulls": false,
                     "stacking": {
@@ -7589,7 +7589,7 @@
                     "barAlignment": 0,
                     "barWidthFactor": 0.6,
                     "drawStyle": "line",
-                    "fillOpacity": 0,
+                    "fillOpacity": 8,
                     "gradientMode": "none",
                     "hideFrom": {
                       "legend": false,
@@ -7598,12 +7598,12 @@
                     },
                     "insertNulls": false,
                     "lineInterpolation": "linear",
-                    "lineWidth": 1,
+                    "lineWidth": 2,
                     "pointSize": 5,
                     "scaleDistribution": {
                       "type": "linear"
                     },
-                    "showPoints": "auto",
+                    "showPoints": "never",
                     "showValues": false,
                     "spanNulls": false,
                     "stacking": {
@@ -7704,7 +7704,7 @@
                     "barAlignment": 0,
                     "barWidthFactor": 0.6,
                     "drawStyle": "line",
-                    "fillOpacity": 0,
+                    "fillOpacity": 8,
                     "gradientMode": "none",
                     "hideFrom": {
                       "legend": false,
@@ -7713,12 +7713,12 @@
                     },
                     "insertNulls": false,
                     "lineInterpolation": "linear",
-                    "lineWidth": 1,
+                    "lineWidth": 2,
                     "pointSize": 5,
                     "scaleDistribution": {
                       "type": "linear"
                     },
-                    "showPoints": "auto",
+                    "showPoints": "never",
                     "showValues": false,
                     "spanNulls": false,
                     "stacking": {
@@ -7819,7 +7819,7 @@
                     "barAlignment": 0,
                     "barWidthFactor": 0.6,
                     "drawStyle": "line",
-                    "fillOpacity": 0,
+                    "fillOpacity": 8,
                     "gradientMode": "none",
                     "hideFrom": {
                       "legend": false,
@@ -7828,12 +7828,12 @@
                     },
                     "insertNulls": false,
                     "lineInterpolation": "linear",
-                    "lineWidth": 1,
+                    "lineWidth": 2,
                     "pointSize": 5,
                     "scaleDistribution": {
                       "type": "linear"
                     },
-                    "showPoints": "auto",
+                    "showPoints": "never",
                     "showValues": false,
                     "spanNulls": false,
                     "stacking": {
@@ -7934,7 +7934,7 @@
                     "barAlignment": 0,
                     "barWidthFactor": 0.6,
                     "drawStyle": "line",
-                    "fillOpacity": 0,
+                    "fillOpacity": 8,
                     "gradientMode": "none",
                     "hideFrom": {
                       "legend": false,
@@ -7943,12 +7943,12 @@
                     },
                     "insertNulls": false,
                     "lineInterpolation": "linear",
-                    "lineWidth": 1,
+                    "lineWidth": 2,
                     "pointSize": 5,
                     "scaleDistribution": {
                       "type": "linear"
                     },
-                    "showPoints": "auto",
+                    "showPoints": "never",
                     "showValues": false,
                     "spanNulls": false,
                     "stacking": {
@@ -8049,7 +8049,7 @@
                     "barAlignment": 0,
                     "barWidthFactor": 0.6,
                     "drawStyle": "line",
-                    "fillOpacity": 0,
+                    "fillOpacity": 8,
                     "gradientMode": "none",
                     "hideFrom": {
                       "legend": false,
@@ -8058,12 +8058,12 @@
                     },
                     "insertNulls": false,
                     "lineInterpolation": "linear",
-                    "lineWidth": 1,
+                    "lineWidth": 2,
                     "pointSize": 5,
                     "scaleDistribution": {
                       "type": "linear"
                     },
-                    "showPoints": "auto",
+                    "showPoints": "never",
                     "showValues": false,
                     "spanNulls": false,
                     "stacking": {
@@ -8164,7 +8164,7 @@
                     "barAlignment": 0,
                     "barWidthFactor": 0.6,
                     "drawStyle": "line",
-                    "fillOpacity": 0,
+                    "fillOpacity": 8,
                     "gradientMode": "none",
                     "hideFrom": {
                       "legend": false,
@@ -8173,12 +8173,12 @@
                     },
                     "insertNulls": false,
                     "lineInterpolation": "linear",
-                    "lineWidth": 1,
+                    "lineWidth": 2,
                     "pointSize": 5,
                     "scaleDistribution": {
                       "type": "linear"
                     },
-                    "showPoints": "auto",
+                    "showPoints": "never",
                     "showValues": false,
                     "spanNulls": false,
                     "stacking": {
@@ -8279,7 +8279,7 @@
                     "barAlignment": 0,
                     "barWidthFactor": 0.6,
                     "drawStyle": "line",
-                    "fillOpacity": 0,
+                    "fillOpacity": 8,
                     "gradientMode": "none",
                     "hideFrom": {
                       "legend": false,
@@ -8288,12 +8288,12 @@
                     },
                     "insertNulls": false,
                     "lineInterpolation": "linear",
-                    "lineWidth": 1,
+                    "lineWidth": 2,
                     "pointSize": 5,
                     "scaleDistribution": {
                       "type": "linear"
                     },
-                    "showPoints": "auto",
+                    "showPoints": "never",
                     "showValues": false,
                     "spanNulls": false,
                     "stacking": {
@@ -8394,7 +8394,7 @@
                     "barAlignment": 0,
                     "barWidthFactor": 0.6,
                     "drawStyle": "line",
-                    "fillOpacity": 0,
+                    "fillOpacity": 8,
                     "gradientMode": "none",
                     "hideFrom": {
                       "legend": false,
@@ -8403,12 +8403,12 @@
                     },
                     "insertNulls": false,
                     "lineInterpolation": "linear",
-                    "lineWidth": 1,
+                    "lineWidth": 2,
                     "pointSize": 5,
                     "scaleDistribution": {
                       "type": "linear"
                     },
-                    "showPoints": "auto",
+                    "showPoints": "never",
                     "showValues": false,
                     "spanNulls": false,
                     "stacking": {
@@ -8509,7 +8509,7 @@
                     "barAlignment": 0,
                     "barWidthFactor": 0.6,
                     "drawStyle": "line",
-                    "fillOpacity": 0,
+                    "fillOpacity": 8,
                     "gradientMode": "none",
                     "hideFrom": {
                       "legend": false,
@@ -8518,12 +8518,12 @@
                     },
                     "insertNulls": false,
                     "lineInterpolation": "linear",
-                    "lineWidth": 1,
+                    "lineWidth": 2,
                     "pointSize": 5,
                     "scaleDistribution": {
                       "type": "linear"
                     },
-                    "showPoints": "auto",
+                    "showPoints": "never",
                     "showValues": false,
                     "spanNulls": false,
                     "stacking": {
@@ -8808,7 +8808,7 @@
                     "barAlignment": 0,
                     "barWidthFactor": 0.6,
                     "drawStyle": "line",
-                    "fillOpacity": 0,
+                    "fillOpacity": 8,
                     "gradientMode": "none",
                     "hideFrom": {
                       "legend": false,
@@ -8817,12 +8817,12 @@
                     },
                     "insertNulls": false,
                     "lineInterpolation": "linear",
-                    "lineWidth": 1,
+                    "lineWidth": 2,
                     "pointSize": 5,
                     "scaleDistribution": {
                       "type": "linear"
                     },
-                    "showPoints": "auto",
+                    "showPoints": "never",
                     "showValues": false,
                     "spanNulls": false,
                     "stacking": {
@@ -8923,7 +8923,7 @@
                     "barAlignment": 0,
                     "barWidthFactor": 0.6,
                     "drawStyle": "line",
-                    "fillOpacity": 0,
+                    "fillOpacity": 8,
                     "gradientMode": "none",
                     "hideFrom": {
                       "legend": false,
@@ -8932,12 +8932,12 @@
                     },
                     "insertNulls": false,
                     "lineInterpolation": "linear",
-                    "lineWidth": 1,
+                    "lineWidth": 2,
                     "pointSize": 5,
                     "scaleDistribution": {
                       "type": "linear"
                     },
-                    "showPoints": "auto",
+                    "showPoints": "never",
                     "showValues": false,
                     "spanNulls": false,
                     "stacking": {
@@ -9038,7 +9038,7 @@
                     "barAlignment": 0,
                     "barWidthFactor": 0.6,
                     "drawStyle": "line",
-                    "fillOpacity": 0,
+                    "fillOpacity": 8,
                     "gradientMode": "none",
                     "hideFrom": {
                       "legend": false,
@@ -9047,12 +9047,12 @@
                     },
                     "insertNulls": false,
                     "lineInterpolation": "linear",
-                    "lineWidth": 1,
+                    "lineWidth": 2,
                     "pointSize": 5,
                     "scaleDistribution": {
                       "type": "linear"
                     },
-                    "showPoints": "auto",
+                    "showPoints": "never",
                     "showValues": false,
                     "spanNulls": false,
                     "stacking": {
@@ -9153,7 +9153,7 @@
                     "barAlignment": 0,
                     "barWidthFactor": 0.6,
                     "drawStyle": "line",
-                    "fillOpacity": 0,
+                    "fillOpacity": 8,
                     "gradientMode": "none",
                     "hideFrom": {
                       "legend": false,
@@ -9162,12 +9162,12 @@
                     },
                     "insertNulls": false,
                     "lineInterpolation": "linear",
-                    "lineWidth": 1,
+                    "lineWidth": 2,
                     "pointSize": 5,
                     "scaleDistribution": {
                       "type": "linear"
                     },
-                    "showPoints": "auto",
+                    "showPoints": "never",
                     "showValues": false,
                     "spanNulls": false,
                     "stacking": {
@@ -9268,7 +9268,7 @@
                     "barAlignment": 0,
                     "barWidthFactor": 0.6,
                     "drawStyle": "line",
-                    "fillOpacity": 0,
+                    "fillOpacity": 8,
                     "gradientMode": "none",
                     "hideFrom": {
                       "legend": false,
@@ -9277,12 +9277,12 @@
                     },
                     "insertNulls": false,
                     "lineInterpolation": "linear",
-                    "lineWidth": 1,
+                    "lineWidth": 2,
                     "pointSize": 5,
                     "scaleDistribution": {
                       "type": "linear"
                     },
-                    "showPoints": "auto",
+                    "showPoints": "never",
                     "showValues": false,
                     "spanNulls": false,
                     "stacking": {
@@ -9383,7 +9383,7 @@
                     "barAlignment": 0,
                     "barWidthFactor": 0.6,
                     "drawStyle": "line",
-                    "fillOpacity": 0,
+                    "fillOpacity": 8,
                     "gradientMode": "none",
                     "hideFrom": {
                       "legend": false,
@@ -9392,12 +9392,12 @@
                     },
                     "insertNulls": false,
                     "lineInterpolation": "linear",
-                    "lineWidth": 1,
+                    "lineWidth": 2,
                     "pointSize": 5,
                     "scaleDistribution": {
                       "type": "linear"
                     },
-                    "showPoints": "auto",
+                    "showPoints": "never",
                     "showValues": false,
                     "spanNulls": false,
                     "stacking": {
@@ -9498,7 +9498,7 @@
                     "barAlignment": 0,
                     "barWidthFactor": 0.6,
                     "drawStyle": "line",
-                    "fillOpacity": 0,
+                    "fillOpacity": 8,
                     "gradientMode": "none",
                     "hideFrom": {
                       "legend": false,
@@ -9507,12 +9507,12 @@
                     },
                     "insertNulls": false,
                     "lineInterpolation": "linear",
-                    "lineWidth": 1,
+                    "lineWidth": 2,
                     "pointSize": 5,
                     "scaleDistribution": {
                       "type": "linear"
                     },
-                    "showPoints": "auto",
+                    "showPoints": "never",
                     "showValues": false,
                     "spanNulls": false,
                     "stacking": {
@@ -9613,7 +9613,7 @@
                     "barAlignment": 0,
                     "barWidthFactor": 0.6,
                     "drawStyle": "line",
-                    "fillOpacity": 0,
+                    "fillOpacity": 8,
                     "gradientMode": "none",
                     "hideFrom": {
                       "legend": false,
@@ -9622,12 +9622,12 @@
                     },
                     "insertNulls": false,
                     "lineInterpolation": "linear",
-                    "lineWidth": 1,
+                    "lineWidth": 2,
                     "pointSize": 5,
                     "scaleDistribution": {
                       "type": "linear"
                     },
-                    "showPoints": "auto",
+                    "showPoints": "never",
                     "showValues": false,
                     "spanNulls": false,
                     "stacking": {
@@ -9728,7 +9728,7 @@
                     "barAlignment": 0,
                     "barWidthFactor": 0.6,
                     "drawStyle": "line",
-                    "fillOpacity": 0,
+                    "fillOpacity": 8,
                     "gradientMode": "none",
                     "hideFrom": {
                       "legend": false,
@@ -9737,12 +9737,12 @@
                     },
                     "insertNulls": false,
                     "lineInterpolation": "linear",
-                    "lineWidth": 1,
+                    "lineWidth": 2,
                     "pointSize": 5,
                     "scaleDistribution": {
                       "type": "linear"
                     },
-                    "showPoints": "auto",
+                    "showPoints": "never",
                     "showValues": false,
                     "spanNulls": false,
                     "stacking": {
@@ -9843,7 +9843,7 @@
                     "barAlignment": 0,
                     "barWidthFactor": 0.6,
                     "drawStyle": "line",
-                    "fillOpacity": 0,
+                    "fillOpacity": 8,
                     "gradientMode": "none",
                     "hideFrom": {
                       "legend": false,
@@ -9852,12 +9852,12 @@
                     },
                     "insertNulls": false,
                     "lineInterpolation": "linear",
-                    "lineWidth": 1,
+                    "lineWidth": 2,
                     "pointSize": 5,
                     "scaleDistribution": {
                       "type": "linear"
                     },
-                    "showPoints": "auto",
+                    "showPoints": "never",
                     "showValues": false,
                     "spanNulls": false,
                     "stacking": {
@@ -11990,7 +11990,7 @@
                     "barAlignment": 0,
                     "barWidthFactor": 0.6,
                     "drawStyle": "line",
-                    "fillOpacity": 0,
+                    "fillOpacity": 8,
                     "gradientMode": "none",
                     "hideFrom": {
                       "legend": false,
@@ -11999,12 +11999,12 @@
                     },
                     "insertNulls": false,
                     "lineInterpolation": "linear",
-                    "lineWidth": 1,
+                    "lineWidth": 2,
                     "pointSize": 5,
                     "scaleDistribution": {
                       "type": "linear"
                     },
-                    "showPoints": "auto",
+                    "showPoints": "never",
                     "showValues": false,
                     "spanNulls": false,
                     "stacking": {
@@ -12105,7 +12105,7 @@
                     "barAlignment": 0,
                     "barWidthFactor": 0.6,
                     "drawStyle": "line",
-                    "fillOpacity": 0,
+                    "fillOpacity": 8,
                     "gradientMode": "none",
                     "hideFrom": {
                       "legend": false,
@@ -12114,12 +12114,12 @@
                     },
                     "insertNulls": false,
                     "lineInterpolation": "linear",
-                    "lineWidth": 1,
+                    "lineWidth": 2,
                     "pointSize": 5,
                     "scaleDistribution": {
                       "type": "linear"
                     },
-                    "showPoints": "auto",
+                    "showPoints": "never",
                     "showValues": false,
                     "spanNulls": false,
                     "stacking": {
@@ -12220,7 +12220,7 @@
                     "barAlignment": 0,
                     "barWidthFactor": 0.6,
                     "drawStyle": "line",
-                    "fillOpacity": 0,
+                    "fillOpacity": 8,
                     "gradientMode": "none",
                     "hideFrom": {
                       "legend": false,
@@ -12229,12 +12229,12 @@
                     },
                     "insertNulls": false,
                     "lineInterpolation": "linear",
-                    "lineWidth": 1,
+                    "lineWidth": 2,
                     "pointSize": 5,
                     "scaleDistribution": {
                       "type": "linear"
                     },
-                    "showPoints": "auto",
+                    "showPoints": "never",
                     "showValues": false,
                     "spanNulls": false,
                     "stacking": {
@@ -12335,7 +12335,7 @@
                     "barAlignment": 0,
                     "barWidthFactor": 0.6,
                     "drawStyle": "line",
-                    "fillOpacity": 0,
+                    "fillOpacity": 8,
                     "gradientMode": "none",
                     "hideFrom": {
                       "legend": false,
@@ -12344,12 +12344,12 @@
                     },
                     "insertNulls": false,
                     "lineInterpolation": "linear",
-                    "lineWidth": 1,
+                    "lineWidth": 2,
                     "pointSize": 5,
                     "scaleDistribution": {
                       "type": "linear"
                     },
-                    "showPoints": "auto",
+                    "showPoints": "never",
                     "showValues": false,
                     "spanNulls": false,
                     "stacking": {
@@ -12450,7 +12450,7 @@
                     "barAlignment": 0,
                     "barWidthFactor": 0.6,
                     "drawStyle": "line",
-                    "fillOpacity": 0,
+                    "fillOpacity": 8,
                     "gradientMode": "none",
                     "hideFrom": {
                       "legend": false,
@@ -12459,12 +12459,12 @@
                     },
                     "insertNulls": false,
                     "lineInterpolation": "linear",
-                    "lineWidth": 1,
+                    "lineWidth": 2,
                     "pointSize": 5,
                     "scaleDistribution": {
                       "type": "linear"
                     },
-                    "showPoints": "auto",
+                    "showPoints": "never",
                     "showValues": false,
                     "spanNulls": false,
                     "stacking": {
@@ -12565,7 +12565,7 @@
                     "barAlignment": 0,
                     "barWidthFactor": 0.6,
                     "drawStyle": "line",
-                    "fillOpacity": 0,
+                    "fillOpacity": 8,
                     "gradientMode": "none",
                     "hideFrom": {
                       "legend": false,
@@ -12574,12 +12574,12 @@
                     },
                     "insertNulls": false,
                     "lineInterpolation": "linear",
-                    "lineWidth": 1,
+                    "lineWidth": 2,
                     "pointSize": 5,
                     "scaleDistribution": {
                       "type": "linear"
                     },
-                    "showPoints": "auto",
+                    "showPoints": "never",
                     "showValues": false,
                     "spanNulls": false,
                     "stacking": {
@@ -12680,7 +12680,7 @@
                     "barAlignment": 0,
                     "barWidthFactor": 0.6,
                     "drawStyle": "line",
-                    "fillOpacity": 0,
+                    "fillOpacity": 8,
                     "gradientMode": "none",
                     "hideFrom": {
                       "legend": false,
@@ -12689,12 +12689,12 @@
                     },
                     "insertNulls": false,
                     "lineInterpolation": "linear",
-                    "lineWidth": 1,
+                    "lineWidth": 2,
                     "pointSize": 5,
                     "scaleDistribution": {
                       "type": "linear"
                     },
-                    "showPoints": "auto",
+                    "showPoints": "never",
                     "showValues": false,
                     "spanNulls": false,
                     "stacking": {
@@ -12795,7 +12795,7 @@
                     "barAlignment": 0,
                     "barWidthFactor": 0.6,
                     "drawStyle": "line",
-                    "fillOpacity": 0,
+                    "fillOpacity": 8,
                     "gradientMode": "none",
                     "hideFrom": {
                       "legend": false,
@@ -12804,12 +12804,12 @@
                     },
                     "insertNulls": false,
                     "lineInterpolation": "linear",
-                    "lineWidth": 1,
+                    "lineWidth": 2,
                     "pointSize": 5,
                     "scaleDistribution": {
                       "type": "linear"
                     },
-                    "showPoints": "auto",
+                    "showPoints": "never",
                     "showValues": false,
                     "spanNulls": false,
                     "stacking": {
@@ -12910,7 +12910,7 @@
                     "barAlignment": 0,
                     "barWidthFactor": 0.6,
                     "drawStyle": "line",
-                    "fillOpacity": 0,
+                    "fillOpacity": 8,
                     "gradientMode": "none",
                     "hideFrom": {
                       "legend": false,
@@ -12919,12 +12919,12 @@
                     },
                     "insertNulls": false,
                     "lineInterpolation": "linear",
-                    "lineWidth": 1,
+                    "lineWidth": 2,
                     "pointSize": 5,
                     "scaleDistribution": {
                       "type": "linear"
                     },
-                    "showPoints": "auto",
+                    "showPoints": "never",
                     "showValues": false,
                     "spanNulls": false,
                     "stacking": {
@@ -13025,7 +13025,7 @@
                     "barAlignment": 0,
                     "barWidthFactor": 0.6,
                     "drawStyle": "line",
-                    "fillOpacity": 0,
+                    "fillOpacity": 8,
                     "gradientMode": "none",
                     "hideFrom": {
                       "legend": false,
@@ -13034,12 +13034,12 @@
                     },
                     "insertNulls": false,
                     "lineInterpolation": "linear",
-                    "lineWidth": 1,
+                    "lineWidth": 2,
                     "pointSize": 5,
                     "scaleDistribution": {
                       "type": "linear"
                     },
-                    "showPoints": "auto",
+                    "showPoints": "never",
                     "showValues": false,
                     "spanNulls": false,
                     "stacking": {
@@ -13140,7 +13140,7 @@
                     "barAlignment": 0,
                     "barWidthFactor": 0.6,
                     "drawStyle": "line",
-                    "fillOpacity": 0,
+                    "fillOpacity": 8,
                     "gradientMode": "none",
                     "hideFrom": {
                       "legend": false,
@@ -13149,12 +13149,12 @@
                     },
                     "insertNulls": false,
                     "lineInterpolation": "linear",
-                    "lineWidth": 1,
+                    "lineWidth": 2,
                     "pointSize": 5,
                     "scaleDistribution": {
                       "type": "linear"
                     },
-                    "showPoints": "auto",
+                    "showPoints": "never",
                     "showValues": false,
                     "spanNulls": false,
                     "stacking": {

--- a/rl_insight/config/services/grafana/dashboards/verl_tainer_v1_with_vllm_engine.json
+++ b/rl_insight/config/services/grafana/dashboards/verl_tainer_v1_with_vllm_engine.json
@@ -2928,7 +2928,7 @@
                       "spec": {
                         "editorMode": "builder",
                         "expr": "rl_insight_monitor_critic_advantages_max",
-                        "legendFormat": "__auto",
+                        "legendFormat": "{{__name__}}",
                         "range": true
                       }
                     },
@@ -3043,7 +3043,7 @@
                       "spec": {
                         "editorMode": "builder",
                         "expr": "rl_insight_monitor_critic_advantages_mean",
-                        "legendFormat": "__auto",
+                        "legendFormat": "{{__name__}}",
                         "range": true
                       }
                     },
@@ -3475,7 +3475,7 @@
                       "spec": {
                         "editorMode": "builder",
                         "expr": "rl_insight_monitor_critic_advantages_min",
-                        "legendFormat": "__auto",
+                        "legendFormat": "{{__name__}}",
                         "range": true
                       }
                     },
@@ -3590,7 +3590,7 @@
                       "spec": {
                         "editorMode": "builder",
                         "expr": "rl_insight_monitor_critic_returns_max",
-                        "legendFormat": "__auto",
+                        "legendFormat": "{{__name__}}",
                         "range": true
                       }
                     },
@@ -3705,7 +3705,7 @@
                       "spec": {
                         "editorMode": "builder",
                         "expr": "rl_insight_monitor_critic_returns_mean",
-                        "legendFormat": "__auto",
+                        "legendFormat": "{{__name__}}",
                         "range": true
                       }
                     },
@@ -3820,7 +3820,7 @@
                       "spec": {
                         "editorMode": "builder",
                         "expr": "rl_insight_monitor_critic_returns_min",
-                        "legendFormat": "__auto",
+                        "legendFormat": "{{__name__}}",
                         "range": true
                       }
                     },
@@ -3935,7 +3935,7 @@
                       "spec": {
                         "editorMode": "builder",
                         "expr": "rl_insight_monitor_critic_rewards_max",
-                        "legendFormat": "__auto",
+                        "legendFormat": "{{__name__}}",
                         "range": true
                       }
                     },
@@ -4050,7 +4050,7 @@
                       "spec": {
                         "editorMode": "builder",
                         "expr": "rl_insight_monitor_critic_rewards_mean",
-                        "legendFormat": "__auto",
+                        "legendFormat": "{{__name__}}",
                         "range": true
                       }
                     },
@@ -4165,7 +4165,7 @@
                       "spec": {
                         "editorMode": "builder",
                         "expr": "rl_insight_monitor_critic_rewards_min",
-                        "legendFormat": "__auto",
+                        "legendFormat": "{{__name__}}",
                         "range": true
                       }
                     },
@@ -4280,7 +4280,7 @@
                       "spec": {
                         "editorMode": "builder",
                         "expr": "rl_insight_monitor_critic_score_max",
-                        "legendFormat": "__auto",
+                        "legendFormat": "{{__name__}}",
                         "range": true
                       }
                     },
@@ -4395,7 +4395,7 @@
                       "spec": {
                         "editorMode": "builder",
                         "expr": "rl_insight_monitor_critic_score_mean",
-                        "legendFormat": "__auto",
+                        "legendFormat": "{{__name__}}",
                         "range": true
                       }
                     },
@@ -4510,7 +4510,7 @@
                       "spec": {
                         "editorMode": "builder",
                         "expr": "rl_insight_monitor_critic_score_min",
-                        "legendFormat": "__auto",
+                        "legendFormat": "{{__name__}}",
                         "range": true
                       }
                     },
@@ -10899,7 +10899,7 @@
                       "spec": {
                         "editorMode": "builder",
                         "expr": "rl_insight_monitor_training_epoch",
-                        "legendFormat": "__auto",
+                        "legendFormat": "{{__name__}}",
                         "range": true
                       }
                     },
@@ -10991,7 +10991,7 @@
                       "spec": {
                         "editorMode": "builder",
                         "expr": "rl_insight_monitor_training_global_step",
-                        "legendFormat": "__auto",
+                        "legendFormat": "{{__name__}}",
                         "range": true
                       }
                     },

--- a/rl_insight/config/services/grafana/dashboards/verl_tainer_v1_with_vllm_engine.json
+++ b/rl_insight/config/services/grafana/dashboards/verl_tainer_v1_with_vllm_engine.json
@@ -1286,7 +1286,7 @@
                     "barAlignment": 0,
                     "barWidthFactor": 0.6,
                     "drawStyle": "line",
-                    "fillOpacity": 0,
+                    "fillOpacity": 8,
                     "gradientMode": "none",
                     "hideFrom": {
                       "legend": false,
@@ -1295,12 +1295,12 @@
                     },
                     "insertNulls": false,
                     "lineInterpolation": "linear",
-                    "lineWidth": 1,
+                    "lineWidth": 2,
                     "pointSize": 5,
                     "scaleDistribution": {
                       "type": "linear"
                     },
-                    "showPoints": "auto",
+                    "showPoints": "never",
                     "showValues": false,
                     "spanNulls": false,
                     "stacking": {
@@ -1401,7 +1401,7 @@
                     "barAlignment": 0,
                     "barWidthFactor": 0.6,
                     "drawStyle": "line",
-                    "fillOpacity": 0,
+                    "fillOpacity": 8,
                     "gradientMode": "none",
                     "hideFrom": {
                       "legend": false,
@@ -1410,12 +1410,12 @@
                     },
                     "insertNulls": false,
                     "lineInterpolation": "linear",
-                    "lineWidth": 1,
+                    "lineWidth": 2,
                     "pointSize": 5,
                     "scaleDistribution": {
                       "type": "linear"
                     },
-                    "showPoints": "auto",
+                    "showPoints": "never",
                     "showValues": false,
                     "spanNulls": false,
                     "stacking": {
@@ -1516,7 +1516,7 @@
                     "barAlignment": 0,
                     "barWidthFactor": 0.6,
                     "drawStyle": "line",
-                    "fillOpacity": 0,
+                    "fillOpacity": 8,
                     "gradientMode": "none",
                     "hideFrom": {
                       "legend": false,
@@ -1525,12 +1525,12 @@
                     },
                     "insertNulls": false,
                     "lineInterpolation": "linear",
-                    "lineWidth": 1,
+                    "lineWidth": 2,
                     "pointSize": 5,
                     "scaleDistribution": {
                       "type": "linear"
                     },
-                    "showPoints": "auto",
+                    "showPoints": "never",
                     "showValues": false,
                     "spanNulls": false,
                     "stacking": {
@@ -1631,7 +1631,7 @@
                     "barAlignment": 0,
                     "barWidthFactor": 0.6,
                     "drawStyle": "line",
-                    "fillOpacity": 0,
+                    "fillOpacity": 8,
                     "gradientMode": "none",
                     "hideFrom": {
                       "legend": false,
@@ -1640,12 +1640,12 @@
                     },
                     "insertNulls": false,
                     "lineInterpolation": "linear",
-                    "lineWidth": 1,
+                    "lineWidth": 2,
                     "pointSize": 5,
                     "scaleDistribution": {
                       "type": "linear"
                     },
-                    "showPoints": "auto",
+                    "showPoints": "never",
                     "showValues": false,
                     "spanNulls": false,
                     "stacking": {
@@ -1746,7 +1746,7 @@
                     "barAlignment": 0,
                     "barWidthFactor": 0.6,
                     "drawStyle": "line",
-                    "fillOpacity": 0,
+                    "fillOpacity": 8,
                     "gradientMode": "none",
                     "hideFrom": {
                       "legend": false,
@@ -1755,12 +1755,12 @@
                     },
                     "insertNulls": false,
                     "lineInterpolation": "linear",
-                    "lineWidth": 1,
+                    "lineWidth": 2,
                     "pointSize": 5,
                     "scaleDistribution": {
                       "type": "linear"
                     },
-                    "showPoints": "auto",
+                    "showPoints": "never",
                     "showValues": false,
                     "spanNulls": false,
                     "stacking": {
@@ -1861,7 +1861,7 @@
                     "barAlignment": 0,
                     "barWidthFactor": 0.6,
                     "drawStyle": "line",
-                    "fillOpacity": 0,
+                    "fillOpacity": 8,
                     "gradientMode": "none",
                     "hideFrom": {
                       "legend": false,
@@ -1870,12 +1870,12 @@
                     },
                     "insertNulls": false,
                     "lineInterpolation": "linear",
-                    "lineWidth": 1,
+                    "lineWidth": 2,
                     "pointSize": 5,
                     "scaleDistribution": {
                       "type": "linear"
                     },
-                    "showPoints": "auto",
+                    "showPoints": "never",
                     "showValues": false,
                     "spanNulls": false,
                     "stacking": {
@@ -2070,7 +2070,7 @@
                     "barAlignment": 0,
                     "barWidthFactor": 0.6,
                     "drawStyle": "line",
-                    "fillOpacity": 0,
+                    "fillOpacity": 8,
                     "gradientMode": "none",
                     "hideFrom": {
                       "legend": false,
@@ -2079,12 +2079,12 @@
                     },
                     "insertNulls": false,
                     "lineInterpolation": "linear",
-                    "lineWidth": 1,
+                    "lineWidth": 2,
                     "pointSize": 5,
                     "scaleDistribution": {
                       "type": "linear"
                     },
-                    "showPoints": "auto",
+                    "showPoints": "never",
                     "showValues": false,
                     "spanNulls": false,
                     "stacking": {
@@ -2185,7 +2185,7 @@
                     "barAlignment": 0,
                     "barWidthFactor": 0.6,
                     "drawStyle": "line",
-                    "fillOpacity": 0,
+                    "fillOpacity": 8,
                     "gradientMode": "none",
                     "hideFrom": {
                       "legend": false,
@@ -2194,12 +2194,12 @@
                     },
                     "insertNulls": false,
                     "lineInterpolation": "linear",
-                    "lineWidth": 1,
+                    "lineWidth": 2,
                     "pointSize": 5,
                     "scaleDistribution": {
                       "type": "linear"
                     },
-                    "showPoints": "auto",
+                    "showPoints": "never",
                     "showValues": false,
                     "spanNulls": false,
                     "stacking": {
@@ -2300,7 +2300,7 @@
                     "barAlignment": 0,
                     "barWidthFactor": 0.6,
                     "drawStyle": "line",
-                    "fillOpacity": 0,
+                    "fillOpacity": 8,
                     "gradientMode": "none",
                     "hideFrom": {
                       "legend": false,
@@ -2309,12 +2309,12 @@
                     },
                     "insertNulls": false,
                     "lineInterpolation": "linear",
-                    "lineWidth": 1,
+                    "lineWidth": 2,
                     "pointSize": 5,
                     "scaleDistribution": {
                       "type": "linear"
                     },
-                    "showPoints": "auto",
+                    "showPoints": "never",
                     "showValues": false,
                     "spanNulls": false,
                     "stacking": {
@@ -2415,7 +2415,7 @@
                     "barAlignment": 0,
                     "barWidthFactor": 0.6,
                     "drawStyle": "line",
-                    "fillOpacity": 0,
+                    "fillOpacity": 8,
                     "gradientMode": "none",
                     "hideFrom": {
                       "legend": false,
@@ -2424,12 +2424,12 @@
                     },
                     "insertNulls": false,
                     "lineInterpolation": "linear",
-                    "lineWidth": 1,
+                    "lineWidth": 2,
                     "pointSize": 5,
                     "scaleDistribution": {
                       "type": "linear"
                     },
-                    "showPoints": "auto",
+                    "showPoints": "never",
                     "showValues": false,
                     "spanNulls": false,
                     "stacking": {
@@ -2530,7 +2530,7 @@
                     "barAlignment": 0,
                     "barWidthFactor": 0.6,
                     "drawStyle": "line",
-                    "fillOpacity": 0,
+                    "fillOpacity": 8,
                     "gradientMode": "none",
                     "hideFrom": {
                       "legend": false,
@@ -2539,12 +2539,12 @@
                     },
                     "insertNulls": false,
                     "lineInterpolation": "linear",
-                    "lineWidth": 1,
+                    "lineWidth": 2,
                     "pointSize": 5,
                     "scaleDistribution": {
                       "type": "linear"
                     },
-                    "showPoints": "auto",
+                    "showPoints": "never",
                     "showValues": false,
                     "spanNulls": false,
                     "stacking": {
@@ -2645,7 +2645,7 @@
                     "barAlignment": 0,
                     "barWidthFactor": 0.6,
                     "drawStyle": "line",
-                    "fillOpacity": 0,
+                    "fillOpacity": 8,
                     "gradientMode": "none",
                     "hideFrom": {
                       "legend": false,
@@ -2654,12 +2654,12 @@
                     },
                     "insertNulls": false,
                     "lineInterpolation": "linear",
-                    "lineWidth": 1,
+                    "lineWidth": 2,
                     "pointSize": 5,
                     "scaleDistribution": {
                       "type": "linear"
                     },
-                    "showPoints": "auto",
+                    "showPoints": "never",
                     "showValues": false,
                     "spanNulls": false,
                     "stacking": {
@@ -2760,7 +2760,7 @@
                     "barAlignment": 0,
                     "barWidthFactor": 0.6,
                     "drawStyle": "line",
-                    "fillOpacity": 0,
+                    "fillOpacity": 8,
                     "gradientMode": "none",
                     "hideFrom": {
                       "legend": false,
@@ -2769,12 +2769,12 @@
                     },
                     "insertNulls": false,
                     "lineInterpolation": "linear",
-                    "lineWidth": 1,
+                    "lineWidth": 2,
                     "pointSize": 5,
                     "scaleDistribution": {
                       "type": "linear"
                     },
-                    "showPoints": "auto",
+                    "showPoints": "never",
                     "showValues": false,
                     "spanNulls": false,
                     "stacking": {
@@ -2875,7 +2875,7 @@
                     "barAlignment": 0,
                     "barWidthFactor": 0.6,
                     "drawStyle": "line",
-                    "fillOpacity": 0,
+                    "fillOpacity": 8,
                     "gradientMode": "none",
                     "hideFrom": {
                       "legend": false,
@@ -2884,12 +2884,12 @@
                     },
                     "insertNulls": false,
                     "lineInterpolation": "linear",
-                    "lineWidth": 1,
+                    "lineWidth": 2,
                     "pointSize": 5,
                     "scaleDistribution": {
                       "type": "linear"
                     },
-                    "showPoints": "auto",
+                    "showPoints": "never",
                     "showValues": false,
                     "spanNulls": false,
                     "stacking": {
@@ -2990,7 +2990,7 @@
                     "barAlignment": 0,
                     "barWidthFactor": 0.6,
                     "drawStyle": "line",
-                    "fillOpacity": 0,
+                    "fillOpacity": 8,
                     "gradientMode": "none",
                     "hideFrom": {
                       "legend": false,
@@ -2999,12 +2999,12 @@
                     },
                     "insertNulls": false,
                     "lineInterpolation": "linear",
-                    "lineWidth": 1,
+                    "lineWidth": 2,
                     "pointSize": 5,
                     "scaleDistribution": {
                       "type": "linear"
                     },
-                    "showPoints": "auto",
+                    "showPoints": "never",
                     "showValues": false,
                     "spanNulls": false,
                     "stacking": {
@@ -3105,7 +3105,7 @@
                     "barAlignment": 0,
                     "barWidthFactor": 0.6,
                     "drawStyle": "line",
-                    "fillOpacity": 0,
+                    "fillOpacity": 8,
                     "gradientMode": "none",
                     "hideFrom": {
                       "legend": false,
@@ -3114,12 +3114,12 @@
                     },
                     "insertNulls": false,
                     "lineInterpolation": "linear",
-                    "lineWidth": 1,
+                    "lineWidth": 2,
                     "pointSize": 5,
                     "scaleDistribution": {
                       "type": "linear"
                     },
-                    "showPoints": "auto",
+                    "showPoints": "never",
                     "showValues": false,
                     "spanNulls": false,
                     "stacking": {
@@ -3537,7 +3537,7 @@
                     "barAlignment": 0,
                     "barWidthFactor": 0.6,
                     "drawStyle": "line",
-                    "fillOpacity": 0,
+                    "fillOpacity": 8,
                     "gradientMode": "none",
                     "hideFrom": {
                       "legend": false,
@@ -3546,12 +3546,12 @@
                     },
                     "insertNulls": false,
                     "lineInterpolation": "linear",
-                    "lineWidth": 1,
+                    "lineWidth": 2,
                     "pointSize": 5,
                     "scaleDistribution": {
                       "type": "linear"
                     },
-                    "showPoints": "auto",
+                    "showPoints": "never",
                     "showValues": false,
                     "spanNulls": false,
                     "stacking": {
@@ -3652,7 +3652,7 @@
                     "barAlignment": 0,
                     "barWidthFactor": 0.6,
                     "drawStyle": "line",
-                    "fillOpacity": 0,
+                    "fillOpacity": 8,
                     "gradientMode": "none",
                     "hideFrom": {
                       "legend": false,
@@ -3661,12 +3661,12 @@
                     },
                     "insertNulls": false,
                     "lineInterpolation": "linear",
-                    "lineWidth": 1,
+                    "lineWidth": 2,
                     "pointSize": 5,
                     "scaleDistribution": {
                       "type": "linear"
                     },
-                    "showPoints": "auto",
+                    "showPoints": "never",
                     "showValues": false,
                     "spanNulls": false,
                     "stacking": {
@@ -3767,7 +3767,7 @@
                     "barAlignment": 0,
                     "barWidthFactor": 0.6,
                     "drawStyle": "line",
-                    "fillOpacity": 0,
+                    "fillOpacity": 8,
                     "gradientMode": "none",
                     "hideFrom": {
                       "legend": false,
@@ -3776,12 +3776,12 @@
                     },
                     "insertNulls": false,
                     "lineInterpolation": "linear",
-                    "lineWidth": 1,
+                    "lineWidth": 2,
                     "pointSize": 5,
                     "scaleDistribution": {
                       "type": "linear"
                     },
-                    "showPoints": "auto",
+                    "showPoints": "never",
                     "showValues": false,
                     "spanNulls": false,
                     "stacking": {
@@ -3882,7 +3882,7 @@
                     "barAlignment": 0,
                     "barWidthFactor": 0.6,
                     "drawStyle": "line",
-                    "fillOpacity": 0,
+                    "fillOpacity": 8,
                     "gradientMode": "none",
                     "hideFrom": {
                       "legend": false,
@@ -3891,12 +3891,12 @@
                     },
                     "insertNulls": false,
                     "lineInterpolation": "linear",
-                    "lineWidth": 1,
+                    "lineWidth": 2,
                     "pointSize": 5,
                     "scaleDistribution": {
                       "type": "linear"
                     },
-                    "showPoints": "auto",
+                    "showPoints": "never",
                     "showValues": false,
                     "spanNulls": false,
                     "stacking": {
@@ -3997,7 +3997,7 @@
                     "barAlignment": 0,
                     "barWidthFactor": 0.6,
                     "drawStyle": "line",
-                    "fillOpacity": 0,
+                    "fillOpacity": 8,
                     "gradientMode": "none",
                     "hideFrom": {
                       "legend": false,
@@ -4006,12 +4006,12 @@
                     },
                     "insertNulls": false,
                     "lineInterpolation": "linear",
-                    "lineWidth": 1,
+                    "lineWidth": 2,
                     "pointSize": 5,
                     "scaleDistribution": {
                       "type": "linear"
                     },
-                    "showPoints": "auto",
+                    "showPoints": "never",
                     "showValues": false,
                     "spanNulls": false,
                     "stacking": {
@@ -4112,7 +4112,7 @@
                     "barAlignment": 0,
                     "barWidthFactor": 0.6,
                     "drawStyle": "line",
-                    "fillOpacity": 0,
+                    "fillOpacity": 8,
                     "gradientMode": "none",
                     "hideFrom": {
                       "legend": false,
@@ -4121,12 +4121,12 @@
                     },
                     "insertNulls": false,
                     "lineInterpolation": "linear",
-                    "lineWidth": 1,
+                    "lineWidth": 2,
                     "pointSize": 5,
                     "scaleDistribution": {
                       "type": "linear"
                     },
-                    "showPoints": "auto",
+                    "showPoints": "never",
                     "showValues": false,
                     "spanNulls": false,
                     "stacking": {
@@ -4227,7 +4227,7 @@
                     "barAlignment": 0,
                     "barWidthFactor": 0.6,
                     "drawStyle": "line",
-                    "fillOpacity": 0,
+                    "fillOpacity": 8,
                     "gradientMode": "none",
                     "hideFrom": {
                       "legend": false,
@@ -4236,12 +4236,12 @@
                     },
                     "insertNulls": false,
                     "lineInterpolation": "linear",
-                    "lineWidth": 1,
+                    "lineWidth": 2,
                     "pointSize": 5,
                     "scaleDistribution": {
                       "type": "linear"
                     },
-                    "showPoints": "auto",
+                    "showPoints": "never",
                     "showValues": false,
                     "spanNulls": false,
                     "stacking": {
@@ -4342,7 +4342,7 @@
                     "barAlignment": 0,
                     "barWidthFactor": 0.6,
                     "drawStyle": "line",
-                    "fillOpacity": 0,
+                    "fillOpacity": 8,
                     "gradientMode": "none",
                     "hideFrom": {
                       "legend": false,
@@ -4351,12 +4351,12 @@
                     },
                     "insertNulls": false,
                     "lineInterpolation": "linear",
-                    "lineWidth": 1,
+                    "lineWidth": 2,
                     "pointSize": 5,
                     "scaleDistribution": {
                       "type": "linear"
                     },
-                    "showPoints": "auto",
+                    "showPoints": "never",
                     "showValues": false,
                     "spanNulls": false,
                     "stacking": {
@@ -4457,7 +4457,7 @@
                     "barAlignment": 0,
                     "barWidthFactor": 0.6,
                     "drawStyle": "line",
-                    "fillOpacity": 0,
+                    "fillOpacity": 8,
                     "gradientMode": "none",
                     "hideFrom": {
                       "legend": false,
@@ -4466,12 +4466,12 @@
                     },
                     "insertNulls": false,
                     "lineInterpolation": "linear",
-                    "lineWidth": 1,
+                    "lineWidth": 2,
                     "pointSize": 5,
                     "scaleDistribution": {
                       "type": "linear"
                     },
-                    "showPoints": "auto",
+                    "showPoints": "never",
                     "showValues": false,
                     "spanNulls": false,
                     "stacking": {
@@ -4572,7 +4572,7 @@
                     "barAlignment": 0,
                     "barWidthFactor": 0.6,
                     "drawStyle": "line",
-                    "fillOpacity": 0,
+                    "fillOpacity": 8,
                     "gradientMode": "none",
                     "hideFrom": {
                       "legend": false,
@@ -4581,12 +4581,12 @@
                     },
                     "insertNulls": false,
                     "lineInterpolation": "linear",
-                    "lineWidth": 1,
+                    "lineWidth": 2,
                     "pointSize": 5,
                     "scaleDistribution": {
                       "type": "linear"
                     },
-                    "showPoints": "auto",
+                    "showPoints": "never",
                     "showValues": false,
                     "spanNulls": false,
                     "stacking": {
@@ -4781,7 +4781,7 @@
                     "barAlignment": 0,
                     "barWidthFactor": 0.6,
                     "drawStyle": "line",
-                    "fillOpacity": 0,
+                    "fillOpacity": 8,
                     "gradientMode": "none",
                     "hideFrom": {
                       "legend": false,
@@ -4790,12 +4790,12 @@
                     },
                     "insertNulls": false,
                     "lineInterpolation": "linear",
-                    "lineWidth": 1,
+                    "lineWidth": 2,
                     "pointSize": 5,
                     "scaleDistribution": {
                       "type": "linear"
                     },
-                    "showPoints": "auto",
+                    "showPoints": "never",
                     "showValues": false,
                     "spanNulls": false,
                     "stacking": {
@@ -4896,7 +4896,7 @@
                     "barAlignment": 0,
                     "barWidthFactor": 0.6,
                     "drawStyle": "line",
-                    "fillOpacity": 0,
+                    "fillOpacity": 8,
                     "gradientMode": "none",
                     "hideFrom": {
                       "legend": false,
@@ -4905,12 +4905,12 @@
                     },
                     "insertNulls": false,
                     "lineInterpolation": "linear",
-                    "lineWidth": 1,
+                    "lineWidth": 2,
                     "pointSize": 5,
                     "scaleDistribution": {
                       "type": "linear"
                     },
-                    "showPoints": "auto",
+                    "showPoints": "never",
                     "showValues": false,
                     "spanNulls": false,
                     "stacking": {
@@ -5011,7 +5011,7 @@
                     "barAlignment": 0,
                     "barWidthFactor": 0.6,
                     "drawStyle": "line",
-                    "fillOpacity": 0,
+                    "fillOpacity": 8,
                     "gradientMode": "none",
                     "hideFrom": {
                       "legend": false,
@@ -5020,12 +5020,12 @@
                     },
                     "insertNulls": false,
                     "lineInterpolation": "linear",
-                    "lineWidth": 1,
+                    "lineWidth": 2,
                     "pointSize": 5,
                     "scaleDistribution": {
                       "type": "linear"
                     },
-                    "showPoints": "auto",
+                    "showPoints": "never",
                     "showValues": false,
                     "spanNulls": false,
                     "stacking": {
@@ -5126,7 +5126,7 @@
                     "barAlignment": 0,
                     "barWidthFactor": 0.6,
                     "drawStyle": "line",
-                    "fillOpacity": 0,
+                    "fillOpacity": 8,
                     "gradientMode": "none",
                     "hideFrom": {
                       "legend": false,
@@ -5135,12 +5135,12 @@
                     },
                     "insertNulls": false,
                     "lineInterpolation": "linear",
-                    "lineWidth": 1,
+                    "lineWidth": 2,
                     "pointSize": 5,
                     "scaleDistribution": {
                       "type": "linear"
                     },
-                    "showPoints": "auto",
+                    "showPoints": "never",
                     "showValues": false,
                     "spanNulls": false,
                     "stacking": {
@@ -5241,7 +5241,7 @@
                     "barAlignment": 0,
                     "barWidthFactor": 0.6,
                     "drawStyle": "line",
-                    "fillOpacity": 0,
+                    "fillOpacity": 8,
                     "gradientMode": "none",
                     "hideFrom": {
                       "legend": false,
@@ -5250,12 +5250,12 @@
                     },
                     "insertNulls": false,
                     "lineInterpolation": "linear",
-                    "lineWidth": 1,
+                    "lineWidth": 2,
                     "pointSize": 5,
                     "scaleDistribution": {
                       "type": "linear"
                     },
-                    "showPoints": "auto",
+                    "showPoints": "never",
                     "showValues": false,
                     "spanNulls": false,
                     "stacking": {
@@ -5356,7 +5356,7 @@
                     "barAlignment": 0,
                     "barWidthFactor": 0.6,
                     "drawStyle": "line",
-                    "fillOpacity": 0,
+                    "fillOpacity": 8,
                     "gradientMode": "none",
                     "hideFrom": {
                       "legend": false,
@@ -5365,12 +5365,12 @@
                     },
                     "insertNulls": false,
                     "lineInterpolation": "linear",
-                    "lineWidth": 1,
+                    "lineWidth": 2,
                     "pointSize": 5,
                     "scaleDistribution": {
                       "type": "linear"
                     },
-                    "showPoints": "auto",
+                    "showPoints": "never",
                     "showValues": false,
                     "spanNulls": false,
                     "stacking": {
@@ -5471,7 +5471,7 @@
                     "barAlignment": 0,
                     "barWidthFactor": 0.6,
                     "drawStyle": "line",
-                    "fillOpacity": 0,
+                    "fillOpacity": 8,
                     "gradientMode": "none",
                     "hideFrom": {
                       "legend": false,
@@ -5480,12 +5480,12 @@
                     },
                     "insertNulls": false,
                     "lineInterpolation": "linear",
-                    "lineWidth": 1,
+                    "lineWidth": 2,
                     "pointSize": 5,
                     "scaleDistribution": {
                       "type": "linear"
                     },
-                    "showPoints": "auto",
+                    "showPoints": "never",
                     "showValues": false,
                     "spanNulls": false,
                     "stacking": {
@@ -5586,7 +5586,7 @@
                     "barAlignment": 0,
                     "barWidthFactor": 0.6,
                     "drawStyle": "line",
-                    "fillOpacity": 0,
+                    "fillOpacity": 8,
                     "gradientMode": "none",
                     "hideFrom": {
                       "legend": false,
@@ -5595,12 +5595,12 @@
                     },
                     "insertNulls": false,
                     "lineInterpolation": "linear",
-                    "lineWidth": 1,
+                    "lineWidth": 2,
                     "pointSize": 5,
                     "scaleDistribution": {
                       "type": "linear"
                     },
-                    "showPoints": "auto",
+                    "showPoints": "never",
                     "showValues": false,
                     "spanNulls": false,
                     "stacking": {
@@ -5701,7 +5701,7 @@
                     "barAlignment": 0,
                     "barWidthFactor": 0.6,
                     "drawStyle": "line",
-                    "fillOpacity": 0,
+                    "fillOpacity": 8,
                     "gradientMode": "none",
                     "hideFrom": {
                       "legend": false,
@@ -5710,12 +5710,12 @@
                     },
                     "insertNulls": false,
                     "lineInterpolation": "linear",
-                    "lineWidth": 1,
+                    "lineWidth": 2,
                     "pointSize": 5,
                     "scaleDistribution": {
                       "type": "linear"
                     },
-                    "showPoints": "auto",
+                    "showPoints": "never",
                     "showValues": false,
                     "spanNulls": false,
                     "stacking": {
@@ -5816,7 +5816,7 @@
                     "barAlignment": 0,
                     "barWidthFactor": 0.6,
                     "drawStyle": "line",
-                    "fillOpacity": 0,
+                    "fillOpacity": 8,
                     "gradientMode": "none",
                     "hideFrom": {
                       "legend": false,
@@ -5825,12 +5825,12 @@
                     },
                     "insertNulls": false,
                     "lineInterpolation": "linear",
-                    "lineWidth": 1,
+                    "lineWidth": 2,
                     "pointSize": 5,
                     "scaleDistribution": {
                       "type": "linear"
                     },
-                    "showPoints": "auto",
+                    "showPoints": "never",
                     "showValues": false,
                     "spanNulls": false,
                     "stacking": {
@@ -5931,7 +5931,7 @@
                     "barAlignment": 0,
                     "barWidthFactor": 0.6,
                     "drawStyle": "line",
-                    "fillOpacity": 0,
+                    "fillOpacity": 8,
                     "gradientMode": "none",
                     "hideFrom": {
                       "legend": false,
@@ -5940,12 +5940,12 @@
                     },
                     "insertNulls": false,
                     "lineInterpolation": "linear",
-                    "lineWidth": 1,
+                    "lineWidth": 2,
                     "pointSize": 5,
                     "scaleDistribution": {
                       "type": "linear"
                     },
-                    "showPoints": "auto",
+                    "showPoints": "never",
                     "showValues": false,
                     "spanNulls": false,
                     "stacking": {
@@ -6046,7 +6046,7 @@
                     "barAlignment": 0,
                     "barWidthFactor": 0.6,
                     "drawStyle": "line",
-                    "fillOpacity": 0,
+                    "fillOpacity": 8,
                     "gradientMode": "none",
                     "hideFrom": {
                       "legend": false,
@@ -6055,12 +6055,12 @@
                     },
                     "insertNulls": false,
                     "lineInterpolation": "linear",
-                    "lineWidth": 1,
+                    "lineWidth": 2,
                     "pointSize": 5,
                     "scaleDistribution": {
                       "type": "linear"
                     },
-                    "showPoints": "auto",
+                    "showPoints": "never",
                     "showValues": false,
                     "spanNulls": false,
                     "stacking": {
@@ -6161,7 +6161,7 @@
                     "barAlignment": 0,
                     "barWidthFactor": 0.6,
                     "drawStyle": "line",
-                    "fillOpacity": 0,
+                    "fillOpacity": 8,
                     "gradientMode": "none",
                     "hideFrom": {
                       "legend": false,
@@ -6170,12 +6170,12 @@
                     },
                     "insertNulls": false,
                     "lineInterpolation": "linear",
-                    "lineWidth": 1,
+                    "lineWidth": 2,
                     "pointSize": 5,
                     "scaleDistribution": {
                       "type": "linear"
                     },
-                    "showPoints": "auto",
+                    "showPoints": "never",
                     "showValues": false,
                     "spanNulls": false,
                     "stacking": {
@@ -6276,7 +6276,7 @@
                     "barAlignment": 0,
                     "barWidthFactor": 0.6,
                     "drawStyle": "line",
-                    "fillOpacity": 0,
+                    "fillOpacity": 8,
                     "gradientMode": "none",
                     "hideFrom": {
                       "legend": false,
@@ -6285,12 +6285,12 @@
                     },
                     "insertNulls": false,
                     "lineInterpolation": "linear",
-                    "lineWidth": 1,
+                    "lineWidth": 2,
                     "pointSize": 5,
                     "scaleDistribution": {
                       "type": "linear"
                     },
-                    "showPoints": "auto",
+                    "showPoints": "never",
                     "showValues": false,
                     "spanNulls": false,
                     "stacking": {
@@ -6391,7 +6391,7 @@
                     "barAlignment": 0,
                     "barWidthFactor": 0.6,
                     "drawStyle": "line",
-                    "fillOpacity": 0,
+                    "fillOpacity": 8,
                     "gradientMode": "none",
                     "hideFrom": {
                       "legend": false,
@@ -6400,12 +6400,12 @@
                     },
                     "insertNulls": false,
                     "lineInterpolation": "linear",
-                    "lineWidth": 1,
+                    "lineWidth": 2,
                     "pointSize": 5,
                     "scaleDistribution": {
                       "type": "linear"
                     },
-                    "showPoints": "auto",
+                    "showPoints": "never",
                     "showValues": false,
                     "spanNulls": false,
                     "stacking": {
@@ -6506,7 +6506,7 @@
                     "barAlignment": 0,
                     "barWidthFactor": 0.6,
                     "drawStyle": "line",
-                    "fillOpacity": 0,
+                    "fillOpacity": 8,
                     "gradientMode": "none",
                     "hideFrom": {
                       "legend": false,
@@ -6515,12 +6515,12 @@
                     },
                     "insertNulls": false,
                     "lineInterpolation": "linear",
-                    "lineWidth": 1,
+                    "lineWidth": 2,
                     "pointSize": 5,
                     "scaleDistribution": {
                       "type": "linear"
                     },
-                    "showPoints": "auto",
+                    "showPoints": "never",
                     "showValues": false,
                     "spanNulls": false,
                     "stacking": {
@@ -6719,7 +6719,7 @@
                     "barAlignment": 0,
                     "barWidthFactor": 0.6,
                     "drawStyle": "line",
-                    "fillOpacity": 0,
+                    "fillOpacity": 8,
                     "gradientMode": "none",
                     "hideFrom": {
                       "legend": false,
@@ -6728,12 +6728,12 @@
                     },
                     "insertNulls": false,
                     "lineInterpolation": "linear",
-                    "lineWidth": 1,
+                    "lineWidth": 2,
                     "pointSize": 5,
                     "scaleDistribution": {
                       "type": "linear"
                     },
-                    "showPoints": "auto",
+                    "showPoints": "never",
                     "showValues": false,
                     "spanNulls": false,
                     "stacking": {
@@ -6834,7 +6834,7 @@
                     "barAlignment": 0,
                     "barWidthFactor": 0.6,
                     "drawStyle": "line",
-                    "fillOpacity": 0,
+                    "fillOpacity": 8,
                     "gradientMode": "none",
                     "hideFrom": {
                       "legend": false,
@@ -6843,12 +6843,12 @@
                     },
                     "insertNulls": false,
                     "lineInterpolation": "linear",
-                    "lineWidth": 1,
+                    "lineWidth": 2,
                     "pointSize": 5,
                     "scaleDistribution": {
                       "type": "linear"
                     },
-                    "showPoints": "auto",
+                    "showPoints": "never",
                     "showValues": false,
                     "spanNulls": false,
                     "stacking": {
@@ -6949,7 +6949,7 @@
                     "barAlignment": 0,
                     "barWidthFactor": 0.6,
                     "drawStyle": "line",
-                    "fillOpacity": 0,
+                    "fillOpacity": 8,
                     "gradientMode": "none",
                     "hideFrom": {
                       "legend": false,
@@ -6958,12 +6958,12 @@
                     },
                     "insertNulls": false,
                     "lineInterpolation": "linear",
-                    "lineWidth": 1,
+                    "lineWidth": 2,
                     "pointSize": 5,
                     "scaleDistribution": {
                       "type": "linear"
                     },
-                    "showPoints": "auto",
+                    "showPoints": "never",
                     "showValues": false,
                     "spanNulls": false,
                     "stacking": {
@@ -7064,7 +7064,7 @@
                     "barAlignment": 0,
                     "barWidthFactor": 0.6,
                     "drawStyle": "line",
-                    "fillOpacity": 0,
+                    "fillOpacity": 8,
                     "gradientMode": "none",
                     "hideFrom": {
                       "legend": false,
@@ -7073,12 +7073,12 @@
                     },
                     "insertNulls": false,
                     "lineInterpolation": "linear",
-                    "lineWidth": 1,
+                    "lineWidth": 2,
                     "pointSize": 5,
                     "scaleDistribution": {
                       "type": "linear"
                     },
-                    "showPoints": "auto",
+                    "showPoints": "never",
                     "showValues": false,
                     "spanNulls": false,
                     "stacking": {
@@ -7179,7 +7179,7 @@
                     "barAlignment": 0,
                     "barWidthFactor": 0.6,
                     "drawStyle": "line",
-                    "fillOpacity": 0,
+                    "fillOpacity": 8,
                     "gradientMode": "none",
                     "hideFrom": {
                       "legend": false,
@@ -7188,12 +7188,12 @@
                     },
                     "insertNulls": false,
                     "lineInterpolation": "linear",
-                    "lineWidth": 1,
+                    "lineWidth": 2,
                     "pointSize": 5,
                     "scaleDistribution": {
                       "type": "linear"
                     },
-                    "showPoints": "auto",
+                    "showPoints": "never",
                     "showValues": false,
                     "spanNulls": false,
                     "stacking": {
@@ -7294,7 +7294,7 @@
                     "barAlignment": 0,
                     "barWidthFactor": 0.6,
                     "drawStyle": "line",
-                    "fillOpacity": 0,
+                    "fillOpacity": 8,
                     "gradientMode": "none",
                     "hideFrom": {
                       "legend": false,
@@ -7303,12 +7303,12 @@
                     },
                     "insertNulls": false,
                     "lineInterpolation": "linear",
-                    "lineWidth": 1,
+                    "lineWidth": 2,
                     "pointSize": 5,
                     "scaleDistribution": {
                       "type": "linear"
                     },
-                    "showPoints": "auto",
+                    "showPoints": "never",
                     "showValues": false,
                     "spanNulls": false,
                     "stacking": {
@@ -7409,7 +7409,7 @@
                     "barAlignment": 0,
                     "barWidthFactor": 0.6,
                     "drawStyle": "line",
-                    "fillOpacity": 0,
+                    "fillOpacity": 8,
                     "gradientMode": "none",
                     "hideFrom": {
                       "legend": false,
@@ -7418,12 +7418,12 @@
                     },
                     "insertNulls": false,
                     "lineInterpolation": "linear",
-                    "lineWidth": 1,
+                    "lineWidth": 2,
                     "pointSize": 5,
                     "scaleDistribution": {
                       "type": "linear"
                     },
-                    "showPoints": "auto",
+                    "showPoints": "never",
                     "showValues": false,
                     "spanNulls": false,
                     "stacking": {
@@ -7524,7 +7524,7 @@
                     "barAlignment": 0,
                     "barWidthFactor": 0.6,
                     "drawStyle": "line",
-                    "fillOpacity": 0,
+                    "fillOpacity": 8,
                     "gradientMode": "none",
                     "hideFrom": {
                       "legend": false,
@@ -7533,12 +7533,12 @@
                     },
                     "insertNulls": false,
                     "lineInterpolation": "linear",
-                    "lineWidth": 1,
+                    "lineWidth": 2,
                     "pointSize": 5,
                     "scaleDistribution": {
                       "type": "linear"
                     },
-                    "showPoints": "auto",
+                    "showPoints": "never",
                     "showValues": false,
                     "spanNulls": false,
                     "stacking": {
@@ -7639,7 +7639,7 @@
                     "barAlignment": 0,
                     "barWidthFactor": 0.6,
                     "drawStyle": "line",
-                    "fillOpacity": 0,
+                    "fillOpacity": 8,
                     "gradientMode": "none",
                     "hideFrom": {
                       "legend": false,
@@ -7648,12 +7648,12 @@
                     },
                     "insertNulls": false,
                     "lineInterpolation": "linear",
-                    "lineWidth": 1,
+                    "lineWidth": 2,
                     "pointSize": 5,
                     "scaleDistribution": {
                       "type": "linear"
                     },
-                    "showPoints": "auto",
+                    "showPoints": "never",
                     "showValues": false,
                     "spanNulls": false,
                     "stacking": {
@@ -7754,7 +7754,7 @@
                     "barAlignment": 0,
                     "barWidthFactor": 0.6,
                     "drawStyle": "line",
-                    "fillOpacity": 0,
+                    "fillOpacity": 8,
                     "gradientMode": "none",
                     "hideFrom": {
                       "legend": false,
@@ -7763,12 +7763,12 @@
                     },
                     "insertNulls": false,
                     "lineInterpolation": "linear",
-                    "lineWidth": 1,
+                    "lineWidth": 2,
                     "pointSize": 5,
                     "scaleDistribution": {
                       "type": "linear"
                     },
-                    "showPoints": "auto",
+                    "showPoints": "never",
                     "showValues": false,
                     "spanNulls": false,
                     "stacking": {
@@ -7967,7 +7967,7 @@
                     "barAlignment": 0,
                     "barWidthFactor": 0.6,
                     "drawStyle": "line",
-                    "fillOpacity": 0,
+                    "fillOpacity": 8,
                     "gradientMode": "none",
                     "hideFrom": {
                       "legend": false,
@@ -7976,12 +7976,12 @@
                     },
                     "insertNulls": false,
                     "lineInterpolation": "linear",
-                    "lineWidth": 1,
+                    "lineWidth": 2,
                     "pointSize": 5,
                     "scaleDistribution": {
                       "type": "linear"
                     },
-                    "showPoints": "auto",
+                    "showPoints": "never",
                     "showValues": false,
                     "spanNulls": false,
                     "stacking": {
@@ -8082,7 +8082,7 @@
                     "barAlignment": 0,
                     "barWidthFactor": 0.6,
                     "drawStyle": "line",
-                    "fillOpacity": 0,
+                    "fillOpacity": 8,
                     "gradientMode": "none",
                     "hideFrom": {
                       "legend": false,
@@ -8091,12 +8091,12 @@
                     },
                     "insertNulls": false,
                     "lineInterpolation": "linear",
-                    "lineWidth": 1,
+                    "lineWidth": 2,
                     "pointSize": 5,
                     "scaleDistribution": {
                       "type": "linear"
                     },
-                    "showPoints": "auto",
+                    "showPoints": "never",
                     "showValues": false,
                     "spanNulls": false,
                     "stacking": {
@@ -8197,7 +8197,7 @@
                     "barAlignment": 0,
                     "barWidthFactor": 0.6,
                     "drawStyle": "line",
-                    "fillOpacity": 0,
+                    "fillOpacity": 8,
                     "gradientMode": "none",
                     "hideFrom": {
                       "legend": false,
@@ -8206,12 +8206,12 @@
                     },
                     "insertNulls": false,
                     "lineInterpolation": "linear",
-                    "lineWidth": 1,
+                    "lineWidth": 2,
                     "pointSize": 5,
                     "scaleDistribution": {
                       "type": "linear"
                     },
-                    "showPoints": "auto",
+                    "showPoints": "never",
                     "showValues": false,
                     "spanNulls": false,
                     "stacking": {
@@ -8312,7 +8312,7 @@
                     "barAlignment": 0,
                     "barWidthFactor": 0.6,
                     "drawStyle": "line",
-                    "fillOpacity": 0,
+                    "fillOpacity": 8,
                     "gradientMode": "none",
                     "hideFrom": {
                       "legend": false,
@@ -8321,12 +8321,12 @@
                     },
                     "insertNulls": false,
                     "lineInterpolation": "linear",
-                    "lineWidth": 1,
+                    "lineWidth": 2,
                     "pointSize": 5,
                     "scaleDistribution": {
                       "type": "linear"
                     },
-                    "showPoints": "auto",
+                    "showPoints": "never",
                     "showValues": false,
                     "spanNulls": false,
                     "stacking": {
@@ -8427,7 +8427,7 @@
                     "barAlignment": 0,
                     "barWidthFactor": 0.6,
                     "drawStyle": "line",
-                    "fillOpacity": 0,
+                    "fillOpacity": 8,
                     "gradientMode": "none",
                     "hideFrom": {
                       "legend": false,
@@ -8436,12 +8436,12 @@
                     },
                     "insertNulls": false,
                     "lineInterpolation": "linear",
-                    "lineWidth": 1,
+                    "lineWidth": 2,
                     "pointSize": 5,
                     "scaleDistribution": {
                       "type": "linear"
                     },
-                    "showPoints": "auto",
+                    "showPoints": "never",
                     "showValues": false,
                     "spanNulls": false,
                     "stacking": {
@@ -8542,7 +8542,7 @@
                     "barAlignment": 0,
                     "barWidthFactor": 0.6,
                     "drawStyle": "line",
-                    "fillOpacity": 0,
+                    "fillOpacity": 8,
                     "gradientMode": "none",
                     "hideFrom": {
                       "legend": false,
@@ -8551,12 +8551,12 @@
                     },
                     "insertNulls": false,
                     "lineInterpolation": "linear",
-                    "lineWidth": 1,
+                    "lineWidth": 2,
                     "pointSize": 5,
                     "scaleDistribution": {
                       "type": "linear"
                     },
-                    "showPoints": "auto",
+                    "showPoints": "never",
                     "showValues": false,
                     "spanNulls": false,
                     "stacking": {
@@ -8657,7 +8657,7 @@
                     "barAlignment": 0,
                     "barWidthFactor": 0.6,
                     "drawStyle": "line",
-                    "fillOpacity": 0,
+                    "fillOpacity": 8,
                     "gradientMode": "none",
                     "hideFrom": {
                       "legend": false,
@@ -8666,12 +8666,12 @@
                     },
                     "insertNulls": false,
                     "lineInterpolation": "linear",
-                    "lineWidth": 1,
+                    "lineWidth": 2,
                     "pointSize": 5,
                     "scaleDistribution": {
                       "type": "linear"
                     },
-                    "showPoints": "auto",
+                    "showPoints": "never",
                     "showValues": false,
                     "spanNulls": false,
                     "stacking": {
@@ -8772,7 +8772,7 @@
                     "barAlignment": 0,
                     "barWidthFactor": 0.6,
                     "drawStyle": "line",
-                    "fillOpacity": 0,
+                    "fillOpacity": 8,
                     "gradientMode": "none",
                     "hideFrom": {
                       "legend": false,
@@ -8781,12 +8781,12 @@
                     },
                     "insertNulls": false,
                     "lineInterpolation": "linear",
-                    "lineWidth": 1,
+                    "lineWidth": 2,
                     "pointSize": 5,
                     "scaleDistribution": {
                       "type": "linear"
                     },
-                    "showPoints": "auto",
+                    "showPoints": "never",
                     "showValues": false,
                     "spanNulls": false,
                     "stacking": {
@@ -8887,7 +8887,7 @@
                     "barAlignment": 0,
                     "barWidthFactor": 0.6,
                     "drawStyle": "line",
-                    "fillOpacity": 0,
+                    "fillOpacity": 8,
                     "gradientMode": "none",
                     "hideFrom": {
                       "legend": false,
@@ -8896,12 +8896,12 @@
                     },
                     "insertNulls": false,
                     "lineInterpolation": "linear",
-                    "lineWidth": 1,
+                    "lineWidth": 2,
                     "pointSize": 5,
                     "scaleDistribution": {
                       "type": "linear"
                     },
-                    "showPoints": "auto",
+                    "showPoints": "never",
                     "showValues": false,
                     "spanNulls": false,
                     "stacking": {
@@ -9002,7 +9002,7 @@
                     "barAlignment": 0,
                     "barWidthFactor": 0.6,
                     "drawStyle": "line",
-                    "fillOpacity": 0,
+                    "fillOpacity": 8,
                     "gradientMode": "none",
                     "hideFrom": {
                       "legend": false,
@@ -9011,12 +9011,12 @@
                     },
                     "insertNulls": false,
                     "lineInterpolation": "linear",
-                    "lineWidth": 1,
+                    "lineWidth": 2,
                     "pointSize": 5,
                     "scaleDistribution": {
                       "type": "linear"
                     },
-                    "showPoints": "auto",
+                    "showPoints": "never",
                     "showValues": false,
                     "spanNulls": false,
                     "stacking": {
@@ -9215,7 +9215,7 @@
                     "barAlignment": 0,
                     "barWidthFactor": 0.6,
                     "drawStyle": "line",
-                    "fillOpacity": 0,
+                    "fillOpacity": 8,
                     "gradientMode": "none",
                     "hideFrom": {
                       "legend": false,
@@ -9224,12 +9224,12 @@
                     },
                     "insertNulls": false,
                     "lineInterpolation": "linear",
-                    "lineWidth": 1,
+                    "lineWidth": 2,
                     "pointSize": 5,
                     "scaleDistribution": {
                       "type": "linear"
                     },
-                    "showPoints": "auto",
+                    "showPoints": "never",
                     "showValues": false,
                     "spanNulls": false,
                     "stacking": {
@@ -9330,7 +9330,7 @@
                     "barAlignment": 0,
                     "barWidthFactor": 0.6,
                     "drawStyle": "line",
-                    "fillOpacity": 0,
+                    "fillOpacity": 8,
                     "gradientMode": "none",
                     "hideFrom": {
                       "legend": false,
@@ -9339,12 +9339,12 @@
                     },
                     "insertNulls": false,
                     "lineInterpolation": "linear",
-                    "lineWidth": 1,
+                    "lineWidth": 2,
                     "pointSize": 5,
                     "scaleDistribution": {
                       "type": "linear"
                     },
-                    "showPoints": "auto",
+                    "showPoints": "never",
                     "showValues": false,
                     "spanNulls": false,
                     "stacking": {
@@ -9445,7 +9445,7 @@
                     "barAlignment": 0,
                     "barWidthFactor": 0.6,
                     "drawStyle": "line",
-                    "fillOpacity": 0,
+                    "fillOpacity": 8,
                     "gradientMode": "none",
                     "hideFrom": {
                       "legend": false,
@@ -9454,12 +9454,12 @@
                     },
                     "insertNulls": false,
                     "lineInterpolation": "linear",
-                    "lineWidth": 1,
+                    "lineWidth": 2,
                     "pointSize": 5,
                     "scaleDistribution": {
                       "type": "linear"
                     },
-                    "showPoints": "auto",
+                    "showPoints": "never",
                     "showValues": false,
                     "spanNulls": false,
                     "stacking": {
@@ -9560,7 +9560,7 @@
                     "barAlignment": 0,
                     "barWidthFactor": 0.6,
                     "drawStyle": "line",
-                    "fillOpacity": 0,
+                    "fillOpacity": 8,
                     "gradientMode": "none",
                     "hideFrom": {
                       "legend": false,
@@ -9569,12 +9569,12 @@
                     },
                     "insertNulls": false,
                     "lineInterpolation": "linear",
-                    "lineWidth": 1,
+                    "lineWidth": 2,
                     "pointSize": 5,
                     "scaleDistribution": {
                       "type": "linear"
                     },
-                    "showPoints": "auto",
+                    "showPoints": "never",
                     "showValues": false,
                     "spanNulls": false,
                     "stacking": {
@@ -9675,7 +9675,7 @@
                     "barAlignment": 0,
                     "barWidthFactor": 0.6,
                     "drawStyle": "line",
-                    "fillOpacity": 0,
+                    "fillOpacity": 8,
                     "gradientMode": "none",
                     "hideFrom": {
                       "legend": false,
@@ -9684,12 +9684,12 @@
                     },
                     "insertNulls": false,
                     "lineInterpolation": "linear",
-                    "lineWidth": 1,
+                    "lineWidth": 2,
                     "pointSize": 5,
                     "scaleDistribution": {
                       "type": "linear"
                     },
-                    "showPoints": "auto",
+                    "showPoints": "never",
                     "showValues": false,
                     "spanNulls": false,
                     "stacking": {
@@ -10034,7 +10034,7 @@
                     "barAlignment": 0,
                     "barWidthFactor": 0.6,
                     "drawStyle": "line",
-                    "fillOpacity": 0,
+                    "fillOpacity": 8,
                     "gradientMode": "none",
                     "hideFrom": {
                       "legend": false,
@@ -10043,12 +10043,12 @@
                     },
                     "insertNulls": false,
                     "lineInterpolation": "linear",
-                    "lineWidth": 1,
+                    "lineWidth": 2,
                     "pointSize": 5,
                     "scaleDistribution": {
                       "type": "linear"
                     },
-                    "showPoints": "auto",
+                    "showPoints": "never",
                     "showValues": false,
                     "spanNulls": false,
                     "stacking": {
@@ -10149,7 +10149,7 @@
                     "barAlignment": 0,
                     "barWidthFactor": 0.6,
                     "drawStyle": "line",
-                    "fillOpacity": 0,
+                    "fillOpacity": 8,
                     "gradientMode": "none",
                     "hideFrom": {
                       "legend": false,
@@ -10158,12 +10158,12 @@
                     },
                     "insertNulls": false,
                     "lineInterpolation": "linear",
-                    "lineWidth": 1,
+                    "lineWidth": 2,
                     "pointSize": 5,
                     "scaleDistribution": {
                       "type": "linear"
                     },
-                    "showPoints": "auto",
+                    "showPoints": "never",
                     "showValues": false,
                     "spanNulls": false,
                     "stacking": {
@@ -10264,7 +10264,7 @@
                     "barAlignment": 0,
                     "barWidthFactor": 0.6,
                     "drawStyle": "line",
-                    "fillOpacity": 0,
+                    "fillOpacity": 8,
                     "gradientMode": "none",
                     "hideFrom": {
                       "legend": false,
@@ -10273,12 +10273,12 @@
                     },
                     "insertNulls": false,
                     "lineInterpolation": "linear",
-                    "lineWidth": 1,
+                    "lineWidth": 2,
                     "pointSize": 5,
                     "scaleDistribution": {
                       "type": "linear"
                     },
-                    "showPoints": "auto",
+                    "showPoints": "never",
                     "showValues": false,
                     "spanNulls": false,
                     "stacking": {
@@ -10379,7 +10379,7 @@
                     "barAlignment": 0,
                     "barWidthFactor": 0.6,
                     "drawStyle": "line",
-                    "fillOpacity": 0,
+                    "fillOpacity": 8,
                     "gradientMode": "none",
                     "hideFrom": {
                       "legend": false,
@@ -10388,12 +10388,12 @@
                     },
                     "insertNulls": false,
                     "lineInterpolation": "linear",
-                    "lineWidth": 1,
+                    "lineWidth": 2,
                     "pointSize": 5,
                     "scaleDistribution": {
                       "type": "linear"
                     },
-                    "showPoints": "auto",
+                    "showPoints": "never",
                     "showValues": false,
                     "spanNulls": false,
                     "stacking": {
@@ -10616,7 +10616,7 @@
                     "barAlignment": 0,
                     "barWidthFactor": 0.6,
                     "drawStyle": "line",
-                    "fillOpacity": 0,
+                    "fillOpacity": 8,
                     "gradientMode": "none",
                     "hideFrom": {
                       "legend": false,
@@ -10625,12 +10625,12 @@
                     },
                     "insertNulls": false,
                     "lineInterpolation": "linear",
-                    "lineWidth": 1,
+                    "lineWidth": 2,
                     "pointSize": 5,
                     "scaleDistribution": {
                       "type": "linear"
                     },
-                    "showPoints": "auto",
+                    "showPoints": "never",
                     "showValues": false,
                     "spanNulls": false,
                     "stacking": {
@@ -10731,7 +10731,7 @@
                     "barAlignment": 0,
                     "barWidthFactor": 0.6,
                     "drawStyle": "line",
-                    "fillOpacity": 0,
+                    "fillOpacity": 8,
                     "gradientMode": "none",
                     "hideFrom": {
                       "legend": false,
@@ -10740,12 +10740,12 @@
                     },
                     "insertNulls": false,
                     "lineInterpolation": "linear",
-                    "lineWidth": 1,
+                    "lineWidth": 2,
                     "pointSize": 5,
                     "scaleDistribution": {
                       "type": "linear"
                     },
-                    "showPoints": "auto",
+                    "showPoints": "never",
                     "showValues": false,
                     "spanNulls": false,
                     "stacking": {
@@ -10846,7 +10846,7 @@
                     "barAlignment": 0,
                     "barWidthFactor": 0.6,
                     "drawStyle": "line",
-                    "fillOpacity": 0,
+                    "fillOpacity": 8,
                     "gradientMode": "none",
                     "hideFrom": {
                       "legend": false,
@@ -10855,12 +10855,12 @@
                     },
                     "insertNulls": false,
                     "lineInterpolation": "linear",
-                    "lineWidth": 1,
+                    "lineWidth": 2,
                     "pointSize": 5,
                     "scaleDistribution": {
                       "type": "linear"
                     },
-                    "showPoints": "auto",
+                    "showPoints": "never",
                     "showValues": false,
                     "spanNulls": false,
                     "stacking": {
@@ -11145,7 +11145,7 @@
                     "barAlignment": 0,
                     "barWidthFactor": 0.6,
                     "drawStyle": "line",
-                    "fillOpacity": 0,
+                    "fillOpacity": 8,
                     "gradientMode": "none",
                     "hideFrom": {
                       "legend": false,
@@ -11154,12 +11154,12 @@
                     },
                     "insertNulls": false,
                     "lineInterpolation": "linear",
-                    "lineWidth": 1,
+                    "lineWidth": 2,
                     "pointSize": 5,
                     "scaleDistribution": {
                       "type": "linear"
                     },
-                    "showPoints": "auto",
+                    "showPoints": "never",
                     "showValues": false,
                     "spanNulls": false,
                     "stacking": {
@@ -11260,7 +11260,7 @@
                     "barAlignment": 0,
                     "barWidthFactor": 0.6,
                     "drawStyle": "line",
-                    "fillOpacity": 0,
+                    "fillOpacity": 8,
                     "gradientMode": "none",
                     "hideFrom": {
                       "legend": false,
@@ -11269,12 +11269,12 @@
                     },
                     "insertNulls": false,
                     "lineInterpolation": "linear",
-                    "lineWidth": 1,
+                    "lineWidth": 2,
                     "pointSize": 5,
                     "scaleDistribution": {
                       "type": "linear"
                     },
-                    "showPoints": "auto",
+                    "showPoints": "never",
                     "showValues": false,
                     "spanNulls": false,
                     "stacking": {
@@ -11375,7 +11375,7 @@
                     "barAlignment": 0,
                     "barWidthFactor": 0.6,
                     "drawStyle": "line",
-                    "fillOpacity": 0,
+                    "fillOpacity": 8,
                     "gradientMode": "none",
                     "hideFrom": {
                       "legend": false,
@@ -11384,12 +11384,12 @@
                     },
                     "insertNulls": false,
                     "lineInterpolation": "linear",
-                    "lineWidth": 1,
+                    "lineWidth": 2,
                     "pointSize": 5,
                     "scaleDistribution": {
                       "type": "linear"
                     },
-                    "showPoints": "auto",
+                    "showPoints": "never",
                     "showValues": false,
                     "spanNulls": false,
                     "stacking": {
@@ -11490,7 +11490,7 @@
                     "barAlignment": 0,
                     "barWidthFactor": 0.6,
                     "drawStyle": "line",
-                    "fillOpacity": 0,
+                    "fillOpacity": 8,
                     "gradientMode": "none",
                     "hideFrom": {
                       "legend": false,
@@ -11499,12 +11499,12 @@
                     },
                     "insertNulls": false,
                     "lineInterpolation": "linear",
-                    "lineWidth": 1,
+                    "lineWidth": 2,
                     "pointSize": 5,
                     "scaleDistribution": {
                       "type": "linear"
                     },
-                    "showPoints": "auto",
+                    "showPoints": "never",
                     "showValues": false,
                     "spanNulls": false,
                     "stacking": {
@@ -11605,7 +11605,7 @@
                     "barAlignment": 0,
                     "barWidthFactor": 0.6,
                     "drawStyle": "line",
-                    "fillOpacity": 0,
+                    "fillOpacity": 8,
                     "gradientMode": "none",
                     "hideFrom": {
                       "legend": false,
@@ -11614,12 +11614,12 @@
                     },
                     "insertNulls": false,
                     "lineInterpolation": "linear",
-                    "lineWidth": 1,
+                    "lineWidth": 2,
                     "pointSize": 5,
                     "scaleDistribution": {
                       "type": "linear"
                     },
-                    "showPoints": "auto",
+                    "showPoints": "never",
                     "showValues": false,
                     "spanNulls": false,
                     "stacking": {
@@ -11720,7 +11720,7 @@
                     "barAlignment": 0,
                     "barWidthFactor": 0.6,
                     "drawStyle": "line",
-                    "fillOpacity": 0,
+                    "fillOpacity": 8,
                     "gradientMode": "none",
                     "hideFrom": {
                       "legend": false,
@@ -11729,12 +11729,12 @@
                     },
                     "insertNulls": false,
                     "lineInterpolation": "linear",
-                    "lineWidth": 1,
+                    "lineWidth": 2,
                     "pointSize": 5,
                     "scaleDistribution": {
                       "type": "linear"
                     },
-                    "showPoints": "auto",
+                    "showPoints": "never",
                     "showValues": false,
                     "spanNulls": false,
                     "stacking": {
@@ -11835,7 +11835,7 @@
                     "barAlignment": 0,
                     "barWidthFactor": 0.6,
                     "drawStyle": "line",
-                    "fillOpacity": 0,
+                    "fillOpacity": 8,
                     "gradientMode": "none",
                     "hideFrom": {
                       "legend": false,
@@ -11844,12 +11844,12 @@
                     },
                     "insertNulls": false,
                     "lineInterpolation": "linear",
-                    "lineWidth": 1,
+                    "lineWidth": 2,
                     "pointSize": 5,
                     "scaleDistribution": {
                       "type": "linear"
                     },
-                    "showPoints": "auto",
+                    "showPoints": "never",
                     "showValues": false,
                     "spanNulls": false,
                     "stacking": {
@@ -11950,7 +11950,7 @@
                     "barAlignment": 0,
                     "barWidthFactor": 0.6,
                     "drawStyle": "line",
-                    "fillOpacity": 0,
+                    "fillOpacity": 8,
                     "gradientMode": "none",
                     "hideFrom": {
                       "legend": false,
@@ -11959,12 +11959,12 @@
                     },
                     "insertNulls": false,
                     "lineInterpolation": "linear",
-                    "lineWidth": 1,
+                    "lineWidth": 2,
                     "pointSize": 5,
                     "scaleDistribution": {
                       "type": "linear"
                     },
-                    "showPoints": "auto",
+                    "showPoints": "never",
                     "showValues": false,
                     "spanNulls": false,
                     "stacking": {
@@ -12065,7 +12065,7 @@
                     "barAlignment": 0,
                     "barWidthFactor": 0.6,
                     "drawStyle": "line",
-                    "fillOpacity": 0,
+                    "fillOpacity": 8,
                     "gradientMode": "none",
                     "hideFrom": {
                       "legend": false,
@@ -12074,12 +12074,12 @@
                     },
                     "insertNulls": false,
                     "lineInterpolation": "linear",
-                    "lineWidth": 1,
+                    "lineWidth": 2,
                     "pointSize": 5,
                     "scaleDistribution": {
                       "type": "linear"
                     },
-                    "showPoints": "auto",
+                    "showPoints": "never",
                     "showValues": false,
                     "spanNulls": false,
                     "stacking": {
@@ -12180,7 +12180,7 @@
                     "barAlignment": 0,
                     "barWidthFactor": 0.6,
                     "drawStyle": "line",
-                    "fillOpacity": 0,
+                    "fillOpacity": 8,
                     "gradientMode": "none",
                     "hideFrom": {
                       "legend": false,
@@ -12189,12 +12189,12 @@
                     },
                     "insertNulls": false,
                     "lineInterpolation": "linear",
-                    "lineWidth": 1,
+                    "lineWidth": 2,
                     "pointSize": 5,
                     "scaleDistribution": {
                       "type": "linear"
                     },
-                    "showPoints": "auto",
+                    "showPoints": "never",
                     "showValues": false,
                     "spanNulls": false,
                     "stacking": {
@@ -14787,7 +14787,7 @@
                     "barAlignment": 0,
                     "barWidthFactor": 0.6,
                     "drawStyle": "line",
-                    "fillOpacity": 0,
+                    "fillOpacity": 8,
                     "gradientMode": "none",
                     "hideFrom": {
                       "legend": false,
@@ -14796,12 +14796,12 @@
                     },
                     "insertNulls": false,
                     "lineInterpolation": "linear",
-                    "lineWidth": 1,
+                    "lineWidth": 2,
                     "pointSize": 5,
                     "scaleDistribution": {
                       "type": "linear"
                     },
-                    "showPoints": "auto",
+                    "showPoints": "never",
                     "showValues": false,
                     "spanNulls": false,
                     "stacking": {
@@ -14902,7 +14902,7 @@
                     "barAlignment": 0,
                     "barWidthFactor": 0.6,
                     "drawStyle": "line",
-                    "fillOpacity": 0,
+                    "fillOpacity": 8,
                     "gradientMode": "none",
                     "hideFrom": {
                       "legend": false,
@@ -14911,12 +14911,12 @@
                     },
                     "insertNulls": false,
                     "lineInterpolation": "linear",
-                    "lineWidth": 1,
+                    "lineWidth": 2,
                     "pointSize": 5,
                     "scaleDistribution": {
                       "type": "linear"
                     },
-                    "showPoints": "auto",
+                    "showPoints": "never",
                     "showValues": false,
                     "spanNulls": false,
                     "stacking": {
@@ -15017,7 +15017,7 @@
                     "barAlignment": 0,
                     "barWidthFactor": 0.6,
                     "drawStyle": "line",
-                    "fillOpacity": 0,
+                    "fillOpacity": 8,
                     "gradientMode": "none",
                     "hideFrom": {
                       "legend": false,
@@ -15026,12 +15026,12 @@
                     },
                     "insertNulls": false,
                     "lineInterpolation": "linear",
-                    "lineWidth": 1,
+                    "lineWidth": 2,
                     "pointSize": 5,
                     "scaleDistribution": {
                       "type": "linear"
                     },
-                    "showPoints": "auto",
+                    "showPoints": "never",
                     "showValues": false,
                     "spanNulls": false,
                     "stacking": {
@@ -15132,7 +15132,7 @@
                     "barAlignment": 0,
                     "barWidthFactor": 0.6,
                     "drawStyle": "line",
-                    "fillOpacity": 0,
+                    "fillOpacity": 8,
                     "gradientMode": "none",
                     "hideFrom": {
                       "legend": false,
@@ -15141,12 +15141,12 @@
                     },
                     "insertNulls": false,
                     "lineInterpolation": "linear",
-                    "lineWidth": 1,
+                    "lineWidth": 2,
                     "pointSize": 5,
                     "scaleDistribution": {
                       "type": "linear"
                     },
-                    "showPoints": "auto",
+                    "showPoints": "never",
                     "showValues": false,
                     "spanNulls": false,
                     "stacking": {
@@ -15247,7 +15247,7 @@
                     "barAlignment": 0,
                     "barWidthFactor": 0.6,
                     "drawStyle": "line",
-                    "fillOpacity": 0,
+                    "fillOpacity": 8,
                     "gradientMode": "none",
                     "hideFrom": {
                       "legend": false,
@@ -15256,12 +15256,12 @@
                     },
                     "insertNulls": false,
                     "lineInterpolation": "linear",
-                    "lineWidth": 1,
+                    "lineWidth": 2,
                     "pointSize": 5,
                     "scaleDistribution": {
                       "type": "linear"
                     },
-                    "showPoints": "auto",
+                    "showPoints": "never",
                     "showValues": false,
                     "spanNulls": false,
                     "stacking": {
@@ -15362,7 +15362,7 @@
                     "barAlignment": 0,
                     "barWidthFactor": 0.6,
                     "drawStyle": "line",
-                    "fillOpacity": 0,
+                    "fillOpacity": 8,
                     "gradientMode": "none",
                     "hideFrom": {
                       "legend": false,
@@ -15371,12 +15371,12 @@
                     },
                     "insertNulls": false,
                     "lineInterpolation": "linear",
-                    "lineWidth": 1,
+                    "lineWidth": 2,
                     "pointSize": 5,
                     "scaleDistribution": {
                       "type": "linear"
                     },
-                    "showPoints": "auto",
+                    "showPoints": "never",
                     "showValues": false,
                     "spanNulls": false,
                     "stacking": {
@@ -15623,7 +15623,7 @@
                     "barAlignment": 0,
                     "barWidthFactor": 0.6,
                     "drawStyle": "line",
-                    "fillOpacity": 0,
+                    "fillOpacity": 8,
                     "gradientMode": "none",
                     "hideFrom": {
                       "legend": false,
@@ -15632,12 +15632,12 @@
                     },
                     "insertNulls": false,
                     "lineInterpolation": "linear",
-                    "lineWidth": 1,
+                    "lineWidth": 2,
                     "pointSize": 5,
                     "scaleDistribution": {
                       "type": "linear"
                     },
-                    "showPoints": "auto",
+                    "showPoints": "never",
                     "showValues": false,
                     "spanNulls": false,
                     "stacking": {
@@ -15738,7 +15738,7 @@
                     "barAlignment": 0,
                     "barWidthFactor": 0.6,
                     "drawStyle": "line",
-                    "fillOpacity": 0,
+                    "fillOpacity": 8,
                     "gradientMode": "none",
                     "hideFrom": {
                       "legend": false,
@@ -15747,12 +15747,12 @@
                     },
                     "insertNulls": false,
                     "lineInterpolation": "linear",
-                    "lineWidth": 1,
+                    "lineWidth": 2,
                     "pointSize": 5,
                     "scaleDistribution": {
                       "type": "linear"
                     },
-                    "showPoints": "auto",
+                    "showPoints": "never",
                     "showValues": false,
                     "spanNulls": false,
                     "stacking": {
@@ -15853,7 +15853,7 @@
                     "barAlignment": 0,
                     "barWidthFactor": 0.6,
                     "drawStyle": "line",
-                    "fillOpacity": 0,
+                    "fillOpacity": 8,
                     "gradientMode": "none",
                     "hideFrom": {
                       "legend": false,
@@ -15862,12 +15862,12 @@
                     },
                     "insertNulls": false,
                     "lineInterpolation": "linear",
-                    "lineWidth": 1,
+                    "lineWidth": 2,
                     "pointSize": 5,
                     "scaleDistribution": {
                       "type": "linear"
                     },
-                    "showPoints": "auto",
+                    "showPoints": "never",
                     "showValues": false,
                     "spanNulls": false,
                     "stacking": {
@@ -15968,7 +15968,7 @@
                     "barAlignment": 0,
                     "barWidthFactor": 0.6,
                     "drawStyle": "line",
-                    "fillOpacity": 0,
+                    "fillOpacity": 8,
                     "gradientMode": "none",
                     "hideFrom": {
                       "legend": false,
@@ -15977,12 +15977,12 @@
                     },
                     "insertNulls": false,
                     "lineInterpolation": "linear",
-                    "lineWidth": 1,
+                    "lineWidth": 2,
                     "pointSize": 5,
                     "scaleDistribution": {
                       "type": "linear"
                     },
-                    "showPoints": "auto",
+                    "showPoints": "never",
                     "showValues": false,
                     "spanNulls": false,
                     "stacking": {
@@ -16083,7 +16083,7 @@
                     "barAlignment": 0,
                     "barWidthFactor": 0.6,
                     "drawStyle": "line",
-                    "fillOpacity": 0,
+                    "fillOpacity": 8,
                     "gradientMode": "none",
                     "hideFrom": {
                       "legend": false,
@@ -16092,12 +16092,12 @@
                     },
                     "insertNulls": false,
                     "lineInterpolation": "linear",
-                    "lineWidth": 1,
+                    "lineWidth": 2,
                     "pointSize": 5,
                     "scaleDistribution": {
                       "type": "linear"
                     },
-                    "showPoints": "auto",
+                    "showPoints": "never",
                     "showValues": false,
                     "spanNulls": false,
                     "stacking": {

--- a/rl_insight/config/services/grafana/dashboards/verl_tainer_v1_with_vllm_engine.json
+++ b/rl_insight/config/services/grafana/dashboards/verl_tainer_v1_with_vllm_engine.json
@@ -19266,7 +19266,7 @@
                                   "x": 0,
                                   "y": 0,
                                   "width": 8,
-                                  "height": 9,
+                                  "height": 8,
                                   "element": {
                                     "kind": "ElementReference",
                                     "name": "panel-184"
@@ -19279,7 +19279,7 @@
                                   "x": 8,
                                   "y": 0,
                                   "width": 8,
-                                  "height": 9,
+                                  "height": 8,
                                   "element": {
                                     "kind": "ElementReference",
                                     "name": "panel-185"
@@ -19292,7 +19292,7 @@
                                   "x": 16,
                                   "y": 0,
                                   "width": 8,
-                                  "height": 9,
+                                  "height": 8,
                                   "element": {
                                     "kind": "ElementReference",
                                     "name": "panel-186"
@@ -19303,7 +19303,7 @@
                                 "kind": "GridLayoutItem",
                                 "spec": {
                                   "x": 0,
-                                  "y": 9,
+                                  "y": 8,
                                   "width": 8,
                                   "height": 8,
                                   "element": {
@@ -19316,7 +19316,7 @@
                                 "kind": "GridLayoutItem",
                                 "spec": {
                                   "x": 8,
-                                  "y": 9,
+                                  "y": 8,
                                   "width": 8,
                                   "height": 8,
                                   "element": {
@@ -19329,7 +19329,7 @@
                                 "kind": "GridLayoutItem",
                                 "spec": {
                                   "x": 16,
-                                  "y": 9,
+                                  "y": 8,
                                   "width": 8,
                                   "height": 8,
                                   "element": {
@@ -19342,7 +19342,7 @@
                                 "kind": "GridLayoutItem",
                                 "spec": {
                                   "x": 0,
-                                  "y": 17,
+                                  "y": 16,
                                   "width": 8,
                                   "height": 8,
                                   "element": {
@@ -19355,7 +19355,7 @@
                                 "kind": "GridLayoutItem",
                                 "spec": {
                                   "x": 8,
-                                  "y": 17,
+                                  "y": 16,
                                   "width": 8,
                                   "height": 8,
                                   "element": {
@@ -19368,7 +19368,7 @@
                                 "kind": "GridLayoutItem",
                                 "spec": {
                                   "x": 16,
-                                  "y": 17,
+                                  "y": 16,
                                   "width": 8,
                                   "height": 8,
                                   "element": {
@@ -19381,7 +19381,7 @@
                                 "kind": "GridLayoutItem",
                                 "spec": {
                                   "x": 0,
-                                  "y": 25,
+                                  "y": 24,
                                   "width": 8,
                                   "height": 8,
                                   "element": {
@@ -19394,7 +19394,7 @@
                                 "kind": "GridLayoutItem",
                                 "spec": {
                                   "x": 8,
-                                  "y": 25,
+                                  "y": 24,
                                   "width": 8,
                                   "height": 8,
                                   "element": {
@@ -19407,7 +19407,7 @@
                                 "kind": "GridLayoutItem",
                                 "spec": {
                                   "x": 16,
-                                  "y": 25,
+                                  "y": 24,
                                   "width": 8,
                                   "height": 8,
                                   "element": {
@@ -19420,7 +19420,7 @@
                                 "kind": "GridLayoutItem",
                                 "spec": {
                                   "x": 0,
-                                  "y": 33,
+                                  "y": 32,
                                   "width": 8,
                                   "height": 8,
                                   "element": {
@@ -19433,7 +19433,7 @@
                                 "kind": "GridLayoutItem",
                                 "spec": {
                                   "x": 8,
-                                  "y": 33,
+                                  "y": 32,
                                   "width": 8,
                                   "height": 8,
                                   "element": {
@@ -19462,7 +19462,7 @@
                                   "x": 0,
                                   "y": 0,
                                   "width": 8,
-                                  "height": 9,
+                                  "height": 8,
                                   "element": {
                                     "kind": "ElementReference",
                                     "name": "panel-198"
@@ -19475,7 +19475,7 @@
                                   "x": 8,
                                   "y": 0,
                                   "width": 8,
-                                  "height": 9,
+                                  "height": 8,
                                   "element": {
                                     "kind": "ElementReference",
                                     "name": "panel-199"
@@ -19488,7 +19488,7 @@
                                   "x": 16,
                                   "y": 0,
                                   "width": 8,
-                                  "height": 9,
+                                  "height": 8,
                                   "element": {
                                     "kind": "ElementReference",
                                     "name": "panel-200"
@@ -19499,9 +19499,9 @@
                                 "kind": "GridLayoutItem",
                                 "spec": {
                                   "x": 0,
-                                  "y": 9,
+                                  "y": 8,
                                   "width": 8,
-                                  "height": 9,
+                                  "height": 8,
                                   "element": {
                                     "kind": "ElementReference",
                                     "name": "panel-201"
@@ -19512,9 +19512,9 @@
                                 "kind": "GridLayoutItem",
                                 "spec": {
                                   "x": 8,
-                                  "y": 9,
+                                  "y": 8,
                                   "width": 8,
-                                  "height": 9,
+                                  "height": 8,
                                   "element": {
                                     "kind": "ElementReference",
                                     "name": "panel-202"
@@ -19525,9 +19525,9 @@
                                 "kind": "GridLayoutItem",
                                 "spec": {
                                   "x": 16,
-                                  "y": 9,
+                                  "y": 8,
                                   "width": 8,
-                                  "height": 9,
+                                  "height": 8,
                                   "element": {
                                     "kind": "ElementReference",
                                     "name": "panel-203"
@@ -19538,9 +19538,9 @@
                                 "kind": "GridLayoutItem",
                                 "spec": {
                                   "x": 0,
-                                  "y": 18,
+                                  "y": 16,
                                   "width": 8,
-                                  "height": 9,
+                                  "height": 8,
                                   "element": {
                                     "kind": "ElementReference",
                                     "name": "panel-204"
@@ -19551,9 +19551,9 @@
                                 "kind": "GridLayoutItem",
                                 "spec": {
                                   "x": 8,
-                                  "y": 18,
+                                  "y": 16,
                                   "width": 8,
-                                  "height": 9,
+                                  "height": 8,
                                   "element": {
                                     "kind": "ElementReference",
                                     "name": "panel-205"
@@ -19564,9 +19564,9 @@
                                 "kind": "GridLayoutItem",
                                 "spec": {
                                   "x": 16,
-                                  "y": 18,
+                                  "y": 16,
                                   "width": 8,
-                                  "height": 9,
+                                  "height": 8,
                                   "element": {
                                     "kind": "ElementReference",
                                     "name": "panel-206"
@@ -19577,9 +19577,9 @@
                                 "kind": "GridLayoutItem",
                                 "spec": {
                                   "x": 0,
-                                  "y": 27,
+                                  "y": 24,
                                   "width": 8,
-                                  "height": 9,
+                                  "height": 8,
                                   "element": {
                                     "kind": "ElementReference",
                                     "name": "panel-207"
@@ -19590,9 +19590,9 @@
                                 "kind": "GridLayoutItem",
                                 "spec": {
                                   "x": 8,
-                                  "y": 27,
+                                  "y": 24,
                                   "width": 8,
-                                  "height": 9,
+                                  "height": 8,
                                   "element": {
                                     "kind": "ElementReference",
                                     "name": "panel-208"
@@ -19603,9 +19603,9 @@
                                 "kind": "GridLayoutItem",
                                 "spec": {
                                   "x": 16,
-                                  "y": 27,
+                                  "y": 24,
                                   "width": 8,
-                                  "height": 9,
+                                  "height": 8,
                                   "element": {
                                     "kind": "ElementReference",
                                     "name": "panel-209"
@@ -19632,7 +19632,7 @@
                                   "x": 0,
                                   "y": 0,
                                   "width": 8,
-                                  "height": 9,
+                                  "height": 8,
                                   "element": {
                                     "kind": "ElementReference",
                                     "name": "panel-210"
@@ -19645,7 +19645,7 @@
                                   "x": 8,
                                   "y": 0,
                                   "width": 8,
-                                  "height": 9,
+                                  "height": 8,
                                   "element": {
                                     "kind": "ElementReference",
                                     "name": "panel-211"
@@ -19658,7 +19658,7 @@
                                   "x": 16,
                                   "y": 0,
                                   "width": 8,
-                                  "height": 9,
+                                  "height": 8,
                                   "element": {
                                     "kind": "ElementReference",
                                     "name": "panel-212"
@@ -19669,9 +19669,9 @@
                                 "kind": "GridLayoutItem",
                                 "spec": {
                                   "x": 0,
-                                  "y": 9,
+                                  "y": 8,
                                   "width": 8,
-                                  "height": 9,
+                                  "height": 8,
                                   "element": {
                                     "kind": "ElementReference",
                                     "name": "panel-213"
@@ -19682,9 +19682,9 @@
                                 "kind": "GridLayoutItem",
                                 "spec": {
                                   "x": 8,
-                                  "y": 9,
+                                  "y": 8,
                                   "width": 8,
-                                  "height": 9,
+                                  "height": 8,
                                   "element": {
                                     "kind": "ElementReference",
                                     "name": "panel-214"
@@ -19695,9 +19695,9 @@
                                 "kind": "GridLayoutItem",
                                 "spec": {
                                   "x": 16,
-                                  "y": 9,
+                                  "y": 8,
                                   "width": 8,
-                                  "height": 9,
+                                  "height": 8,
                                   "element": {
                                     "kind": "ElementReference",
                                     "name": "panel-215"
@@ -19724,7 +19724,7 @@
                                   "x": 0,
                                   "y": 0,
                                   "width": 8,
-                                  "height": 9,
+                                  "height": 8,
                                   "element": {
                                     "kind": "ElementReference",
                                     "name": "panel-219"
@@ -19737,7 +19737,7 @@
                                   "x": 8,
                                   "y": 0,
                                   "width": 8,
-                                  "height": 9,
+                                  "height": 8,
                                   "element": {
                                     "kind": "ElementReference",
                                     "name": "panel-223"
@@ -19750,7 +19750,7 @@
                                   "x": 16,
                                   "y": 0,
                                   "width": 8,
-                                  "height": 9,
+                                  "height": 8,
                                   "element": {
                                     "kind": "ElementReference",
                                     "name": "panel-221"
@@ -19761,9 +19761,9 @@
                                 "kind": "GridLayoutItem",
                                 "spec": {
                                   "x": 0,
-                                  "y": 9,
+                                  "y": 8,
                                   "width": 8,
-                                  "height": 9,
+                                  "height": 8,
                                   "element": {
                                     "kind": "ElementReference",
                                     "name": "panel-222"
@@ -19790,7 +19790,7 @@
                                   "x": 0,
                                   "y": 0,
                                   "width": 8,
-                                  "height": 9,
+                                  "height": 8,
                                   "element": {
                                     "kind": "ElementReference",
                                     "name": "panel-224"
@@ -19803,7 +19803,7 @@
                                   "x": 8,
                                   "y": 0,
                                   "width": 8,
-                                  "height": 9,
+                                  "height": 8,
                                   "element": {
                                     "kind": "ElementReference",
                                     "name": "panel-225"
@@ -19816,7 +19816,7 @@
                                   "x": 16,
                                   "y": 0,
                                   "width": 8,
-                                  "height": 9,
+                                  "height": 8,
                                   "element": {
                                     "kind": "ElementReference",
                                     "name": "panel-226"
@@ -19827,9 +19827,9 @@
                                 "kind": "GridLayoutItem",
                                 "spec": {
                                   "x": 0,
-                                  "y": 9,
+                                  "y": 8,
                                   "width": 8,
-                                  "height": 9,
+                                  "height": 8,
                                   "element": {
                                     "kind": "ElementReference",
                                     "name": "panel-227"
@@ -19856,7 +19856,7 @@
                                   "x": 0,
                                   "y": 0,
                                   "width": 8,
-                                  "height": 9,
+                                  "height": 8,
                                   "element": {
                                     "kind": "ElementReference",
                                     "name": "panel-228"
@@ -19869,7 +19869,7 @@
                                   "x": 8,
                                   "y": 0,
                                   "width": 8,
-                                  "height": 9,
+                                  "height": 8,
                                   "element": {
                                     "kind": "ElementReference",
                                     "name": "panel-229"
@@ -19882,7 +19882,7 @@
                                   "x": 16,
                                   "y": 0,
                                   "width": 8,
-                                  "height": 9,
+                                  "height": 8,
                                   "element": {
                                     "kind": "ElementReference",
                                     "name": "panel-230"
@@ -19893,9 +19893,9 @@
                                 "kind": "GridLayoutItem",
                                 "spec": {
                                   "x": 0,
-                                  "y": 9,
+                                  "y": 8,
                                   "width": 8,
-                                  "height": 9,
+                                  "height": 8,
                                   "element": {
                                     "kind": "ElementReference",
                                     "name": "panel-231"
@@ -19906,9 +19906,9 @@
                                 "kind": "GridLayoutItem",
                                 "spec": {
                                   "x": 8,
-                                  "y": 9,
+                                  "y": 8,
                                   "width": 8,
-                                  "height": 9,
+                                  "height": 8,
                                   "element": {
                                     "kind": "ElementReference",
                                     "name": "panel-232"
@@ -19919,9 +19919,9 @@
                                 "kind": "GridLayoutItem",
                                 "spec": {
                                   "x": 16,
-                                  "y": 9,
+                                  "y": 8,
                                   "width": 8,
-                                  "height": 9,
+                                  "height": 8,
                                   "element": {
                                     "kind": "ElementReference",
                                     "name": "panel-233"
@@ -19932,9 +19932,9 @@
                                 "kind": "GridLayoutItem",
                                 "spec": {
                                   "x": 0,
-                                  "y": 18,
+                                  "y": 16,
                                   "width": 8,
-                                  "height": 9,
+                                  "height": 8,
                                   "element": {
                                     "kind": "ElementReference",
                                     "name": "panel-234"
@@ -19945,9 +19945,9 @@
                                 "kind": "GridLayoutItem",
                                 "spec": {
                                   "x": 8,
-                                  "y": 18,
+                                  "y": 16,
                                   "width": 8,
-                                  "height": 9,
+                                  "height": 8,
                                   "element": {
                                     "kind": "ElementReference",
                                     "name": "panel-235"
@@ -19958,9 +19958,9 @@
                                 "kind": "GridLayoutItem",
                                 "spec": {
                                   "x": 16,
-                                  "y": 18,
+                                  "y": 16,
                                   "width": 8,
-                                  "height": 9,
+                                  "height": 8,
                                   "element": {
                                     "kind": "ElementReference",
                                     "name": "panel-236"
@@ -19987,7 +19987,7 @@
                                   "x": 0,
                                   "y": 0,
                                   "width": 8,
-                                  "height": 9,
+                                  "height": 8,
                                   "element": {
                                     "kind": "ElementReference",
                                     "name": "panel-237"
@@ -20000,7 +20000,7 @@
                                   "x": 8,
                                   "y": 0,
                                   "width": 8,
-                                  "height": 9,
+                                  "height": 8,
                                   "element": {
                                     "kind": "ElementReference",
                                     "name": "panel-238"
@@ -20013,7 +20013,7 @@
                                   "x": 16,
                                   "y": 0,
                                   "width": 8,
-                                  "height": 9,
+                                  "height": 8,
                                   "element": {
                                     "kind": "ElementReference",
                                     "name": "panel-239"
@@ -20024,9 +20024,9 @@
                                 "kind": "GridLayoutItem",
                                 "spec": {
                                   "x": 0,
-                                  "y": 9,
+                                  "y": 8,
                                   "width": 8,
-                                  "height": 9,
+                                  "height": 8,
                                   "element": {
                                     "kind": "ElementReference",
                                     "name": "panel-240"
@@ -20037,9 +20037,9 @@
                                 "kind": "GridLayoutItem",
                                 "spec": {
                                   "x": 8,
-                                  "y": 9,
+                                  "y": 8,
                                   "width": 8,
-                                  "height": 9,
+                                  "height": 8,
                                   "element": {
                                     "kind": "ElementReference",
                                     "name": "panel-241"
@@ -20050,9 +20050,9 @@
                                 "kind": "GridLayoutItem",
                                 "spec": {
                                   "x": 16,
-                                  "y": 9,
+                                  "y": 8,
                                   "width": 8,
-                                  "height": 9,
+                                  "height": 8,
                                   "element": {
                                     "kind": "ElementReference",
                                     "name": "panel-242"
@@ -20063,9 +20063,9 @@
                                 "kind": "GridLayoutItem",
                                 "spec": {
                                   "x": 0,
-                                  "y": 18,
+                                  "y": 16,
                                   "width": 8,
-                                  "height": 9,
+                                  "height": 8,
                                   "element": {
                                     "kind": "ElementReference",
                                     "name": "panel-243"
@@ -20076,9 +20076,9 @@
                                 "kind": "GridLayoutItem",
                                 "spec": {
                                   "x": 8,
-                                  "y": 18,
+                                  "y": 16,
                                   "width": 8,
-                                  "height": 9,
+                                  "height": 8,
                                   "element": {
                                     "kind": "ElementReference",
                                     "name": "panel-244"
@@ -20089,9 +20089,9 @@
                                 "kind": "GridLayoutItem",
                                 "spec": {
                                   "x": 16,
-                                  "y": 18,
+                                  "y": 16,
                                   "width": 8,
-                                  "height": 9,
+                                  "height": 8,
                                   "element": {
                                     "kind": "ElementReference",
                                     "name": "panel-245"
@@ -20102,9 +20102,9 @@
                                 "kind": "GridLayoutItem",
                                 "spec": {
                                   "x": 0,
-                                  "y": 27,
+                                  "y": 24,
                                   "width": 8,
-                                  "height": 9,
+                                  "height": 8,
                                   "element": {
                                     "kind": "ElementReference",
                                     "name": "panel-246"
@@ -20115,9 +20115,9 @@
                                 "kind": "GridLayoutItem",
                                 "spec": {
                                   "x": 8,
-                                  "y": 27,
+                                  "y": 24,
                                   "width": 8,
-                                  "height": 9,
+                                  "height": 8,
                                   "element": {
                                     "kind": "ElementReference",
                                     "name": "panel-247"
@@ -20128,9 +20128,9 @@
                                 "kind": "GridLayoutItem",
                                 "spec": {
                                   "x": 16,
-                                  "y": 27,
+                                  "y": 24,
                                   "width": 8,
-                                  "height": 9,
+                                  "height": 8,
                                   "element": {
                                     "kind": "ElementReference",
                                     "name": "panel-248"
@@ -20141,9 +20141,9 @@
                                 "kind": "GridLayoutItem",
                                 "spec": {
                                   "x": 0,
-                                  "y": 36,
+                                  "y": 32,
                                   "width": 8,
-                                  "height": 9,
+                                  "height": 8,
                                   "element": {
                                     "kind": "ElementReference",
                                     "name": "panel-249"
@@ -20170,7 +20170,7 @@
                                   "x": 0,
                                   "y": 0,
                                   "width": 8,
-                                  "height": 9,
+                                  "height": 8,
                                   "element": {
                                     "kind": "ElementReference",
                                     "name": "panel-250"
@@ -20183,7 +20183,7 @@
                                   "x": 8,
                                   "y": 0,
                                   "width": 8,
-                                  "height": 9,
+                                  "height": 8,
                                   "element": {
                                     "kind": "ElementReference",
                                     "name": "panel-251"
@@ -20196,7 +20196,7 @@
                                   "x": 16,
                                   "y": 0,
                                   "width": 8,
-                                  "height": 9,
+                                  "height": 8,
                                   "element": {
                                     "kind": "ElementReference",
                                     "name": "panel-252"
@@ -20207,9 +20207,9 @@
                                 "kind": "GridLayoutItem",
                                 "spec": {
                                   "x": 0,
-                                  "y": 9,
+                                  "y": 8,
                                   "width": 8,
-                                  "height": 9,
+                                  "height": 8,
                                   "element": {
                                     "kind": "ElementReference",
                                     "name": "panel-253"
@@ -20220,9 +20220,9 @@
                                 "kind": "GridLayoutItem",
                                 "spec": {
                                   "x": 8,
-                                  "y": 9,
+                                  "y": 8,
                                   "width": 8,
-                                  "height": 9,
+                                  "height": 8,
                                   "element": {
                                     "kind": "ElementReference",
                                     "name": "panel-254"
@@ -20233,9 +20233,9 @@
                                 "kind": "GridLayoutItem",
                                 "spec": {
                                   "x": 16,
-                                  "y": 9,
+                                  "y": 8,
                                   "width": 8,
-                                  "height": 9,
+                                  "height": 8,
                                   "element": {
                                     "kind": "ElementReference",
                                     "name": "panel-273"
@@ -20246,9 +20246,9 @@
                                 "kind": "GridLayoutItem",
                                 "spec": {
                                   "x": 0,
-                                  "y": 18,
+                                  "y": 16,
                                   "width": 8,
-                                  "height": 9,
+                                  "height": 8,
                                   "element": {
                                     "kind": "ElementReference",
                                     "name": "panel-274"
@@ -20259,9 +20259,9 @@
                                 "kind": "GridLayoutItem",
                                 "spec": {
                                   "x": 8,
-                                  "y": 18,
+                                  "y": 16,
                                   "width": 8,
-                                  "height": 9,
+                                  "height": 8,
                                   "element": {
                                     "kind": "ElementReference",
                                     "name": "panel-275"
@@ -20272,9 +20272,9 @@
                                 "kind": "GridLayoutItem",
                                 "spec": {
                                   "x": 16,
-                                  "y": 18,
+                                  "y": 16,
                                   "width": 8,
-                                  "height": 9,
+                                  "height": 8,
                                   "element": {
                                     "kind": "ElementReference",
                                     "name": "panel-281"
@@ -20285,9 +20285,9 @@
                                 "kind": "GridLayoutItem",
                                 "spec": {
                                   "x": 0,
-                                  "y": 27,
+                                  "y": 24,
                                   "width": 8,
-                                  "height": 9,
+                                  "height": 8,
                                   "element": {
                                     "kind": "ElementReference",
                                     "name": "panel-282"
@@ -20298,9 +20298,9 @@
                                 "kind": "GridLayoutItem",
                                 "spec": {
                                   "x": 8,
-                                  "y": 27,
+                                  "y": 24,
                                   "width": 8,
-                                  "height": 9,
+                                  "height": 8,
                                   "element": {
                                     "kind": "ElementReference",
                                     "name": "panel-278"
@@ -20311,9 +20311,9 @@
                                 "kind": "GridLayoutItem",
                                 "spec": {
                                   "x": 16,
-                                  "y": 27,
+                                  "y": 24,
                                   "width": 8,
-                                  "height": 9,
+                                  "height": 8,
                                   "element": {
                                     "kind": "ElementReference",
                                     "name": "panel-280"
@@ -20340,7 +20340,7 @@
                                   "x": 0,
                                   "y": 0,
                                   "width": 8,
-                                  "height": 9,
+                                  "height": 8,
                                   "element": {
                                     "kind": "ElementReference",
                                     "name": "panel-283"
@@ -20353,7 +20353,7 @@
                                   "x": 8,
                                   "y": 0,
                                   "width": 8,
-                                  "height": 9,
+                                  "height": 8,
                                   "element": {
                                     "kind": "ElementReference",
                                     "name": "panel-284"
@@ -20366,7 +20366,7 @@
                                   "x": 16,
                                   "y": 0,
                                   "width": 8,
-                                  "height": 9,
+                                  "height": 8,
                                   "element": {
                                     "kind": "ElementReference",
                                     "name": "panel-314"
@@ -20377,9 +20377,9 @@
                                 "kind": "GridLayoutItem",
                                 "spec": {
                                   "x": 0,
-                                  "y": 9,
+                                  "y": 8,
                                   "width": 8,
-                                  "height": 9,
+                                  "height": 8,
                                   "element": {
                                     "kind": "ElementReference",
                                     "name": "panel-316"
@@ -20390,9 +20390,9 @@
                                 "kind": "GridLayoutItem",
                                 "spec": {
                                   "x": 8,
-                                  "y": 9,
+                                  "y": 8,
                                   "width": 8,
-                                  "height": 9,
+                                  "height": 8,
                                   "element": {
                                     "kind": "ElementReference",
                                     "name": "panel-320"
@@ -20403,9 +20403,9 @@
                                 "kind": "GridLayoutItem",
                                 "spec": {
                                   "x": 16,
-                                  "y": 9,
+                                  "y": 8,
                                   "width": 8,
-                                  "height": 9,
+                                  "height": 8,
                                   "element": {
                                     "kind": "ElementReference",
                                     "name": "panel-285"
@@ -20416,9 +20416,9 @@
                                 "kind": "GridLayoutItem",
                                 "spec": {
                                   "x": 0,
-                                  "y": 18,
+                                  "y": 16,
                                   "width": 8,
-                                  "height": 9,
+                                  "height": 8,
                                   "element": {
                                     "kind": "ElementReference",
                                     "name": "panel-286"
@@ -20429,9 +20429,9 @@
                                 "kind": "GridLayoutItem",
                                 "spec": {
                                   "x": 8,
-                                  "y": 18,
+                                  "y": 16,
                                   "width": 8,
-                                  "height": 9,
+                                  "height": 8,
                                   "element": {
                                     "kind": "ElementReference",
                                     "name": "panel-287"
@@ -20442,9 +20442,9 @@
                                 "kind": "GridLayoutItem",
                                 "spec": {
                                   "x": 16,
-                                  "y": 18,
+                                  "y": 16,
                                   "width": 8,
-                                  "height": 9,
+                                  "height": 8,
                                   "element": {
                                     "kind": "ElementReference",
                                     "name": "panel-288"
@@ -20455,9 +20455,9 @@
                                 "kind": "GridLayoutItem",
                                 "spec": {
                                   "x": 0,
-                                  "y": 27,
+                                  "y": 24,
                                   "width": 8,
-                                  "height": 9,
+                                  "height": 8,
                                   "element": {
                                     "kind": "ElementReference",
                                     "name": "panel-289"
@@ -20468,9 +20468,9 @@
                                 "kind": "GridLayoutItem",
                                 "spec": {
                                   "x": 8,
-                                  "y": 27,
+                                  "y": 24,
                                   "width": 8,
-                                  "height": 9,
+                                  "height": 8,
                                   "element": {
                                     "kind": "ElementReference",
                                     "name": "panel-322"
@@ -20481,9 +20481,9 @@
                                 "kind": "GridLayoutItem",
                                 "spec": {
                                   "x": 16,
-                                  "y": 27,
+                                  "y": 24,
                                   "width": 8,
-                                  "height": 9,
+                                  "height": 8,
                                   "element": {
                                     "kind": "ElementReference",
                                     "name": "panel-315"
@@ -20494,7 +20494,7 @@
                                 "kind": "GridLayoutItem",
                                 "spec": {
                                   "x": 0,
-                                  "y": 36,
+                                  "y": 32,
                                   "width": 8,
                                   "height": 8,
                                   "element": {
@@ -20507,7 +20507,7 @@
                                 "kind": "GridLayoutItem",
                                 "spec": {
                                   "x": 8,
-                                  "y": 36,
+                                  "y": 32,
                                   "width": 8,
                                   "height": 8,
                                   "element": {
@@ -20520,7 +20520,7 @@
                                 "kind": "GridLayoutItem",
                                 "spec": {
                                   "x": 16,
-                                  "y": 36,
+                                  "y": 32,
                                   "width": 8,
                                   "height": 8,
                                   "element": {
@@ -20533,7 +20533,7 @@
                                 "kind": "GridLayoutItem",
                                 "spec": {
                                   "x": 0,
-                                  "y": 44,
+                                  "y": 40,
                                   "width": 8,
                                   "height": 8,
                                   "element": {
@@ -20546,7 +20546,7 @@
                                 "kind": "GridLayoutItem",
                                 "spec": {
                                   "x": 8,
-                                  "y": 44,
+                                  "y": 40,
                                   "width": 8,
                                   "height": 8,
                                   "element": {
@@ -20559,7 +20559,7 @@
                                 "kind": "GridLayoutItem",
                                 "spec": {
                                   "x": 16,
-                                  "y": 44,
+                                  "y": 40,
                                   "width": 8,
                                   "height": 8,
                                   "element": {
@@ -20588,7 +20588,7 @@
                                   "x": 0,
                                   "y": 0,
                                   "width": 8,
-                                  "height": 9,
+                                  "height": 8,
                                   "element": {
                                     "kind": "ElementReference",
                                     "name": "panel-290"
@@ -20601,7 +20601,7 @@
                                   "x": 8,
                                   "y": 0,
                                   "width": 8,
-                                  "height": 9,
+                                  "height": 8,
                                   "element": {
                                     "kind": "ElementReference",
                                     "name": "panel-291"
@@ -20614,7 +20614,7 @@
                                   "x": 16,
                                   "y": 0,
                                   "width": 8,
-                                  "height": 9,
+                                  "height": 8,
                                   "element": {
                                     "kind": "ElementReference",
                                     "name": "panel-292"
@@ -20625,9 +20625,9 @@
                                 "kind": "GridLayoutItem",
                                 "spec": {
                                   "x": 0,
-                                  "y": 9,
+                                  "y": 8,
                                   "width": 8,
-                                  "height": 9,
+                                  "height": 8,
                                   "element": {
                                     "kind": "ElementReference",
                                     "name": "panel-293"
@@ -20638,9 +20638,9 @@
                                 "kind": "GridLayoutItem",
                                 "spec": {
                                   "x": 8,
-                                  "y": 9,
+                                  "y": 8,
                                   "width": 8,
-                                  "height": 9,
+                                  "height": 8,
                                   "element": {
                                     "kind": "ElementReference",
                                     "name": "panel-294"
@@ -20672,7 +20672,7 @@
                         "x": 0,
                         "y": 0,
                         "width": 12,
-                        "height": 13,
+                        "height": 8,
                         "element": {
                           "kind": "ElementReference",
                           "name": "panel-1"
@@ -20685,7 +20685,7 @@
                         "x": 12,
                         "y": 0,
                         "width": 12,
-                        "height": 13,
+                        "height": 8,
                         "element": {
                           "kind": "ElementReference",
                           "name": "panel-2"
@@ -20696,9 +20696,9 @@
                       "kind": "GridLayoutItem",
                       "spec": {
                         "x": 0,
-                        "y": 13,
+                        "y": 8,
                         "width": 12,
-                        "height": 13,
+                        "height": 8,
                         "element": {
                           "kind": "ElementReference",
                           "name": "panel-3"
@@ -20709,9 +20709,9 @@
                       "kind": "GridLayoutItem",
                       "spec": {
                         "x": 12,
-                        "y": 13,
+                        "y": 8,
                         "width": 12,
-                        "height": 13,
+                        "height": 8,
                         "element": {
                           "kind": "ElementReference",
                           "name": "panel-5"
@@ -20722,9 +20722,9 @@
                       "kind": "GridLayoutItem",
                       "spec": {
                         "x": 0,
-                        "y": 26,
+                        "y": 16,
                         "width": 12,
-                        "height": 13,
+                        "height": 8,
                         "element": {
                           "kind": "ElementReference",
                           "name": "panel-6"
@@ -20735,9 +20735,9 @@
                       "kind": "GridLayoutItem",
                       "spec": {
                         "x": 12,
-                        "y": 26,
+                        "y": 16,
                         "width": 12,
-                        "height": 13,
+                        "height": 8,
                         "element": {
                           "kind": "ElementReference",
                           "name": "panel-7"
@@ -20748,7 +20748,7 @@
                       "kind": "GridLayoutItem",
                       "spec": {
                         "x": 0,
-                        "y": 39,
+                        "y": 24,
                         "width": 12,
                         "height": 8,
                         "element": {
@@ -20761,7 +20761,7 @@
                       "kind": "GridLayoutItem",
                       "spec": {
                         "x": 12,
-                        "y": 39,
+                        "y": 24,
                         "width": 12,
                         "height": 8,
                         "element": {
@@ -20774,9 +20774,9 @@
                       "kind": "GridLayoutItem",
                       "spec": {
                         "x": 0,
-                        "y": 47,
+                        "y": 32,
                         "width": 12,
-                        "height": 12,
+                        "height": 8,
                         "element": {
                           "kind": "ElementReference",
                           "name": "panel-10"
@@ -20787,9 +20787,9 @@
                       "kind": "GridLayoutItem",
                       "spec": {
                         "x": 12,
-                        "y": 47,
+                        "y": 32,
                         "width": 12,
-                        "height": 12,
+                        "height": 8,
                         "element": {
                           "kind": "ElementReference",
                           "name": "panel-11"
@@ -20800,7 +20800,7 @@
                       "kind": "GridLayoutItem",
                       "spec": {
                         "x": 0,
-                        "y": 59,
+                        "y": 40,
                         "width": 12,
                         "height": 8,
                         "element": {
@@ -20813,7 +20813,7 @@
                       "kind": "GridLayoutItem",
                       "spec": {
                         "x": 12,
-                        "y": 59,
+                        "y": 40,
                         "width": 12,
                         "height": 8,
                         "element": {
@@ -20826,9 +20826,9 @@
                       "kind": "GridLayoutItem",
                       "spec": {
                         "x": 0,
-                        "y": 67,
+                        "y": 48,
                         "width": 12,
-                        "height": 9,
+                        "height": 8,
                         "element": {
                           "kind": "ElementReference",
                           "name": "panel-28"
@@ -20839,9 +20839,9 @@
                       "kind": "GridLayoutItem",
                       "spec": {
                         "x": 12,
-                        "y": 67,
+                        "y": 48,
                         "width": 12,
-                        "height": 9,
+                        "height": 8,
                         "element": {
                           "kind": "ElementReference",
                           "name": "panel-35"
@@ -20852,7 +20852,7 @@
                       "kind": "GridLayoutItem",
                       "spec": {
                         "x": 0,
-                        "y": 76,
+                        "y": 56,
                         "width": 12,
                         "height": 8,
                         "element": {
@@ -20865,7 +20865,7 @@
                       "kind": "GridLayoutItem",
                       "spec": {
                         "x": 12,
-                        "y": 76,
+                        "y": 56,
                         "width": 12,
                         "height": 8,
                         "element": {
@@ -20878,7 +20878,7 @@
                       "kind": "GridLayoutItem",
                       "spec": {
                         "x": 0,
-                        "y": 84,
+                        "y": 64,
                         "width": 12,
                         "height": 8,
                         "element": {
@@ -20891,7 +20891,7 @@
                       "kind": "GridLayoutItem",
                       "spec": {
                         "x": 12,
-                        "y": 84,
+                        "y": 64,
                         "width": 12,
                         "height": 8,
                         "element": {
@@ -20904,7 +20904,7 @@
                       "kind": "GridLayoutItem",
                       "spec": {
                         "x": 0,
-                        "y": 92,
+                        "y": 72,
                         "width": 12,
                         "height": 8,
                         "element": {
@@ -20917,7 +20917,7 @@
                       "kind": "GridLayoutItem",
                       "spec": {
                         "x": 12,
-                        "y": 92,
+                        "y": 72,
                         "width": 12,
                         "height": 8,
                         "element": {
@@ -20930,7 +20930,7 @@
                       "kind": "GridLayoutItem",
                       "spec": {
                         "x": 0,
-                        "y": 100,
+                        "y": 80,
                         "width": 12,
                         "height": 8,
                         "element": {
@@ -20943,7 +20943,7 @@
                       "kind": "GridLayoutItem",
                       "spec": {
                         "x": 12,
-                        "y": 100,
+                        "y": 80,
                         "width": 12,
                         "height": 8,
                         "element": {
@@ -20956,7 +20956,7 @@
                       "kind": "GridLayoutItem",
                       "spec": {
                         "x": 0,
-                        "y": 108,
+                        "y": 88,
                         "width": 12,
                         "height": 8,
                         "element": {
@@ -20969,7 +20969,7 @@
                       "kind": "GridLayoutItem",
                       "spec": {
                         "x": 12,
-                        "y": 108,
+                        "y": 88,
                         "width": 12,
                         "height": 8,
                         "element": {
@@ -20982,7 +20982,7 @@
                       "kind": "GridLayoutItem",
                       "spec": {
                         "x": 0,
-                        "y": 116,
+                        "y": 96,
                         "width": 12,
                         "height": 8,
                         "element": {
@@ -20995,7 +20995,7 @@
                       "kind": "GridLayoutItem",
                       "spec": {
                         "x": 12,
-                        "y": 116,
+                        "y": 96,
                         "width": 12,
                         "height": 8,
                         "element": {
@@ -21008,7 +21008,7 @@
                       "kind": "GridLayoutItem",
                       "spec": {
                         "x": 0,
-                        "y": 124,
+                        "y": 104,
                         "width": 12,
                         "height": 8,
                         "element": {
@@ -21021,7 +21021,7 @@
                       "kind": "GridLayoutItem",
                       "spec": {
                         "x": 12,
-                        "y": 124,
+                        "y": 104,
                         "width": 12,
                         "height": 8,
                         "element": {
@@ -21034,7 +21034,7 @@
                       "kind": "GridLayoutItem",
                       "spec": {
                         "x": 0,
-                        "y": 132,
+                        "y": 112,
                         "width": 12,
                         "height": 8,
                         "element": {
@@ -21047,7 +21047,7 @@
                       "kind": "GridLayoutItem",
                       "spec": {
                         "x": 12,
-                        "y": 132,
+                        "y": 112,
                         "width": 12,
                         "height": 8,
                         "element": {
@@ -21085,7 +21085,7 @@
                                   "x": 0,
                                   "y": 0,
                                   "width": 4,
-                                  "height": 4,
+                                  "height": 8,
                                   "element": {
                                     "kind": "ElementReference",
                                     "name": "panel-295"
@@ -21098,7 +21098,7 @@
                                   "x": 4,
                                   "y": 0,
                                   "width": 4,
-                                  "height": 4,
+                                  "height": 8,
                                   "element": {
                                     "kind": "ElementReference",
                                     "name": "panel-296"
@@ -21111,7 +21111,7 @@
                                   "x": 8,
                                   "y": 0,
                                   "width": 4,
-                                  "height": 4,
+                                  "height": 8,
                                   "element": {
                                     "kind": "ElementReference",
                                     "name": "panel-297"
@@ -21124,7 +21124,7 @@
                                   "x": 12,
                                   "y": 0,
                                   "width": 4,
-                                  "height": 4,
+                                  "height": 8,
                                   "element": {
                                     "kind": "ElementReference",
                                     "name": "panel-298"
@@ -21137,7 +21137,7 @@
                                   "x": 16,
                                   "y": 0,
                                   "width": 4,
-                                  "height": 4,
+                                  "height": 8,
                                   "element": {
                                     "kind": "ElementReference",
                                     "name": "panel-299"
@@ -21257,7 +21257,7 @@
                                   "x": 0,
                                   "y": 0,
                                   "width": 24,
-                                  "height": 6,
+                                  "height": 8,
                                   "element": {
                                     "kind": "ElementReference",
                                     "name": "panel-305"
@@ -21268,7 +21268,7 @@
                                 "kind": "GridLayoutItem",
                                 "spec": {
                                   "x": 0,
-                                  "y": 6,
+                                  "y": 8,
                                   "width": 12,
                                   "height": 8,
                                   "element": {
@@ -21281,7 +21281,7 @@
                                 "kind": "GridLayoutItem",
                                 "spec": {
                                   "x": 12,
-                                  "y": 6,
+                                  "y": 8,
                                   "width": 12,
                                   "height": 8,
                                   "element": {
@@ -21294,7 +21294,7 @@
                                 "kind": "GridLayoutItem",
                                 "spec": {
                                   "x": 0,
-                                  "y": 14,
+                                  "y": 16,
                                   "width": 12,
                                   "height": 8,
                                   "element": {
@@ -21307,7 +21307,7 @@
                                 "kind": "GridLayoutItem",
                                 "spec": {
                                   "x": 12,
-                                  "y": 14,
+                                  "y": 16,
                                   "width": 12,
                                   "height": 8,
                                   "element": {
@@ -21320,7 +21320,7 @@
                                 "kind": "GridLayoutItem",
                                 "spec": {
                                   "x": 0,
-                                  "y": 22,
+                                  "y": 24,
                                   "width": 12,
                                   "height": 8,
                                   "element": {
@@ -21333,7 +21333,7 @@
                                 "kind": "GridLayoutItem",
                                 "spec": {
                                   "x": 0,
-                                  "y": 30,
+                                  "y": 32,
                                   "width": 12,
                                   "height": 8,
                                   "element": {
@@ -21346,7 +21346,7 @@
                                 "kind": "GridLayoutItem",
                                 "spec": {
                                   "x": 0,
-                                  "y": 38,
+                                  "y": 40,
                                   "width": 24,
                                   "height": 8,
                                   "element": {


### PR DESCRIPTION
### What does this PR do?

- Unify grid panel heights to **8** across training / engine / transfer / hardware sections, and repack row `y` positions; keep **state timeline** at height **18**.
- Standardize trainer metric legends: replace remaining `legendFormat: __auto` with `{{__name__}}` so legends consistently show the Prometheus metric name.
- Tidy trainer metric timeseries style only: `lineWidth` 1→2, `fillOpacity` 0→8 (under-curve fill), `showPoints` auto→never. No changes to vLLM / transfer / hardware / timeline panels for style.

### Checklist Before Starting

- [x] Search for similar PRs. Paste at least one query link here: ...
- [x] Format the PR title as `[{modules}] {type}: {description}` (This will be checked by the CI)
  - `{modules}` include:
    - `monitor-api`, `monitor-cli`, `monitor-collector`, `monitor-server`, `monitor-config` for online monitor changes
    - `recipe` for offline analysis changes, including pipeline, parser, visualizer, data checker, recipe config, examples, and sample data
    - `doc`, `ci`, `perf`, `deployment`, `misc` for cross-cutting changes
  - If this PR involves multiple modules, separate them with `,` like `[recipe, ci]` or `[monitor-server, monitor-config]`
  - `{type}` is in `feat`, `fix`, `refactor`, `chore`, `test`
  - If this PR breaks any API (CLI arguments, config, function signature, etc.), add `[BREAKING]` to the beginning of the title.
  - Example: `[BREAKING][mstx, torch_profile] feat: support timeline parsing`

### Test


https://github.com/user-attachments/assets/43d07671-12d3-48cd-a411-4370f12183b9



### API and Usage Example

> Demonstrate how the API changes if any, and provide usage example(s) if possible.

```python
# Add code snippet or script demonstrating how to use this
```

### Design & Code Changes

> Demonstrate the high-level design if this PR is complex, and list the specific changes.

### Checklist Before Submitting

> [!IMPORTANT]
> Please check all the following items before requesting a review, otherwise the reviewer might deprioritize this PR for review.

- [x] Read the [Contribute Guide](https://github.com/verl-project/rl-insight/blob/main/CONTRIBUTING.md).
- [x] Apply [pre-commit checks](https://github.com/verl-project/rl-insight/blob/main/CONTRIBUTING.md#code-linting-and-formatting): `pre-commit install && pre-commit run --all-files --show-diff-on-failure --color=always`
- [x] Add / Update [the documentation](https://github.com/verl-project/rl-insight/tree/main/docs).
- [x] Add unit or end-to-end test(s) to [the CI workflow](https://github.com/verl-project/rl-insight/tree/main/.github/workflows) to cover all the code. If not feasible, explain why: ...
