### PR TITLE
fix(dashboard): SGLang panels show No data when exporter negotiates escaping=underscores

### DIFF
--- a/rl_insight/config/services/grafana/dashboards/verl/verl_tainer_v1_with_sglang_engine.json
+++ b/rl_insight/config/services/grafana/dashboards/verl/verl_tainer_v1_with_sglang_engine.json
@@ -13459,7 +13459,7 @@
                       "spec": {
                         "editorMode": "code",
                         "exemplar": true,
-                        "expr": "histogram_quantile(0.99, sum by (le, replica) (rate(sglang:e2e_request_latency_seconds_bucket{model_name=~\"$sglang_model_name\", replica=~\"$sglang_replica\"}[$__rate_interval])))",
+                        "expr": "histogram_quantile(0.99, sum by (le, replica) (rate({__name__=~\"sglang[:_]e2e_request_latency_seconds_bucket\", model_name=~\"$sglang_model_name\", replica=~\"$sglang_replica\"}[$__rate_interval])))",
                         "interval": "",
                         "legendFormat": "replica {{replica}} P99",
                         "queryType": "randomWalk",
@@ -13480,7 +13480,7 @@
                       "spec": {
                         "editorMode": "code",
                         "exemplar": true,
-                        "expr": "histogram_quantile(0.9, sum by (le, replica) (rate(sglang:e2e_request_latency_seconds_bucket{model_name=~\"$sglang_model_name\", replica=~\"$sglang_replica\"}[$__rate_interval])))",
+                        "expr": "histogram_quantile(0.9, sum by (le, replica) (rate({__name__=~\"sglang[:_]e2e_request_latency_seconds_bucket\", model_name=~\"$sglang_model_name\", replica=~\"$sglang_replica\"}[$__rate_interval])))",
                         "interval": "",
                         "legendFormat": "replica {{replica}} P90",
                         "queryType": "randomWalk",
@@ -13501,7 +13501,7 @@
                       "spec": {
                         "editorMode": "code",
                         "exemplar": true,
-                        "expr": "histogram_quantile(0.5, sum by (le, replica) (rate(sglang:e2e_request_latency_seconds_bucket{model_name=~\"$sglang_model_name\", replica=~\"$sglang_replica\"}[$__rate_interval])))",
+                        "expr": "histogram_quantile(0.5, sum by (le, replica) (rate({__name__=~\"sglang[:_]e2e_request_latency_seconds_bucket\", model_name=~\"$sglang_model_name\", replica=~\"$sglang_replica\"}[$__rate_interval])))",
                         "interval": "",
                         "legendFormat": "replica {{replica}} P50",
                         "queryType": "randomWalk",
@@ -13522,7 +13522,7 @@
                       "spec": {
                         "editorMode": "code",
                         "exemplar": true,
-                        "expr": "sum by (replica) (rate(sglang:e2e_request_latency_seconds_sum{model_name=~\"$sglang_model_name\", replica=~\"$sglang_replica\"}[$__rate_interval])) / sum by (replica) (rate(sglang:e2e_request_latency_seconds_count{model_name=~\"$sglang_model_name\", replica=~\"$sglang_replica\"}[$__rate_interval]))",
+                        "expr": "sum by (replica) (rate({__name__=~\"sglang[:_]e2e_request_latency_seconds_sum\", model_name=~\"$sglang_model_name\", replica=~\"$sglang_replica\"}[$__rate_interval])) / sum by (replica) (rate({__name__=~\"sglang[:_]e2e_request_latency_seconds_count\", model_name=~\"$sglang_model_name\", replica=~\"$sglang_replica\"}[$__rate_interval]))",
                         "interval": "",
                         "legendFormat": "replica {{replica}} Avg",
                         "queryType": "randomWalk",
@@ -13738,7 +13738,7 @@
                       "spec": {
                         "editorMode": "builder",
                         "exemplar": true,
-                        "expr": "sum by (le, replica) (increase(sglang:e2e_request_latency_seconds_bucket{model_name=~\"$sglang_model_name\", replica=~\"$sglang_replica\"}[$__rate_interval]))",
+                        "expr": "sum by (le, replica) (increase({__name__=~\"sglang[:_]e2e_request_latency_seconds_bucket\", model_name=~\"$sglang_model_name\", replica=~\"$sglang_replica\"}[$__rate_interval]))",
                         "interval": "",
                         "legendFormat": "replica {{replica}} le {{le}}",
                         "queryType": "randomWalk",
@@ -13848,7 +13848,7 @@
                       "spec": {
                         "editorMode": "code",
                         "exemplar": true,
-                        "expr": "histogram_quantile(0.99, sum by (le, replica) (rate(sglang:time_to_first_token_seconds_bucket{model_name=~\"$sglang_model_name\", replica=~\"$sglang_replica\"}[$__rate_interval])))",
+                        "expr": "histogram_quantile(0.99, sum by (le, replica) (rate({__name__=~\"sglang[:_]time_to_first_token_seconds_bucket\", model_name=~\"$sglang_model_name\", replica=~\"$sglang_replica\"}[$__rate_interval])))",
                         "interval": "",
                         "legendFormat": "replica {{replica}} P99",
                         "queryType": "randomWalk",
@@ -13869,7 +13869,7 @@
                       "spec": {
                         "editorMode": "code",
                         "exemplar": true,
-                        "expr": "histogram_quantile(0.9, sum by (le, replica) (rate(sglang:time_to_first_token_seconds_bucket{model_name=~\"$sglang_model_name\", replica=~\"$sglang_replica\"}[$__rate_interval])))",
+                        "expr": "histogram_quantile(0.9, sum by (le, replica) (rate({__name__=~\"sglang[:_]time_to_first_token_seconds_bucket\", model_name=~\"$sglang_model_name\", replica=~\"$sglang_replica\"}[$__rate_interval])))",
                         "interval": "",
                         "legendFormat": "replica {{replica}} P90",
                         "queryType": "randomWalk",
@@ -13890,7 +13890,7 @@
                       "spec": {
                         "editorMode": "code",
                         "exemplar": true,
-                        "expr": "histogram_quantile(0.5, sum by (le, replica) (rate(sglang:time_to_first_token_seconds_bucket{model_name=~\"$sglang_model_name\", replica=~\"$sglang_replica\"}[$__rate_interval])))",
+                        "expr": "histogram_quantile(0.5, sum by (le, replica) (rate({__name__=~\"sglang[:_]time_to_first_token_seconds_bucket\", model_name=~\"$sglang_model_name\", replica=~\"$sglang_replica\"}[$__rate_interval])))",
                         "interval": "",
                         "legendFormat": "replica {{replica}} P50",
                         "queryType": "randomWalk",
@@ -13911,7 +13911,7 @@
                       "spec": {
                         "editorMode": "code",
                         "exemplar": true,
-                        "expr": "sum by (replica) (rate(sglang:time_to_first_token_seconds_sum{model_name=~\"$sglang_model_name\", replica=~\"$sglang_replica\"}[$__rate_interval])) / sum by (replica) (rate(sglang:time_to_first_token_seconds_count{model_name=~\"$sglang_model_name\", replica=~\"$sglang_replica\"}[$__rate_interval]))",
+                        "expr": "sum by (replica) (rate({__name__=~\"sglang[:_]time_to_first_token_seconds_sum\", model_name=~\"$sglang_model_name\", replica=~\"$sglang_replica\"}[$__rate_interval])) / sum by (replica) (rate({__name__=~\"sglang[:_]time_to_first_token_seconds_count\", model_name=~\"$sglang_model_name\", replica=~\"$sglang_replica\"}[$__rate_interval]))",
                         "interval": "",
                         "legendFormat": "replica {{replica}} Avg",
                         "queryType": "randomWalk",
@@ -14127,7 +14127,7 @@
                       "spec": {
                         "editorMode": "builder",
                         "exemplar": false,
-                        "expr": "sum by (le, replica) (increase(sglang:time_to_first_token_seconds_bucket{model_name=~\"$sglang_model_name\", replica=~\"$sglang_replica\"}[$__rate_interval]))",
+                        "expr": "sum by (le, replica) (increase({__name__=~\"sglang[:_]time_to_first_token_seconds_bucket\", model_name=~\"$sglang_model_name\", replica=~\"$sglang_replica\"}[$__rate_interval]))",
                         "interval": "",
                         "legendFormat": "replica {{replica}} le {{le}}",
                         "queryType": "randomWalk",
@@ -14237,7 +14237,7 @@
                       "spec": {
                         "editorMode": "code",
                         "exemplar": true,
-                        "expr": "sglang:num_running_reqs{model_name=~\"$sglang_model_name\", replica=~\"$sglang_replica\"}",
+                        "expr": "{__name__=~\"sglang[:_]num_running_reqs\", model_name=~\"$sglang_model_name\", replica=~\"$sglang_replica\"}",
                         "interval": "",
                         "legendFormat": "replica {{replica}}",
                         "queryType": "randomWalk",
@@ -14453,7 +14453,7 @@
                       "spec": {
                         "editorMode": "code",
                         "exemplar": true,
-                        "expr": "sglang:gen_throughput{model_name=~\"$sglang_model_name\", replica=~\"$sglang_replica\"}",
+                        "expr": "{__name__=~\"sglang[:_]gen_throughput\", model_name=~\"$sglang_model_name\", replica=~\"$sglang_replica\"}",
                         "interval": "",
                         "legendFormat": "replica {{replica}}",
                         "queryType": "randomWalk",
@@ -14669,7 +14669,7 @@
                       "spec": {
                         "editorMode": "code",
                         "exemplar": true,
-                        "expr": "sglang:cache_hit_rate{model_name=~\"$sglang_model_name\", replica=~\"$sglang_replica\"}",
+                        "expr": "{__name__=~\"sglang[:_]cache_hit_rate\", model_name=~\"$sglang_model_name\", replica=~\"$sglang_replica\"}",
                         "interval": "",
                         "legendFormat": "replica {{replica}}",
                         "queryType": "randomWalk",
@@ -14885,7 +14885,7 @@
                       "spec": {
                         "editorMode": "code",
                         "exemplar": true,
-                        "expr": "sglang:num_queue_reqs{model_name=~\"$sglang_model_name\", replica=~\"$sglang_replica\"}",
+                        "expr": "{__name__=~\"sglang[:_]num_queue_reqs\", model_name=~\"$sglang_model_name\", replica=~\"$sglang_replica\"}",
                         "interval": "",
                         "legendFormat": "replica {{replica}}",
                         "queryType": "randomWalk",
@@ -17125,14 +17125,14 @@
               "name": "${datasource}"
             },
             "spec": {
-              "query": "label_values(sglang:gen_throughput, model_name)",
+              "query": "label_values({__name__=~\"sglang[:_]gen_throughput\"}, model_name)",
               "refId": "StandardVariableQuery"
             }
           },
           "regex": "",
           "regexApplyTo": "value",
           "sort": "disabled",
-          "definition": "label_values(sglang:gen_throughput, model_name)",
+          "definition": "label_values({__name__=~\"sglang[:_]gen_throughput\"}, model_name)",
           "options": [],
           "multi": false,
           "includeAll": true,
@@ -17161,14 +17161,14 @@
               "name": "${datasource}"
             },
             "spec": {
-              "query": "label_values(sglang:gen_throughput, replica)",
+              "query": "label_values({__name__=~\"sglang[:_]gen_throughput\"}, replica)",
               "refId": "StandardVariableQuery"
             }
           },
           "regex": "",
           "regexApplyTo": "value",
           "sort": "disabled",
-          "definition": "label_values(sglang:gen_throughput, replica)",
+          "definition": "label_values({__name__=~\"sglang[:_]gen_throughput\"}, replica)",
           "options": [],
           "multi": false,
           "includeAll": true,


### PR DESCRIPTION
## Problem

Every panel in `verl_tainer_v1_with_sglang_engine` renders **No data** against a live SGLang rollout, even though Prometheus is scraping the SGLang targets successfully.

The dashboard queries metrics as `sglang:e2e_request_latency_seconds_bucket`, but the series are stored as `sglang_e2e_request_latency_seconds_bucket`.

## Root cause

SGLang 0.5.16 answers `/metrics` with:

```
content-type: application/openmetrics-text; version=1.0.0; charset=utf-8; escaping=underscores
```

The payload itself uses colon-prefixed names (`sglang:cache_hit_rate`, ...), but the negotiated `escaping=underscores` scheme only permits `[a-zA-Z0-9_]`. Colons are outside that set, so Prometheus escapes them to underscores before the sample is stored.

This is observable as a mismatch between what Prometheus parsed and what it stored, on the same target:

```
# parsed names keep the colon
$ curl -sG localhost:9090/api/v1/targets/metadata \
    --data-urlencode 'match_target={job="sglang"}' | jq -r '.data[].metric' | grep e2e
sglang:e2e_request_latency_seconds

# stored names do not — 0 of 194 metric names contain a colon
$ curl -s localhost:9090/api/v1/label/__name__/values | jq '[.data[] | select(contains(":"))] | length'
0
$ curl -s localhost:9090/api/v1/label/__name__/values | jq -r '.data[]' | grep e2e
sglang_e2e_request_latency_seconds_bucket
```

Environment: SGLang 0.5.16, Prometheus 2.54.1 (the version installed by `rl-insight server install`), rl-insight 0.3.0, verl with `rollout.name=sglang`.

## Fix

Select through `__name__` with a character class that accepts both spellings:

```promql
rate({__name__=~"sglang[:_]e2e_request_latency_seconds_bucket", model_name=~"$sglang_model_name"}[$__rate_interval])
```

I deliberately avoided rewriting `sglang:` to `sglang_`, because that would break deployments whose exporter or scrape negotiation preserves the colon form. The character class works in both.

The four `label_values()` template queries need the same change. Without them `$sglang_model_name` and `$sglang_replica` resolve to nothing and every panel stays empty even after the expressions are corrected.

## Verification

Against a live 4-replica SGLang rollout, after the change:

- `$sglang_model_name` resolves to `["DeepSeek-V4-Flash-FP8"]`, `$sglang_replica` to `["0","1","2","3"]`
- the latency ratio panel returns one series per replica
- `histogram_quantile(0.95, ...)` over the bucket selector returns a value

Only query strings changed; no panel layout, title, or datasource was touched. The file remains valid JSON.

- After fix

<img width="1409" height="539" alt="image" src="https://github.com/user-attachments/assets/78decdf5-6bf0-440e-967f-acfab3295501" />
