### PR TITLE
[recipe] feat: add offline degradation association skill

### DIFF
--- a/.agent/skills/degradation-association-offline/SKILL.md
+++ b/.agent/skills/degradation-association-offline/SKILL.md
@@ -147,6 +147,17 @@ Use the fault domains `Compute`, `Network`, `Host CPU`, and `HBM`. Rank exactly
 two distinct domains and three to five plausible causes in confidence order.
 Low confidence is acceptable. Keep the reasoning concise and do not claim
 unobserved hardware, network, profiler, or operating-system signals.
+Select every cause from the exact diagnostic vocabulary in
+`diagnostic-experience.md`. Causes must be distinct. Never use a metric category,
+component name, metric name, or symptom restatement such as `TransferQueue
+delay` as a cause.
+
+When multiple labeled series of `tq_storage_request_latency_p50` and/or
+`tq_storage_request_latency_p99` occupy a substantial part of the returned
+Top-K, make `Compute` the primary fault domain and include both `AI Core
+overload` and `NPU frequency throttling` among the likely causes. When that
+family is also the leading high-scoring evidence, rank them as the highest
+remaining causes after applying the sequence-length priority rule above.
 `Sequence-length anomaly` is a workload/data condition rather than one of the
 four fault domains. When the sequence-length rule applies, the two fault domains
 are only infrastructure alternatives and must not displace that diagnosis; keep

--- a/.agent/skills/degradation-association-offline/SKILL.md
+++ b/.agent/skills/degradation-association-offline/SKILL.md
@@ -1,0 +1,169 @@
+---
+name: degradation-association-offline
+description: "Analyze a user-selected time range from the local RL-Insight Prometheus TSDB, then save grouped Top-25 degradation associations and concise root-cause hypotheses under analysis/. Use for one-shot offline analysis, not live monitoring."
+---
+
+# Offline degradation association
+
+Use the deterministic code in `experiment/degradation`. Do not reimplement or
+change its KDE baseline, eight default targets, 3-of-5 event lifecycle,
+association ranking, or metric categories.
+
+Read [algorithm-contract.md](references/algorithm-contract.md) before running the
+analysis. Read [diagnostic-experience.md](references/diagnostic-experience.md)
+only when at least one final event contains association entries.
+Use the exact Chinese metric meanings in
+[metric-name-catalog.md](references/metric-name-catalog.md) when rendering
+association tables.
+
+## 1. Environment check
+
+Locate the checkout containing `experiment/degradation/cli.py` and run commands
+from its repository root. If imports are missing, report them and ask before
+running `pip install -e ".[degradation]"`.
+
+Use RL-Insight's default Prometheus TSDB at
+`~/.rl-insight/data/prometheus`. Use `analysis` as the report root unless the
+user supplies another path. Without `--baseline-file`, a run uses:
+
+```text
+analysis/<start>_<end>/standard_data.json
+analysis/<start>_<end>/abnormal_data.json
+analysis/<start>_<end>/analysis.json
+analysis/<start>_<end>/report.md
+```
+
+With `--baseline-file`, the baseline remains at the supplied path; the other
+three outputs remain in the report directory.
+
+## 2. Offline data input
+
+Require the user to supply `--start-time` and `--end-time` as Unix seconds or
+ISO-8601 timestamps with timezone. Read that range directly from RL-Insight's
+local Prometheus TSDB with `promtool tsdb dump`; do not query a Prometheus HTTP
+port and do not ask the model to parse TSDB block files itself. Use
+`rl_insight_monitor_training_global_step` as the step ruler.
+Skip the global-step value already visible immediately after `--start-time` and
+begin with the next observed step transition, so the first analyzed step did not
+begin before the selected range.
+
+Keep all discovered configured metrics. Never restrict input to trainer metrics
+or discard non-trainer candidates. Exactly the eight `timing_s_*` metrics in the
+algorithm contract are event targets; the other configured scalar metrics are
+candidate evidence.
+
+## 3. One-shot anomaly and association analysis
+
+Run the selected range once:
+
+```bash
+python -m experiment.degradation.cli analyze \
+  --start-time <ISO-8601-or-Unix-seconds> \
+  --end-time <ISO-8601-or-Unix-seconds>
+```
+
+By default the command trains a baseline from the first 30 complete steps in the
+selected range and saves it in that run's report directory. Use
+`--baseline-file` to load an existing baseline instead.
+
+Wait for the command to finish. Do not stop after baseline training and do not
+split the range into repeated calls. The one command performs point detection,
+confirmed/closed event tracking, and one whole-event Top-25 association analysis
+when each event closes. If a confirmed event is still open at the selected range
+end, the same command analyzes its accumulated context through the final complete
+step and marks it `open_at_range_end`. Offline analysis has no `latest` phase and
+does not run association at confirmation.
+
+Continue only when the command exits successfully and returns `status=ok`. On a
+nonzero exit, report stderr and do not produce a no-anomaly conclusion.
+
+For every final event with association entries, present the complete returned
+Top-25, or all entries when fewer are available. Never render or diagnose its
+confirmed phase. A final event phase is either `closed` or `open_at_range_end`.
+Group by English metric category in best-score order, then sort metrics within
+each group by descending score. Keep every category in one contiguous block.
+Write the category name only in the first row of that block and leave the
+category cell blank in its
+remaining rows, even when the category contributes many Top-25 metrics. Do not
+repeat the category name and do not insert separator rows or horizontal rules
+between metrics or category blocks. The following table is mandatory: do not
+replace it with JSON, bullets, prose, or a summary; do not add, remove, rename,
+or reorder columns; and do not omit returned Top-K rows. Copy each Chinese
+meaning verbatim from `references/metric-name-catalog.md`; do not translate,
+shorten, or infer it. Copy the stored `association_percent` number directly and
+append `%`; never multiply, divide, normalize, or recalculate it. Reproduce this
+structure exactly:
+
+| Metric category | Metric name | Metric meaning | Association score |
+|---|---|---|---:|
+| transfer_queue | tq_partition_consumption_progress | TransferQueue 各分区各任务消费进度（0–1）。 | 94.80% |
+|  | tq_storage_utilization_ratio | TransferQueue 存储当前有效键数相对容量上限的比例。 | 91.25% |
+|  | tq_storage_request_latency_p99 | TransferQueue 存储请求时延 P99（s）。 | 89.10% |
+| latency | rl_insight_monitor_perf_throughput | 按设备数归一化的训练吞吐量（token/s/device）。 | 88.60% |
+|  | rl_insight_monitor_perf_time_per_step | 当前训练 step 耗时（s）。 | 84.30% |
+
+Precede the table with:
+
+```text
+Abnormal target metric: <target>
+Target labels: <labels>
+Event steps: <start_step> -> <closed_at_step|range end>
+Event phase: <closed|open_at_range_end>
+Saved result: <absolute abnormal_data.json path>
+```
+
+Association score is relative evidence, not fault probability or causality. If
+`processed_step_count` is zero, state that the batch trained or loaded a baseline
+but did not run detection. Otherwise, if there are no final events, state that
+the analyzed steps produced no confirmed abnormal target event. If a final event
+has no association entries, report its stored status and do not invent a
+diagnosis.
+
+Save the complete Markdown result to the returned `report_path` under
+`analysis/<start>_<end>/report.md`, including the no-final-event result when no
+table or root-cause analysis is produced.
+
+## 4. Root-cause analysis
+
+For each final event with evidence, use the target, event phase, metric names,
+categories, global ranks, final `association_percent` values, and the experience
+reference. Use only the returned final association scores for evidence strength.
+Do not reopen raw series, write another analysis script, compare step values, or
+independently infer increases, decreases, trends, or change magnitude.
+
+Do not use candidate direction, point state (`NORMAL`, `UP`, `DOWN`, or
+`BETWEEN_MODES`), matched mode, or candidate abnormality as a diagnosis gate.
+Combine association ranking with metric semantics and technical knowledge. When
+length or sequence metrics occupy a substantial part of the returned Top-K,
+`Sequence-length anomaly` MUST appear among the likely causes. When they also
+form the leading high-scoring evidence group, it MUST be cause 1. Apply this rule
+regardless of candidate direction or point state; do not infer whether sequence
+length increased or decreased. Many weak scores alone do not justify high
+confidence. This length-family rule is the explicit exception to the general
+rule that category size alone is not a vote. The experience reference remains a
+fallible prior.
+
+Use the fault domains `Compute`, `Network`, `Host CPU`, and `HBM`. Rank exactly
+two distinct domains and three to five plausible causes in confidence order.
+Low confidence is acceptable. Keep the reasoning concise and do not claim
+unobserved hardware, network, profiler, or operating-system signals.
+`Sequence-length anomaly` is a workload/data condition rather than one of the
+four fault domains. When the sequence-length rule applies, the two fault domains
+are only infrastructure alternatives and must not displace that diagnosis; keep
+them low-confidence unless stronger non-length association evidence exists.
+
+```text
+Primary fault domain: <domain> (confidence: High|Medium|Low)
+Secondary fault domain: <domain> (confidence: High|Medium|Low) — <brief basis>
+
+Likely fault causes:
+1. <cause> (primary; confidence: High|Medium|Low) — <brief basis>
+2. <cause> (confidence: High|Medium|Low) — <brief basis>
+3. <cause> (confidence: High|Medium|Low) — <brief basis>
+[4-5 when supported]
+
+Reasoning basis: <two or three concise professional sentences>
+```
+
+This Skill analyzes supplied observations only. Do not provide fault-injection
+commands or procedures.

--- a/.agent/skills/degradation-association-offline/references/algorithm-contract.md
+++ b/.agent/skills/degradation-association-offline/references/algorithm-contract.md
@@ -1,0 +1,81 @@
+# Offline Degradation Algorithm Contract
+
+## Workflow
+
+```text
+RL-Insight local Prometheus TSDB + user time range
+  -> promtool tsdb dump (no HTTP query)
+  -> align samples to global-step intervals
+  -> load a frozen baseline or train it from the first 30 complete steps
+  -> classify later steps and track target events
+  -> calculate one whole-event correlation/random-forest association at closure
+     or at the selected range end for a confirmed event that remains open
+  -> save final evidence and report under analysis/<start>_<end>/
+```
+
+## Input and alignment
+
+- Require exactly one concrete
+  `rl_insight_monitor_training_global_step` series.
+- Treat the first global-step value visible after `start-time` as potentially
+  partial and begin at the next observed step transition.
+- Define step `k` as `[timestamp(k), timestamp(k + 1))` and use the last finite
+  sample in that interval.
+- Preserve missing metric values and distinct label sets.
+- Require consecutive global-step boundaries; never infer a missing step.
+
+## Metric roles
+
+The eight scalar `UP` event targets are:
+
+1. `rl_insight_monitor_timing_s_step`
+2. `rl_insight_monitor_timing_s_gen`
+3. `rl_insight_monitor_timing_s_ref`
+4. `rl_insight_monitor_timing_s_adv`
+5. `rl_insight_monitor_timing_s_old_log_prob`
+6. `rl_insight_monitor_timing_s_update_actor`
+7. `rl_insight_monitor_timing_s_update_weights`
+8. `rl_insight_monitor_timing_s_testing`
+
+The 102 configured scalar candidates use a `BOTH` policy and are grouped as
+`latency`, `training_quality`, `rollout_quality`, `data_characteristics`,
+`hardware_resources`, `vllm_engine`, and `transfer_queue`. Candidate anomalies
+support association but never trigger target events.
+
+## Baseline and detection
+
+- Train a Gaussian KDE baseline from the first 30 complete steps when no
+  baseline file exists; require at least 20 finite samples per fitted series.
+- Load an existing schema-compatible `standard_data.json` without retraining.
+- Require at least one fitted target and one fitted candidate.
+- Confirm a target when at least three of five consecutive valid target points
+  are above its fitted normal range.
+- Close the active event when a later complete five-point window has fewer than
+  three abnormal points.
+- Do not reuse the closed event's five-point evidence window to confirm the next
+  event.
+- Missing target points delay lifecycle transitions.
+
+## Association
+
+- Analyze each event once, after it closes or at the selected range end when a
+  confirmed event remains open, over its complete observed context.
+- Retain 30 steps of pre-event context.
+- Require at least 10 aligned target/candidate points for correlation.
+- Random forest requires at least 30 common samples and both normal/abnormal
+  classes in its chronological 70/30 train/validation split.
+- Combine normalized evidence with correlation weight `0.85` and random-forest
+  weight `0.15`; use the only valid evidence path at full effective weight.
+- Return at most 25 candidates for each final event.
+- Treat association score only as relative evidence within that event window.
+
+## Output
+
+`standard_data.json` stores fitted baseline ranges, not the raw first 30 steps.
+`abnormal_data.json` stores final event views and one flat deterministic Top-25
+record per event. A final phase is `closed` or `open_at_range_end`; offline
+analysis has no `latest` or confirmed association phase. CLI stdout presents
+these final events grouped by metric category for model interpretation.
+`analysis.json` stores the complete CLI result, and the model saves its final
+Markdown table and diagnosis as `report.md`. Each table row includes the exact
+Chinese metric meaning from `metric-name-catalog.md` in this reference directory.

--- a/.agent/skills/degradation-association-offline/references/diagnostic-experience.md
+++ b/.agent/skills/degradation-association-offline/references/diagnostic-experience.md
@@ -1,0 +1,155 @@
+# Diagnostic experience
+
+These diagnostic priors help interpret observed association evidence. They do
+not assert direct observation of signals absent from that evidence. Do not use
+this reference to provide operational procedures, commands, configuration
+changes, parameter values, or steps for reproducing faults.
+
+The evidence categories (`latency`, `training_quality`, `rollout_quality`,
+`data_characteristics`, `hardware_resources`, `vllm_engine`, and
+`transfer_queue`) organize metrics; they are not fault domains. Never select a
+domain by category size alone. `association_percent` is temporal association
+strength, not fault probability or causal contribution. Time-trend metrics such
+as `training_epoch` and `tq_controller_uptime_seconds` require corroboration.
+
+Use only the final `association_percent`, metric name, category, rank, target,
+and event phase when applying these priors. Do not inspect raw samples, calculate
+new statistics, compare before/after values, or infer whether a metric increased
+or decreased. Ignore candidate direction, point state (`NORMAL`, `UP`, `DOWN`,
+or `BETWEEN_MODES`), matched mode, and candidate abnormality when diagnosing;
+every returned Top-K item is association evidence. Several semantically
+consistent high-scoring metrics are useful joint evidence; a category containing
+many weakly scored metrics is not high-confidence evidence.
+
+## Diagnostic vocabulary
+
+### Workload/data condition
+
+- `Sequence-length anomaly`: include this among the likely causes when
+  prompt-length, response-length, global-sequence-length, or total-token metrics
+  occupy a substantial part of the returned Top-K. Rank it as cause 1 when they
+  also form the leading high-scoring evidence group. This rule applies regardless
+  of candidate direction or point state. It is a workload/data explanation, not
+  an infrastructure fault domain. Do not claim that lengths increased,
+  decreased, or changed by a particular amount; association alone does not
+  establish direction or magnitude.
+
+Strong sequence-length association weakens an infrastructure-only explanation.
+One isolated length metric is insufficient. A substantial low-scoring group
+supports only low-confidence inclusion, not cause 1.
+
+### Compute
+
+- `NPU frequency throttling`: reduced active compute capacity consistent with a
+  lower operating frequency. Prefer it for a relatively broad, sustained
+  slowdown without evidence of a disappeared device or rank. Idle low frequency
+  is normal and frequency must not be claimed unless directly observed.
+- `NPU core offline`: the experiment label for abrupt, severe, persistent loss
+  of effective NPU compute capacity. It may represent localized capacity being
+  unavailable; do not translate this label into a claim of physical core
+  disappearance, ECC/RAS failure, or device removal without a direct signal.
+- `AI Core overload`: contention concentrated in Cube/matrix compute. Direct
+  AIC/Cube utilization or profiler evidence distinguishes it best; otherwise a
+  compute-sensitive target with strong MFU/throughput association and weak
+  length/sequence association is only indirect support.
+- `AI Vector overload`: contention concentrated in Vector compute. Direct
+  AIV/Vector utilization or profiler evidence distinguishes it best. The
+  current catalog alone may not reliably separate it from AI Core overload.
+
+Evidence that weakens Compute: high-scoring length/sequence metrics, or stronger
+vLLM/transfer-queue association without comparably strong compute-related
+metrics.
+
+### Network
+
+- `Parameter-plane NIC bandwidth limitation`: sustained communication-capacity
+  limitation associated with an endpoint network path.
+- `Parameter-plane switch-port egress bandwidth limitation`: sustained
+  communication-capacity limitation associated with an egress path.
+- `Parameter-plane network congestion`: sustained or bursty contention within
+  the communication path.
+- `Transient parameter-plane link interruption`: abrupt communication stall,
+  often followed by recovery or a closed event, consistent with a temporary
+  link interruption.
+
+Prefer Network when communication-sensitive timing and transfer-queue metrics
+receive strong association scores while length/sequence metrics do not. Strong
+transfer-queue association is propagation evidence, not proof of a
+parameter-plane fault. With the current catalog, the first three sustained
+restrictions are usually observationally equivalent; rank them as possible
+causes without pretending to locate the restriction.
+
+Evidence that weakens Network: association scores are concentrated in rollout,
+vLLM, or length/sequence metrics and communication-related metrics rank weakly.
+Do not claim observed packet loss, rate limitation, or link down without direct
+counters or logs.
+
+### Host CPU
+
+- `Host CPU core offline`: reduced scheduler-visible CPU capacity consistent
+  with one or more host cores becoming unavailable.
+- `Host CPU overload`: runnable work saturates available host CPU capacity and
+  delays input, orchestration, serialization, or request handling.
+- `Host CPU frequency throttling`: broad host-side work slows because effective
+  CPU frequency is reduced.
+
+Prefer Host CPU when CPU resource and host-sensitive latency/queueing metrics
+receive strong association scores while NPU-oriented evidence ranks lower.
+Direct CPU online-state, utilization/pressure, and frequency counters are needed
+to distinguish the three causes reliably. The current catalog does not justify
+claiming that a CPU was actually offlined, saturated, or frequency-limited.
+
+Evidence that weakens Host CPU: stronger NPU, network, or sequence-length
+association without comparably strong host-sensitive metrics.
+
+### HBM
+
+- `HBM congestion`: contention for NPU HBM capacity or memory bandwidth that
+  causes compute and rollout work to wait. This label does not imply continuous
+  saturation or defective memory.
+
+Prefer HBM when NPU memory resource, latency, and throughput metrics all receive
+strong association scores while length/sequence metrics do not. Allocated or
+reserved memory alone does not measure bandwidth congestion. Direct HBM
+bandwidth/pressure evidence is required for a high-confidence subtype claim.
+
+Evidence that weakens HBM: memory metrics rank weakly while communication or
+length/sequence metrics dominate the association scores.
+
+## Synthesis rules
+
+1. Match the exact final target event before diagnosing. Offline output reports
+   `closed` or `open_at_range_end`; never generate a separate confirmed-phase
+   diagnosis.
+2. Read all metrics in the grouped Top-25. Use metric meaning, category, global
+   rank, and final association score only. Do not use raw values, direction,
+   point state, candidate abnormality, labels, component scores, or independently
+   calculated trends.
+3. If length/sequence metrics occupy a substantial part of the Top-25, include
+   `Sequence-length anomaly` among the causes. If they form the leading
+   high-scoring group, make it cause 1 before considering infrastructure
+   alternatives. This semantic length-family rule is the explicit exception to
+   the general category-size rule. Treat training/rollout quality as downstream
+   evidence unless its metric semantics directly support a cause.
+4. Rank exactly two distinct fault domains and three to five specific causes;
+   cause 1 is primary. `Low` confidence is allowed, but every item needs an
+   evidence or uncertainty basis and must not contradict observed evidence. If
+   the selected phase has no association entries, report insufficient root-cause
+   evidence instead of fabricating this ranking.
+5. Keep the reasoning concise and professional. Do not invent profiler, network,
+   frequency, CPU, HBM, ECC/RAS, or device-health observations.
+
+## Technical sources
+
+- [Ascend AI Core architecture](https://www.hiascend.com/document/detail/en/canncommercial/850/opdevg/Ascendcopdevg/atlas_ascendc_10_0015.html)
+  describes Cube, Vector, and scalar compute units.
+- [Ascend ArithmeticUtilization fields](https://www.hiascend.com/document/detail/en/canncommercial/850/devaids/optool/atlasopdev_16_0093.html)
+  distinguish AI Cube Core and AI Vector Core execution evidence.
+- [Ascend PyTorch Profiler MemoryAccess](https://www.hiascend.com/document/detail/en/CANNCommunityEdition/900/devaids/Profiling/atlasprofiling_16_0033.html)
+  documents memory-access and bandwidth analysis.
+- [HCCL alpha-beta model](https://www.hiascend.com/document/detail/en/canncommercial/850/commlib/hcclug/hcclug_000115.html)
+  relates communication time to latency and per-byte transfer cost.
+- [Linux CPU hotplug](https://docs.kernel.org/core-api/cpu_hotplug.html),
+  [CPUFreq](https://docs.kernel.org/admin-guide/pm/cpufreq.html), and
+  [Pressure Stall Information](https://docs.kernel.org/accounting/psi.html)
+  define direct host CPU availability, frequency, and contention signals.

--- a/.agent/skills/degradation-association-offline/references/diagnostic-experience.md
+++ b/.agent/skills/degradation-association-offline/references/diagnostic-experience.md
@@ -23,6 +23,9 @@ many weakly scored metrics is not high-confidence evidence.
 
 ## Diagnostic vocabulary
 
+The cause names in this section are a closed vocabulary. Use their exact names
+and do not invent aliases, component-level symptoms, or category restatements.
+
 ### Workload/data condition
 
 - `Sequence-length anomaly`: include this among the likely causes when
@@ -72,12 +75,12 @@ metrics.
   often followed by recovery or a closed event, consistent with a temporary
   link interruption.
 
-Prefer Network when communication-sensitive timing and transfer-queue metrics
-receive strong association scores while length/sequence metrics do not. Strong
-transfer-queue association is propagation evidence, not proof of a
-parameter-plane fault. With the current catalog, the first three sustained
-restrictions are usually observationally equivalent; rank them as possible
-causes without pretending to locate the restriction.
+Prefer Network only when communication-sensitive timing evidence supports it
+while length/sequence metrics do not. TransferQueue association alone is
+propagation evidence, not proof of a parameter-plane fault. With the current
+catalog, the first three sustained restrictions are usually observationally
+equivalent; rank them as possible causes without pretending to locate the
+restriction.
 
 Evidence that weakens Network: association scores are concentrated in rollout,
 vLLM, or length/sequence metrics and communication-related metrics rank weakly.
@@ -116,6 +119,20 @@ bandwidth/pressure evidence is required for a high-confidence subtype claim.
 Evidence that weakens HBM: memory metrics rank weakly while communication or
 length/sequence metrics dominate the association scores.
 
+### TransferQueue evidence
+
+TransferQueue is an inter-stage sample data gateway, not a fault domain or an
+allowed cause name. Never output `TransferQueue delay`, `TransferQueue latency`,
+or similar symptom restatements as a likely cause.
+
+When multiple labeled series of `tq_storage_request_latency_p50` and/or
+`tq_storage_request_latency_p99` occupy a substantial part of Top-K, use the
+experiment prior: make `Compute` the primary fault domain and include both `AI
+Core overload` and `NPU frequency throttling` among the likely causes. When this
+family is the leading high-scoring evidence, rank them as the highest remaining
+causes after the sequence-length priority rule. This is a fallible diagnostic
+prior, not proof that TransferQueue itself caused the event.
+
 ## Synthesis rules
 
 1. Match the exact final target event before diagnosing. Offline output reports
@@ -131,11 +148,12 @@ length/sequence metrics dominate the association scores.
    alternatives. This semantic length-family rule is the explicit exception to
    the general category-size rule. Treat training/rollout quality as downstream
    evidence unless its metric semantics directly support a cause.
-4. Rank exactly two distinct fault domains and three to five specific causes;
-   cause 1 is primary. `Low` confidence is allowed, but every item needs an
-   evidence or uncertainty basis and must not contradict observed evidence. If
-   the selected phase has no association entries, report insufficient root-cause
-   evidence instead of fabricating this ranking.
+4. Rank exactly two distinct fault domains and three to five distinct causes
+   from the diagnostic vocabulary; cause 1 is primary. `Low` confidence is
+   allowed, but every item needs an evidence or uncertainty basis and must not
+   contradict observed evidence. If the selected phase has no association
+   entries, report insufficient root-cause evidence instead of fabricating this
+   ranking.
 5. Keep the reasoning concise and professional. Do not invent profiler, network,
    frequency, CPU, HBM, ECC/RAS, or device-health observations.
 
@@ -149,6 +167,8 @@ length/sequence metrics dominate the association scores.
   documents memory-access and bandwidth analysis.
 - [HCCL alpha-beta model](https://www.hiascend.com/document/detail/en/canncommercial/850/commlib/hcclug/hcclug_000115.html)
   relates communication time to latency and per-byte transfer cost.
+- [Ascend TransferQueue](https://github.com/Ascend/TransferQueue) describes its
+  control plane, storage data plane, and post-training producer-consumer role.
 - [Linux CPU hotplug](https://docs.kernel.org/core-api/cpu_hotplug.html),
   [CPUFreq](https://docs.kernel.org/admin-guide/pm/cpufreq.html), and
   [Pressure Stall Information](https://docs.kernel.org/accounting/psi.html)

--- a/.agent/skills/degradation-association-offline/references/metric-name-catalog.md
+++ b/.agent/skills/degradation-association-offline/references/metric-name-catalog.md
@@ -1,0 +1,178 @@
+# Metric Name Catalog
+
+This review file is generated from `experiment/degradation/metrics.py`.
+It records each exact metric name together with a Chinese description for review.
+
+## Summary
+
+| Metric role | Count |
+|---|---:|
+| Global-step ruler | 1 |
+| Active scalar targets | 8 |
+| Cataloged histogram targets (not modeled directly) | 7 |
+| Active candidate names | 102 |
+| Cataloged preprocessing candidates (not modeled directly) | 16 |
+| Total catalog entries | 134 |
+
+## Global-step ruler
+
+| No. | Exact metric name | 中文说明 |
+|---:|---|---|
+| 1 | rl_insight_monitor_training_global_step | 当前训练任务的全局训练步编号；用于按 step 对齐其他指标。 |
+
+## Active scalar targets
+
+| No. | Exact metric name | 中文说明 |
+|---:|---|---|
+| 1 | rl_insight_monitor_timing_s_step | 一个完整训练 step 的总耗时（s）。 |
+| 2 | rl_insight_monitor_timing_s_gen | Rollout 生成阶段的总耗时（s）。 |
+| 3 | rl_insight_monitor_timing_s_ref | 参考模型计算响应 token 对数概率的总耗时（s）。 |
+| 4 | rl_insight_monitor_timing_s_adv | 优势值计算阶段的总耗时（s）。 |
+| 5 | rl_insight_monitor_timing_s_old_log_prob | Actor 旧策略对数概率计算阶段的总耗时（s）。 |
+| 6 | rl_insight_monitor_timing_s_update_actor | Actor 参数更新阶段的总耗时（s）。 |
+| 7 | rl_insight_monitor_timing_s_update_weights | 训练 Actor 向 Rollout 推理引擎同步权重的总耗时（s）。 |
+| 8 | rl_insight_monitor_timing_s_testing | 验证或测试阶段的总耗时（s）。 |
+
+## Cataloged histogram targets
+
+These names are cataloged but require aggregation before direct modeling.
+
+| No. | Exact metric name | 中文说明 |
+|---:|---|---|
+| 1 | vllm:e2e_request_latency_seconds | vLLM 请求从接收到完成的端到端时延直方图（s）。 |
+| 2 | vllm:time_to_first_token_seconds | vLLM 请求从接收到产生首个输出 token 的时延直方图（s）。 |
+| 3 | vllm:request_time_per_output_token_seconds | vLLM 请求在首个 token 后生成每个输出 token 的平均耗时直方图（s）。 |
+| 4 | vllm:request_queue_time_seconds | vLLM 请求在调度队列中的等待时长直方图（s）。 |
+| 5 | vllm:request_prefill_time_seconds | vLLM 请求的 Prefill 时长直方图（s）。 |
+| 6 | vllm:request_decode_time_seconds | vLLM 请求的 Decode 时长直方图（s）。 |
+| 7 | tq_controller_request_duration_seconds | TransferQueue Controller 按操作类型统计的请求处理时延直方图（s）。 |
+
+## Active candidate names
+
+| No. | Category | Exact metric name | 中文说明 |
+|---:|---|---|---|
+| 1 | latency | rl_insight_monitor_timing_per_token_ms_gen | Rollout 生成阶段的单 token 平均耗时（ms）。 |
+| 2 | latency | rl_insight_monitor_timing_per_token_ms_ref | 参考模型对数概率计算的单 token 平均耗时（ms）。 |
+| 3 | latency | rl_insight_monitor_timing_per_token_ms_adv | 优势值计算的单 token 平均耗时（ms）。 |
+| 4 | latency | rl_insight_monitor_timing_per_token_ms_update_actor | Actor 参数更新的单 token 平均耗时（ms）。 |
+| 5 | latency | rl_insight_monitor_perf_time_per_step | 当前训练 step 耗时（s）。 |
+| 6 | latency | rl_insight_monitor_perf_throughput | 按设备数归一化的训练吞吐量（token/s/device）。 |
+| 7 | hardware_resources | rl_insight_monitor_perf_mfu_actor | Actor 训练的模型浮点运算利用率，即实际计算吞吐相对理论峰值的比例。 |
+| 8 | data_characteristics | rl_insight_monitor_perf_total_num_tokens | 当前训练 step 中参与计算的 token 总数。 |
+| 9 | hardware_resources | rl_insight_monitor_actor_perf_cpu_memory_used_gb | Actor 所在主机已使用的 CPU 内存（GB）。 |
+| 10 | hardware_resources | rl_insight_monitor_actor_perf_max_memory_allocated_gb | Actor 运行期间 PyTorch 实际分配的设备内存峰值（GB）。 |
+| 11 | hardware_resources | rl_insight_monitor_actor_perf_max_memory_reserved_gb | Actor 运行期间 PyTorch 内存分配器保留的设备内存峰值（GB）。 |
+| 12 | data_characteristics | rl_insight_monitor_prompt_length_mean | 当前批次 Prompt token 长度的平均值。 |
+| 13 | data_characteristics | rl_insight_monitor_prompt_length_max | 当前批次 Prompt token 长度的最大值。 |
+| 14 | data_characteristics | rl_insight_monitor_prompt_length_min | 当前批次 Prompt token 长度的最小值。 |
+| 15 | data_characteristics | rl_insight_monitor_prompt_length_clip_ratio | 当前批次中 Prompt 长度达到配置上限的样本比例。 |
+| 16 | data_characteristics | rl_insight_monitor_response_length_mean | 当前批次生成响应 token 长度的平均值。 |
+| 17 | data_characteristics | rl_insight_monitor_response_length_max | 当前批次生成响应 token 长度的最大值。 |
+| 18 | data_characteristics | rl_insight_monitor_response_length_min | 当前批次生成响应 token 长度的最小值。 |
+| 19 | data_characteristics | rl_insight_monitor_response_length_clip_ratio | 当前批次中响应长度达到最大生成长度的样本比例。 |
+| 20 | data_characteristics | rl_insight_monitor_response_length_non_aborted_mean | 排除中止样本后，响应 token 长度的平均值。 |
+| 21 | data_characteristics | rl_insight_monitor_response_length_non_aborted_max | 排除中止样本后，响应 token 长度的最大值。 |
+| 22 | data_characteristics | rl_insight_monitor_response_length_non_aborted_min | 排除中止样本后，响应 token 长度的最小值。 |
+| 23 | data_characteristics | rl_insight_monitor_response_length_non_aborted_clip_ratio | 排除中止样本后，响应长度达到最大生成长度的样本比例。 |
+| 24 | rollout_quality | rl_insight_monitor_response_aborted_ratio | 当前批次中 Rollout 响应被中止、响应长度记为零的样本比例。 |
+| 25 | data_characteristics | rl_insight_monitor_global_seqlen_mean | 数据并行负载均衡前，各分区序列总长度的平均值。 |
+| 26 | data_characteristics | rl_insight_monitor_global_seqlen_max | 数据并行负载均衡前，各分区序列总长度的最大值。 |
+| 27 | data_characteristics | rl_insight_monitor_global_seqlen_min | 数据并行负载均衡前，各分区序列总长度的最小值。 |
+| 28 | data_characteristics | rl_insight_monitor_global_seqlen_minmax_diff | 数据并行负载均衡前，各分区序列总长度最大值与最小值之差。 |
+| 29 | data_characteristics | rl_insight_monitor_global_seqlen_balanced_max | 数据并行负载均衡后，各分区序列总长度的最大值。 |
+| 30 | data_characteristics | rl_insight_monitor_global_seqlen_balanced_min | 数据并行负载均衡后，各分区序列总长度的最小值。 |
+| 31 | training_quality | rl_insight_monitor_actor_loss | Actor 优化使用的总损失；由策略损失及配置启用的 KL、熵等项组合而成。 |
+| 32 | training_quality | rl_insight_monitor_actor_pg_loss | PPO 裁剪后的策略梯度损失。 |
+| 33 | training_quality | rl_insight_monitor_actor_kl_loss | 当前 Actor 策略与参考策略之间的 KL 损失。 |
+| 34 | training_quality | rl_insight_monitor_actor_entropy_loss | Actor 目标函数中使用的策略熵聚合项；其符号和权重由熵系数的组合方式决定。 |
+| 35 | training_quality | rl_insight_monitor_actor_entropy | Actor 策略在有效响应 token 上的平均熵。 |
+| 36 | training_quality | rl_insight_monitor_actor_ppo_kl | 当前策略与生成数据时旧策略之间的 PPO KL 近似统计值。 |
+| 37 | training_quality | rl_insight_monitor_actor_kl_coef | Actor 损失中 KL 正则项当前使用的系数。 |
+| 38 | training_quality | rl_insight_monitor_actor_pg_clipfrac | PPO 概率比触发裁剪的有效 token 比例。 |
+| 39 | training_quality | rl_insight_monitor_actor_pg_clipfrac_lower | PPO 概率比触发下界裁剪的有效 token 比例。 |
+| 40 | training_quality | rl_insight_monitor_actor_grad_norm | 梯度裁剪后记录的 Actor 梯度范数。 |
+| 41 | training_quality | rl_insight_monitor_actor_lr | Actor 优化器当前学习率。 |
+| 42 | training_quality | rl_insight_monitor_critic_score_mean | 排除中止样本后，序列级原始评分的平均值。 |
+| 43 | training_quality | rl_insight_monitor_critic_score_max | 排除中止样本后，序列级原始评分的最大值。 |
+| 44 | training_quality | rl_insight_monitor_critic_score_min | 排除中止样本后，序列级原始评分的最小值。 |
+| 45 | training_quality | rl_insight_monitor_critic_rewards_mean | 排除中止样本后，序列级最终奖励的平均值。 |
+| 46 | training_quality | rl_insight_monitor_critic_rewards_max | 排除中止样本后，序列级最终奖励的最大值。 |
+| 47 | training_quality | rl_insight_monitor_critic_rewards_min | 排除中止样本后，序列级最终奖励的最小值。 |
+| 48 | training_quality | rl_insight_monitor_critic_returns_mean | 有效响应 token 上回报值的平均值。 |
+| 49 | training_quality | rl_insight_monitor_critic_returns_max | 有效响应 token 上回报值的最大值。 |
+| 50 | training_quality | rl_insight_monitor_critic_returns_min | 有效响应 token 上回报值的最小值。 |
+| 51 | training_quality | rl_insight_monitor_critic_advantages_mean | 有效响应 token 上优势值的平均值。 |
+| 52 | training_quality | rl_insight_monitor_critic_advantages_max | 有效响应 token 上优势值的最大值。 |
+| 53 | training_quality | rl_insight_monitor_critic_advantages_min | 有效响应 token 上优势值的最小值。 |
+| 54 | training_quality | rl_insight_monitor_training_epoch | 当前训练轮次编号。 |
+| 55 | data_characteristics | rl_insight_monitor_training_num_turns_mean | 当前训练批次多轮交互轮数的平均值。 |
+| 56 | data_characteristics | rl_insight_monitor_training_num_turns_max | 当前训练批次多轮交互轮数的最大值。 |
+| 57 | data_characteristics | rl_insight_monitor_training_num_turns_min | 当前训练批次多轮交互轮数的最小值。 |
+| 58 | rollout_quality | rl_insight_monitor_training_off_policy_trajectory_staleness_mean | 异步训练中，轨迹生成所用策略版本相对当前训练策略的陈旧步数平均值。 |
+| 59 | rollout_quality | rl_insight_monitor_training_off_policy_trajectory_staleness_max | 异步训练中，轨迹生成所用策略版本相对当前训练策略的陈旧步数最大值。 |
+| 60 | rollout_quality | rl_insight_monitor_training_off_policy_trajectory_staleness_worst_mean | 批次内按框架 worst 口径统计的轨迹陈旧步数平均值。 |
+| 61 | rollout_quality | rl_insight_monitor_training_off_policy_trajectory_staleness_worst_max | 批次内按框架 worst 口径统计的轨迹陈旧步数最大值。 |
+| 62 | rollout_quality | rl_insight_monitor_training_off_policy_trajectory_staleness_worst_min | 批次内按框架 worst 口径统计的轨迹陈旧步数最小值。 |
+| 63 | rollout_quality | rl_insight_monitor_training_off_policy_trajectory_spans_mean | 样本内轨迹所跨策略版本范围的平均值。 |
+| 64 | rollout_quality | rl_insight_monitor_training_off_policy_trajectory_spans_max | 样本内轨迹所跨策略版本范围的最大值。 |
+| 65 | rollout_quality | rl_insight_monitor_training_off_policy_trajectory_spans_min | 样本内轨迹所跨策略版本范围的最小值。 |
+| 66 | rollout_quality | rl_insight_monitor_training_rollout_probs_diff_mean | Rollout 引擎概率与 Actor 重算概率之绝对差的平均值。 |
+| 67 | rollout_quality | rl_insight_monitor_training_rollout_probs_diff_max | Rollout 引擎概率与 Actor 重算概率之绝对差的最大值。 |
+| 68 | rollout_quality | rl_insight_monitor_training_rollout_probs_diff_std | Rollout 引擎概率与 Actor 重算概率之绝对差的标准差。 |
+| 69 | rollout_quality | rl_insight_monitor_training_rollout_probs_diff_valid | Rollout 与 Actor 概率差统计是否有效的标记；1 为有效，0 为无效。 |
+| 70 | rollout_quality | rl_insight_monitor_training_rollout_actor_probs_pearson_corr | Rollout 引擎概率与 Actor 重算概率之间的 Pearson 相关系数。 |
+| 71 | rollout_quality | rl_insight_monitor_rollout_corr_kl | Rollout 策略相对训练策略的直接 KL 估计，即 KL(π_rollout 与 π_training)。 |
+| 72 | rollout_quality | rl_insight_monitor_rollout_corr_k3_kl | Rollout 策略相对训练策略的 K3 KL 估计；相比直接估计在小差异时更稳定。 |
+| 73 | rollout_quality | rl_insight_monitor_rollout_corr_chi2_seq | 训练策略与 Rollout 策略之间的序列级卡方散度。 |
+| 74 | rollout_quality | rl_insight_monitor_rollout_corr_chi2_token | 训练策略与 Rollout 策略之间的 token 级卡方散度。 |
+| 75 | rollout_quality | rl_insight_monitor_rollout_corr_log_ppl_diff | 训练策略与 Rollout 策略的 log 困惑度差；定义为 training log PPL 减 rollout log PPL。 |
+| 76 | rollout_quality | rl_insight_monitor_rollout_corr_log_ppl_diff_max | 逐序列 log 困惑度差的最大值。 |
+| 77 | rollout_quality | rl_insight_monitor_rollout_corr_log_ppl_diff_min | 逐序列 log 困惑度差的最小值。 |
+| 78 | rollout_quality | rl_insight_monitor_rollout_corr_log_ppl_abs_diff | 逐序列 log 困惑度差绝对值的平均值。 |
+| 79 | rollout_quality | rl_insight_monitor_rollout_corr_ppl_ratio | 逐序列 training PPL 与 rollout PPL 比值的平均值。 |
+| 80 | rollout_quality | rl_insight_monitor_rollout_corr_rollout_log_ppl | Rollout 策略逐序列 log 困惑度的批次平均值。 |
+| 81 | rollout_quality | rl_insight_monitor_rollout_corr_rollout_ppl | Rollout 策略逐序列困惑度的批次平均值。 |
+| 82 | rollout_quality | rl_insight_monitor_rollout_corr_training_log_ppl | 训练策略逐序列 log 困惑度的批次平均值。 |
+| 83 | rollout_quality | rl_insight_monitor_rollout_corr_training_ppl | 训练策略逐序列困惑度的批次平均值。 |
+| 84 | data_characteristics | rl_insight_monitor_val_aux_num_turns_mean | 验证批次多轮交互轮数的平均值。 |
+| 85 | data_characteristics | rl_insight_monitor_val_aux_num_turns_max | 验证批次多轮交互轮数的最大值。 |
+| 86 | data_characteristics | rl_insight_monitor_val_aux_num_turns_min | 验证批次多轮交互轮数的最小值。 |
+| 87 | vllm_engine | vllm:request_max_num_generation_tokens | vLLM 请求所指定最大生成 token 数的分布直方图。 |
+| 88 | vllm_engine | vllm:request_prompt_tokens | vLLM 请求输入或 Prefill token 数的分布直方图。 |
+| 89 | vllm_engine | vllm:request_generation_tokens | vLLM 请求实际生成 token 数的分布直方图。 |
+| 90 | vllm_engine | vllm:kv_cache_usage_perc | vLLM KV Cache 使用比例；数值 1 表示使用率 100%。 |
+| 91 | vllm_engine | vllm:num_requests_running | vLLM 当前正在模型执行批次中运行的请求数。 |
+| 92 | vllm_engine | vllm:num_requests_waiting | vLLM 当前等待调度的请求数。 |
+| 93 | vllm_engine | vllm:num_requests_swapped | vLLM 旧版调度器中当前处于 swapped 状态的请求数。 |
+| 94 | transfer_queue | tq_storage_request_latency_p50 | TransferQueue 存储请求时延 P50（s）。 |
+| 95 | transfer_queue | tq_storage_request_latency_p99 | TransferQueue 存储请求时延 P99（s）。 |
+| 96 | transfer_queue | tq_controller_uptime_seconds | TransferQueue Controller 运行时长（s）。 |
+| 97 | transfer_queue | tq_controller_memory_rss_bytes | TransferQueue Controller 进程常驻内存（B）。 |
+| 98 | transfer_queue | tq_partition_production_progress | TransferQueue 各分区生产进度（0–1）。 |
+| 99 | transfer_queue | tq_partition_consumption_progress | TransferQueue 各分区各任务消费进度（0–1）。 |
+| 100 | transfer_queue | tq_storage_utilization_ratio | TransferQueue 存储当前有效键数相对容量上限的比例。 |
+| 101 | transfer_queue | tq_storage_memory_rss_bytes | TransferQueue 存储进程常驻内存（B）。 |
+| 102 | transfer_queue | tq_storage_request_ops | TransferQueue 各存储单元按操作类型统计的已处理请求数。 |
+
+## Cataloged candidates requiring preprocessing
+
+This section follows the current catalog grouping. The vLLM entries are cumulative counters and require rate or increase conversion. Several TransferQueue names ending in `_total` are Gauges in the official implementation; their Chinese descriptions identify that distinction.
+
+| No. | Exact metric name | 中文说明 |
+|---:|---|---|
+| 1 | vllm:generation_tokens_total | vLLM 累计生成的输出 token 数；用于关联前需转换为区间增量或速率。 |
+| 2 | vllm:prompt_tokens_total | vLLM 累计处理的 Prompt token 数；用于关联前需转换为区间增量或速率。 |
+| 3 | vllm:request_success_total | vLLM 按完成原因统计的累计成功请求数；用于关联前需转换为区间增量或速率。 |
+| 4 | vllm:prefix_cache_hits_total | vLLM 前缀缓存累计命中的 token 数；用于关联前需转换为区间增量或速率。 |
+| 5 | vllm:prefix_cache_queries_total | vLLM 前缀缓存累计查询的 token 数；用于关联前需转换为区间增量或速率。 |
+| 6 | vllm:spec_decode_num_accepted_tokens_total | vLLM 投机解码累计接受的草稿 token 数；用于关联前需转换为区间增量或速率。 |
+| 7 | vllm:spec_decode_num_draft_tokens_total | vLLM 投机解码累计生成的草稿 token 数；用于关联前需转换为区间增量或速率。 |
+| 8 | vllm:spec_decode_num_drafts_total | vLLM 投机解码累计执行的草稿提议次数；用于关联前需转换为区间增量或速率。 |
+| 9 | tq_controller_request_total | TransferQueue Controller 按操作类型累计接收的请求数。 |
+| 10 | tq_controller_request_samples_total | TransferQueue Controller 按操作类型累计处理的样本数。 |
+| 11 | tq_partitions_total | TransferQueue 当前活动分区数；官方实现为 Gauge，并非累计 Counter。 |
+| 12 | tq_partition_samples_total | TransferQueue 各分区当前活动样本数；官方实现为 Gauge，并非累计 Counter。 |
+| 13 | tq_storage_active_keys_total | TransferQueue 存储当前有效键数；官方实现为 Gauge，并非累计 Counter。 |
+| 14 | tq_storage_capacity_total | TransferQueue 存储可容纳的最大键数；官方实现为 Gauge，并非累计 Counter。 |
+| 15 | tq_global_index_allocated_total | TransferQueue 当前已分配的全局索引数；官方实现为 Gauge，并非累计 Counter。 |
+| 16 | tq_global_index_reusable_total | TransferQueue 当前可复用的全局索引数；官方实现为 Gauge，并非累计 Counter。 |

--- a/.claude/skills/degradation-association-offline
+++ b/.claude/skills/degradation-association-offline
@@ -1,0 +1,1 @@
+../../.agent/skills/degradation-association-offline

--- a/.codex/skills/degradation-association-offline
+++ b/.codex/skills/degradation-association-offline
@@ -1,0 +1,1 @@
+../../.agent/skills/degradation-association-offline

--- a/experiment/degradation/README.md
+++ b/experiment/degradation/README.md
@@ -1,0 +1,28 @@
+# Offline degradation association
+
+Analyze a user-selected time range directly from RL-Insight's local Prometheus
+TSDB. The first step value visible after the selected start is skipped as
+potentially partial. The next 30 complete steps train a baseline when one is not
+supplied; later steps are checked for target events and Top-25 associations.
+
+## Install
+
+```bash
+pip install -e ".[degradation]"
+```
+
+## Analyze a range
+
+```bash
+python -m experiment.degradation.cli analyze \
+  --start-time 2026-09-08T09:00:00+08:00 \
+  --end-time 2026-09-08T12:00:00+08:00
+```
+
+The default TSDB is `~/.rl-insight/data/prometheus`. Use `--data-dir`,
+`--promtool`, `--analysis-dir`, or `--baseline-file` to override the respective
+paths.
+
+The CLI writes deterministic baseline, event, and analysis JSON. The repository
+Skill at `.agent/skills/degradation-association-offline/SKILL.md` turns the final
+association evidence into the grouped Markdown report and root-cause summary.

--- a/experiment/degradation/association.py
+++ b/experiment/degradation/association.py
@@ -1,0 +1,613 @@
+# Copyright (c) 2026 verl-project authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Rank metrics associated with one confirmed target degradation event."""
+
+from __future__ import annotations
+
+import math
+from collections.abc import Mapping, Sequence
+from dataclasses import dataclass
+
+import numpy as np
+from scipy.stats import pearsonr, spearmanr  # type: ignore[import-untyped]
+from sklearn.ensemble import RandomForestClassifier  # type: ignore[import-untyped]
+from sklearn.inspection import permutation_importance  # type: ignore[import-untyped]
+from sklearn.metrics import balanced_accuracy_score  # type: ignore[import-untyped]
+
+from .detector import PointResult, Policy
+from .series import SeriesId
+
+
+class AssociationError(ValueError):
+    """The supplied event or point history cannot be analyzed safely."""
+
+
+@dataclass(frozen=True)
+class AssociationParameters:
+    """Configurable association and random-forest parameters."""
+
+    correlation_weight: float = 0.85
+    random_forest_weight: float = 0.15
+    min_aligned_points: int = 10
+    min_rf_samples: int = 30
+    min_coverage_ratio: float = 0.6
+    n_estimators: int = 200
+    class_weight: str | None = "balanced"
+    random_state: int = 42
+    train_fraction: float = 0.7
+    permutation_repeats: int = 10
+    n_jobs: int = 1
+
+    def __post_init__(self) -> None:
+        nonnegative_integers = ("random_state",)
+        positive_integers = (
+            "min_aligned_points",
+            "min_rf_samples",
+            "n_estimators",
+            "permutation_repeats",
+        )
+        for name in (*nonnegative_integers, *positive_integers, "n_jobs"):
+            value = getattr(self, name)
+            if isinstance(value, bool) or not isinstance(value, int):
+                raise TypeError(f"{name} must be an integer")
+        for name in nonnegative_integers:
+            if getattr(self, name) < 0:
+                raise ValueError(f"{name} must not be negative")
+        for name in positive_integers:
+            if getattr(self, name) <= 0:
+                raise ValueError(f"{name} must be positive")
+        if self.n_jobs == 0:
+            raise ValueError("n_jobs must not be zero")
+
+        numeric = (
+            "correlation_weight",
+            "random_forest_weight",
+            "min_coverage_ratio",
+            "train_fraction",
+        )
+        for name in numeric:
+            value = getattr(self, name)
+            if isinstance(value, bool) or not isinstance(value, (int, float)):
+                raise TypeError(f"{name} must be a finite number")
+            if not math.isfinite(float(value)):
+                raise ValueError(f"{name} must be a finite number")
+        if self.correlation_weight < 0 or self.random_forest_weight < 0:
+            raise ValueError("association weights must not be negative")
+        if not math.isclose(
+            self.correlation_weight + self.random_forest_weight,
+            1.0,
+            rel_tol=1.0e-9,
+            abs_tol=1.0e-9,
+        ):
+            raise ValueError("association weights must sum to 1")
+        if not 0.0 <= self.min_coverage_ratio <= 1.0:
+            raise ValueError("min_coverage_ratio must be between 0 and 1")
+        if not 0.0 < self.train_fraction < 1.0:
+            raise ValueError("train_fraction must be between 0 and 1")
+        if self.class_weight is not None and not isinstance(self.class_weight, str):
+            raise TypeError("class_weight must be a string or None")
+
+
+@dataclass(frozen=True)
+class CandidateExclusion:
+    """A candidate omitted before evidence scoring."""
+
+    identity: SeriesId
+    reason: str
+
+
+@dataclass(frozen=True)
+class AssociationItem:
+    """Correlation and random-forest evidence for one ranked candidate."""
+
+    identity: SeriesId
+    association_score: float
+    pearson: float | None
+    spearman: float | None
+    selected_correlation: float | None
+    selected_correlation_method: str | None
+    correlation_share: float
+    random_forest_eligible: bool
+    random_forest_importance: float | None
+    random_forest_share: float
+    aligned_sample_count: int
+    coverage_ratio: float
+
+
+@dataclass(frozen=True)
+class AssociationResult:
+    """Complete candidate ranking for one runtime-selected event window."""
+
+    status: str
+    effective_correlation_weight: float
+    effective_random_forest_weight: float
+    random_forest_status: str
+    random_forest_reason: str | None
+    random_forest_sample_count: int
+    random_forest_validation_score: float | None
+    skipped_candidates: tuple[CandidateExclusion, ...]
+    associations: tuple[AssociationItem, ...]
+
+
+@dataclass(frozen=True)
+class _CorrelationEvidence:
+    valid: bool
+    pearson: float | None
+    spearman: float | None
+    selected: float | None
+    method: str | None
+    strength: float
+
+
+@dataclass(frozen=True)
+class _CandidateEvidence:
+    identity: SeriesId
+    steps: tuple[int, ...]
+    target_values: tuple[float, ...]
+    target_labels: tuple[bool, ...]
+    candidate_values: tuple[float, ...]
+    candidate_labels: tuple[bool, ...]
+    coverage_ratio: float
+    abnormal_in_event: bool
+    correlation: _CorrelationEvidence
+
+
+@dataclass(frozen=True)
+class _RandomForestEvidence:
+    status: str
+    reason: str | None
+    importances: Mapping[SeriesId, float]
+    sample_count: int
+    validation_score: float | None
+
+
+DEFAULT_ASSOCIATION_PARAMETERS = AssociationParameters()
+
+
+def _point_map(
+    points: Sequence[PointResult],
+    identity: SeriesId,
+    policy: Policy,
+) -> dict[int, PointResult]:
+    result: dict[int, PointResult] = {}
+    for point in points:
+        if not isinstance(point, PointResult):
+            raise TypeError("point histories must contain PointResult values")
+        if point.identity != identity:
+            raise AssociationError("point identity does not match its history")
+        if point.policy is not policy:
+            raise AssociationError(
+                f"{identity.name!r} association points require policy {policy.value}"
+            )
+        if point.step in result:
+            raise AssociationError(f"duplicate point for step {point.step}")
+        result[point.step] = point
+    return result
+
+
+def _valid_value(point: PointResult | None) -> float | None:
+    if point is None or point.value is None:
+        return None
+    value = float(point.value)
+    return value if math.isfinite(value) else None
+
+
+def _invalid_correlation() -> _CorrelationEvidence:
+    return _CorrelationEvidence(
+        valid=False,
+        pearson=None,
+        spearman=None,
+        selected=None,
+        method=None,
+        strength=0.0,
+    )
+
+
+def _compute_correlation(
+    target_values: Sequence[float],
+    candidate_values: Sequence[float],
+) -> _CorrelationEvidence:
+    target = np.asarray(target_values, dtype=float)
+    candidate = np.asarray(candidate_values, dtype=float)
+    if target.shape != candidate.shape:
+        raise AssociationError("aligned target and candidate shapes must match")
+    finite = np.isfinite(target) & np.isfinite(candidate)
+    target = target[finite]
+    candidate = candidate[finite]
+    if target.size < 2:
+        return _invalid_correlation()
+    if np.ptp(target) == 0:
+        return _invalid_correlation()
+    if np.ptp(candidate) == 0:
+        return _invalid_correlation()
+
+    try:
+        pearson = float(pearsonr(target, candidate).statistic)
+    except ValueError:
+        pearson = math.nan
+    try:
+        spearman = float(spearmanr(target, candidate).statistic)
+    except ValueError:
+        spearman = math.nan
+    valid = [
+        (method, value)
+        for method, value in (("pearson", pearson), ("spearman", spearman))
+        if math.isfinite(value)
+    ]
+    if not valid:
+        return _invalid_correlation()
+    values = dict(valid)
+    if len(values) == 2 and math.isclose(
+        abs(values["pearson"]),
+        abs(values["spearman"]),
+        rel_tol=1.0e-12,
+        abs_tol=1.0e-12,
+    ):
+        method, selected = "pearson", values["pearson"]
+    else:
+        method, selected = max(valid, key=lambda item: abs(item[1]))
+    return _CorrelationEvidence(
+        valid=True,
+        pearson=pearson if math.isfinite(pearson) else None,
+        spearman=spearman if math.isfinite(spearman) else None,
+        selected=selected,
+        method=method,
+        strength=abs(selected),
+    )
+
+
+def _candidate_evidence(
+    identity: SeriesId,
+    points: Mapping[int, PointResult],
+    target_points: Mapping[int, PointResult],
+    *,
+    analysis_start: int,
+    analysis_end: int,
+    event_start: int,
+    valid_target_count: int,
+    parameters: AssociationParameters,
+) -> tuple[_CandidateEvidence | None, CandidateExclusion | None]:
+    common_steps: list[int] = []
+    target_values: list[float] = []
+    target_labels: list[bool] = []
+    candidate_values: list[float] = []
+    candidate_labels: list[bool] = []
+    for step in range(analysis_start, analysis_end + 1):
+        target_point = target_points.get(step)
+        candidate_point = points.get(step)
+        target_value = _valid_value(target_point)
+        candidate_value = _valid_value(candidate_point)
+        if target_value is None or candidate_value is None:
+            continue
+        common_steps.append(step)
+        target_values.append(target_value)
+        target_labels.append(bool(target_point and target_point.abnormal))
+        candidate_values.append(candidate_value)
+        candidate_labels.append(bool(candidate_point and candidate_point.abnormal))
+
+    coverage = len(common_steps) / valid_target_count if valid_target_count else 0.0
+    if coverage < parameters.min_coverage_ratio:
+        return None, CandidateExclusion(identity, "insufficient_coverage")
+    if len(common_steps) < parameters.min_aligned_points:
+        return None, CandidateExclusion(identity, "insufficient_aligned_points")
+    if np.ptp(np.asarray(candidate_values, dtype=float)) == 0:
+        return None, CandidateExclusion(identity, "constant_candidate_series")
+
+    abnormal_in_event = any(
+        event_start <= step <= analysis_end
+        and (point := points.get(step)) is not None
+        and point.valid
+        and point.abnormal
+        for step in range(event_start, analysis_end + 1)
+    )
+    return (
+        _CandidateEvidence(
+            identity=identity,
+            steps=tuple(common_steps),
+            target_values=tuple(target_values),
+            target_labels=tuple(target_labels),
+            candidate_values=tuple(candidate_values),
+            candidate_labels=tuple(candidate_labels),
+            coverage_ratio=float(coverage),
+            abnormal_in_event=abnormal_in_event,
+            correlation=_compute_correlation(target_values, candidate_values),
+        ),
+        None,
+    )
+
+
+def _rf_failure(
+    reason: str,
+    *,
+    sample_count: int = 0,
+) -> _RandomForestEvidence:
+    return _RandomForestEvidence(
+        status="insufficient_data",
+        reason=reason,
+        importances={},
+        sample_count=sample_count,
+        validation_score=None,
+    )
+
+
+def _random_forest_evidence(
+    candidates: Sequence[_CandidateEvidence],
+    parameters: AssociationParameters,
+) -> _RandomForestEvidence:
+    active = sorted(
+        (candidate for candidate in candidates if candidate.abnormal_in_event),
+        key=lambda candidate: candidate.identity,
+    )
+    if not active:
+        return _rf_failure("no_abnormal_candidates")
+
+    candidate_maps = {
+        candidate.identity: dict(zip(candidate.steps, candidate.candidate_labels))
+        for candidate in active
+    }
+    target_maps = {
+        candidate.identity: dict(zip(candidate.steps, candidate.target_labels))
+        for candidate in active
+    }
+    common_steps = set(candidate_maps[active[0].identity])
+    for candidate in active[1:]:
+        common_steps.intersection_update(candidate_maps[candidate.identity])
+
+    if len(common_steps) < parameters.min_rf_samples:
+        return _rf_failure(
+            "insufficient_common_samples",
+            sample_count=len(common_steps),
+        )
+
+    ordered_steps = sorted(common_steps)
+    target_labels = np.asarray(
+        [target_maps[active[0].identity][step] for step in ordered_steps],
+        dtype=int,
+    )
+    if np.unique(target_labels).size < 2:
+        return _rf_failure(
+            "single_target_class",
+            sample_count=len(ordered_steps),
+        )
+
+    matrix = np.asarray(
+        [
+            [candidate_maps[candidate.identity][step] for candidate in active]
+            for step in ordered_steps
+        ],
+        dtype=float,
+    )
+    variable_columns = [
+        index
+        for index in range(matrix.shape[1])
+        if np.unique(matrix[:, index]).size > 1
+    ]
+    if not variable_columns:
+        return _rf_failure(
+            "all_candidate_features_constant",
+            sample_count=len(ordered_steps),
+        )
+
+    model_candidates = [active[index] for index in variable_columns]
+    matrix = matrix[:, variable_columns]
+    split = max(
+        1,
+        min(
+            len(target_labels) - 1, int(len(target_labels) * parameters.train_fraction)
+        ),
+    )
+    training_labels = target_labels[:split]
+    validation_labels = target_labels[split:]
+    if np.unique(training_labels).size < 2 or np.unique(validation_labels).size < 2:
+        return _rf_failure(
+            "time_split_lacks_both_classes",
+            sample_count=len(ordered_steps),
+        )
+
+    try:
+        model = RandomForestClassifier(
+            n_estimators=parameters.n_estimators,
+            class_weight=parameters.class_weight,
+            random_state=parameters.random_state,
+            n_jobs=parameters.n_jobs,
+        )
+        model.fit(matrix[:split], training_labels)
+        prediction = model.predict(matrix[split:])
+        validation_score = float(balanced_accuracy_score(validation_labels, prediction))
+        permutation = permutation_importance(
+            model,
+            matrix[split:],
+            validation_labels,
+            scoring="balanced_accuracy",
+            n_repeats=parameters.permutation_repeats,
+            random_state=parameters.random_state,
+            n_jobs=parameters.n_jobs,
+        )
+    except (ValueError, RuntimeError, FloatingPointError) as exc:
+        return _RandomForestEvidence(
+            status="insufficient_data",
+            reason=f"random_forest_failed: {exc}",
+            importances={},
+            sample_count=len(ordered_steps),
+            validation_score=None,
+        )
+
+    raw = np.asarray(permutation.importances_mean, dtype=float)
+    clipped = np.maximum(np.where(np.isfinite(raw), raw, 0.0), 0.0)
+    if float(np.sum(clipped)) <= 0:
+        return _rf_failure(
+            "all_importances_zero",
+            sample_count=len(ordered_steps),
+        )
+    importances = {candidate.identity: 0.0 for candidate in active}
+    for index, candidate in enumerate(model_candidates):
+        importances[candidate.identity] = float(clipped[index])
+    return _RandomForestEvidence(
+        status="success",
+        reason=None,
+        importances=importances,
+        sample_count=len(ordered_steps),
+        validation_score=validation_score,
+    )
+
+
+def _rank_associations(
+    candidates: Sequence[_CandidateEvidence],
+    random_forest: _RandomForestEvidence,
+    parameters: AssociationParameters,
+) -> tuple[str, float, float, tuple[AssociationItem, ...]]:
+    correlation_total = sum(
+        candidate.correlation.strength
+        for candidate in candidates
+        if candidate.correlation.valid
+    )
+    random_forest_total = sum(random_forest.importances.values())
+    correlation_valid = correlation_total > 0
+    random_forest_valid = random_forest_total > 0
+    if correlation_valid and random_forest_valid:
+        status = "success"
+        correlation_weight = parameters.correlation_weight
+        random_forest_weight = parameters.random_forest_weight
+    elif correlation_valid:
+        status = "partial_success"
+        correlation_weight = 1.0
+        random_forest_weight = 0.0
+    elif random_forest_valid:
+        status = "partial_success"
+        correlation_weight = 0.0
+        random_forest_weight = 1.0
+    else:
+        return "insufficient_data", 0.0, 0.0, ()
+
+    rows: list[tuple[_CandidateEvidence, float, float, float]] = []
+    for candidate in candidates:
+        correlation_share = (
+            candidate.correlation.strength / correlation_total
+            if correlation_valid and candidate.correlation.valid
+            else 0.0
+        )
+        random_forest_share = (
+            random_forest.importances.get(candidate.identity, 0.0) / random_forest_total
+            if random_forest_valid
+            else 0.0
+        )
+        score = (
+            correlation_weight * correlation_share
+            + random_forest_weight * random_forest_share
+        )
+        rows.append((candidate, correlation_share, random_forest_share, score))
+    rows.sort(key=lambda row: (-row[3], row[0].identity))
+
+    associations = tuple(
+        AssociationItem(
+            identity=candidate.identity,
+            association_score=float(score),
+            pearson=candidate.correlation.pearson,
+            spearman=candidate.correlation.spearman,
+            selected_correlation=candidate.correlation.selected,
+            selected_correlation_method=candidate.correlation.method,
+            correlation_share=float(correlation_share),
+            random_forest_eligible=candidate.abnormal_in_event,
+            random_forest_importance=random_forest.importances.get(candidate.identity),
+            random_forest_share=float(random_forest_share),
+            aligned_sample_count=len(candidate.steps),
+            coverage_ratio=candidate.coverage_ratio,
+        )
+        for (
+            candidate,
+            correlation_share,
+            random_forest_share,
+            score,
+        ) in rows
+    )
+    return status, correlation_weight, random_forest_weight, associations
+
+
+def analyze_association(
+    target_points: Sequence[PointResult],
+    candidate_points: Mapping[SeriesId, Sequence[PointResult]],
+    *,
+    event_start_step: int,
+    parameters: AssociationParameters = DEFAULT_ASSOCIATION_PARAMETERS,
+) -> AssociationResult:
+    """Rank candidates in a runtime-selected target-event window."""
+
+    if not isinstance(parameters, AssociationParameters):
+        raise TypeError("parameters must be AssociationParameters")
+    if isinstance(event_start_step, bool) or not isinstance(event_start_step, int):
+        raise TypeError("event_start_step must be an integer")
+    if not target_points:
+        raise AssociationError("target history must not be empty")
+    target_identity = target_points[0].identity
+    target_map = _point_map(target_points, target_identity, Policy.UP)
+    target_steps = sorted(target_map)
+    if target_steps != list(range(target_steps[0], target_steps[-1] + 1)):
+        raise AssociationError("target history must contain consecutive steps")
+    analysis_start, analysis_end = target_steps[0], target_steps[-1]
+    if not analysis_start <= event_start_step <= analysis_end:
+        raise AssociationError("event_start_step must be inside the analysis window")
+    valid_target_count = sum(
+        _valid_value(target_map[step]) is not None for step in target_steps
+    )
+
+    evidence: list[_CandidateEvidence] = []
+    exclusions: list[CandidateExclusion] = []
+    for identity in sorted(candidate_points):
+        if not isinstance(identity, SeriesId):
+            raise TypeError("candidate identities must be SeriesId values")
+        if identity == target_identity:
+            raise AssociationError("target series must not be a candidate")
+        points = _point_map(candidate_points[identity], identity, Policy.BOTH)
+        candidate, exclusion = _candidate_evidence(
+            identity,
+            points,
+            target_map,
+            analysis_start=analysis_start,
+            analysis_end=analysis_end,
+            event_start=event_start_step,
+            valid_target_count=valid_target_count,
+            parameters=parameters,
+        )
+        if candidate is not None:
+            evidence.append(candidate)
+        if exclusion is not None:
+            exclusions.append(exclusion)
+
+    random_forest = _random_forest_evidence(evidence, parameters)
+    status, correlation_weight, random_forest_weight, associations = _rank_associations(
+        evidence, random_forest, parameters
+    )
+    return AssociationResult(
+        status=status,
+        effective_correlation_weight=correlation_weight,
+        effective_random_forest_weight=random_forest_weight,
+        random_forest_status=random_forest.status,
+        random_forest_reason=random_forest.reason,
+        random_forest_sample_count=random_forest.sample_count,
+        random_forest_validation_score=random_forest.validation_score,
+        skipped_candidates=tuple(sorted(exclusions, key=lambda item: item.identity)),
+        associations=associations,
+    )
+
+
+__all__ = [
+    "DEFAULT_ASSOCIATION_PARAMETERS",
+    "AssociationError",
+    "AssociationItem",
+    "AssociationParameters",
+    "AssociationResult",
+    "CandidateExclusion",
+    "analyze_association",
+]

--- a/experiment/degradation/baseline.py
+++ b/experiment/degradation/baseline.py
@@ -1,0 +1,430 @@
+# Copyright (c) 2026 verl-project authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Build per-series KDE baselines from step-aligned metric snapshots."""
+
+from __future__ import annotations
+
+import math
+from dataclasses import dataclass, field
+
+import numpy as np
+from scipy.signal import find_peaks, peak_prominences  # type: ignore[import-untyped]
+from scipy.stats import gaussian_kde  # type: ignore[import-untyped]
+
+from .series import SeriesId
+from .window import StepFrame
+
+
+class BaselineDataError(ValueError):
+    """A metric cannot produce a baseline from the supplied step frames."""
+
+
+class InsufficientBaselineDataError(BaselineDataError):
+    """A metric has fewer valid observations than the configured minimum."""
+
+
+class NoStableSegmentError(BaselineDataError):
+    """No time-contiguous density mode passed the stability test."""
+
+
+@dataclass(frozen=True)
+class BaselineParameters:
+    """Parameters that affect fitted baseline bounds."""
+
+    minimum_samples: int = 20
+    alpha: float = 0.025
+    lower_ratio: float = 1.05
+    upper_ratio: float = 1.05
+    bandwidth: str | float = "auto"
+    grid_size: int = 1024
+    padding_ratio: float = 0.10
+    tail_bandwidths: float = 6.0
+    zero_range_epsilon: float = 1.0e-8
+    random_seed: int = 42
+    peak_prominence_ratio: float = 0.01
+    std_factor: float = 2.0
+    within_std_coefficient: float = 1.05
+    minimum_passed_flags: int = 4
+    mean_tolerance_ratio: float = 0.02
+    step_gap_factor: float = 3.0
+    maximum_step_gap: float | None = None
+
+    def __post_init__(self) -> None:
+        if isinstance(self.minimum_samples, bool) or not isinstance(
+            self.minimum_samples, int
+        ):
+            raise TypeError("minimum_samples must be an integer")
+        if self.minimum_samples < 3:
+            raise ValueError("minimum_samples must be an integer of at least 3")
+        if not math.isfinite(self.alpha) or not 0.0 < self.alpha < 0.5:
+            raise ValueError("alpha must be between 0 and 0.5")
+        for name in ("lower_ratio", "upper_ratio"):
+            value = getattr(self, name)
+            if not math.isfinite(value) or value < 1.0:
+                raise ValueError(f"{name} must be finite and at least 1")
+        if self.bandwidth != "auto":
+            _positive(self.bandwidth, "bandwidth")
+        if isinstance(self.grid_size, bool) or not isinstance(self.grid_size, int):
+            raise TypeError("grid_size must be an integer")
+        if self.grid_size < 32:
+            raise ValueError("grid_size must be an integer of at least 32")
+        _non_negative(self.padding_ratio, "padding_ratio")
+        for name in (
+            "tail_bandwidths",
+            "zero_range_epsilon",
+            "std_factor",
+            "step_gap_factor",
+        ):
+            _positive(getattr(self, name), name)
+        if isinstance(self.random_seed, bool) or not isinstance(self.random_seed, int):
+            raise TypeError("random_seed must be an integer")
+        _non_negative(self.peak_prominence_ratio, "peak_prominence_ratio")
+        if not 1.0 <= self.within_std_coefficient < 2.0:
+            raise ValueError("within_std_coefficient must be in [1, 2)")
+        if not 1 <= self.minimum_passed_flags <= 6:
+            raise ValueError("minimum_passed_flags must be between 1 and 6")
+        _non_negative(self.mean_tolerance_ratio, "mean_tolerance_ratio")
+        if self.maximum_step_gap is not None:
+            _positive(self.maximum_step_gap, "maximum_step_gap")
+
+
+@dataclass(frozen=True)
+class NormalRange:
+    """One stable normal mode and its fitted thresholds."""
+
+    mode_id: int
+    start_step: int
+    end_step: int
+    sample_count: int
+    kde_lower: float
+    kde_upper: float
+    lower: float
+    upper: float
+    bandwidth: float
+
+
+@dataclass(frozen=True)
+class SeriesBaseline:
+    """All normal modes fitted for one concrete metric series."""
+
+    identity: SeriesId
+    sample_count: int
+    ranges: tuple[NormalRange, ...]
+
+
+@dataclass(frozen=True)
+class BaselineFit:
+    """Successful baselines and explicit per-series skip reasons."""
+
+    baselines: dict[SeriesId, SeriesBaseline] = field(default_factory=dict)
+    skipped: dict[SeriesId, str] = field(default_factory=dict)
+
+
+@dataclass(frozen=True)
+class _KDE:
+    grid: np.ndarray
+    density: np.ndarray
+    bandwidth: float
+
+
+@dataclass(frozen=True)
+class _Segment:
+    steps: tuple[int, ...]
+    values: tuple[float, ...]
+
+
+def _positive(value: object, name: str) -> float:
+    if isinstance(value, bool) or not isinstance(value, (int, float, str)):
+        raise TypeError(f"{name} must be a number")
+    try:
+        number = float(value)
+    except (TypeError, ValueError, OverflowError) as exc:
+        raise ValueError(f"{name} must be finite and positive") from exc
+    if not math.isfinite(number) or number <= 0.0:
+        raise ValueError(f"{name} must be finite and positive")
+    return number
+
+
+def _non_negative(value: object, name: str) -> float:
+    if isinstance(value, bool) or not isinstance(value, (int, float, str)):
+        raise TypeError(f"{name} must be a number")
+    try:
+        number = float(value)
+    except (TypeError, ValueError, OverflowError) as exc:
+        raise ValueError(f"{name} must be finite and non-negative") from exc
+    if not math.isfinite(number) or number < 0.0:
+        raise ValueError(f"{name} must be finite and non-negative")
+    return number
+
+
+def _fit_kde(values: tuple[float, ...], parameters: BaselineParameters) -> _KDE:
+    data = np.asarray(values, dtype=float)
+    if data.ndim != 1 or data.size < 2 or not np.all(np.isfinite(data)):
+        raise BaselineDataError("KDE requires at least two finite values")
+
+    adjusted = data.copy()
+    if float(np.ptp(adjusted)) == 0.0:
+        scale = max(abs(float(adjusted[0])), 1.0) * parameters.zero_range_epsilon
+        adjusted += np.random.default_rng(parameters.random_seed).normal(
+            0.0, scale, adjusted.size
+        )
+
+    try:
+        method = None if parameters.bandwidth == "auto" else float(parameters.bandwidth)
+        model = gaussian_kde(adjusted, bw_method=method)
+        bandwidth = float(np.sqrt(model.covariance[0, 0]))
+        span = float(np.ptp(adjusted))
+        padding = max(
+            span * parameters.padding_ratio,
+            parameters.tail_bandwidths * bandwidth,
+        )
+        grid = np.linspace(
+            float(np.min(adjusted)) - padding,
+            float(np.max(adjusted)) + padding,
+            parameters.grid_size,
+        )
+        density = np.maximum(np.asarray(model(grid), dtype=float), 0.0)
+    except (np.linalg.LinAlgError, ValueError, FloatingPointError) as exc:
+        raise BaselineDataError("KDE fitting failed") from exc
+    if not np.all(np.isfinite(density)):
+        raise BaselineDataError("KDE produced a non-finite density")
+    return _KDE(grid=grid, density=density, bandwidth=bandwidth)
+
+
+def _quantile(kde: _KDE, probability: float) -> float:
+    increments = (kde.density[:-1] + kde.density[1:]) * 0.5 * np.diff(kde.grid)
+    cdf = np.concatenate((np.asarray([0.0]), np.cumsum(increments)))
+    total = float(cdf[-1])
+    if not math.isfinite(total) or total <= 0.0:
+        raise BaselineDataError("KDE density has no positive finite mass")
+    cdf = np.maximum.accumulate(cdf / total)
+    cdf[-1] = 1.0
+    return float(np.interp(probability, cdf, kde.grid))
+
+
+def _regions(kde: _KDE, prominence_ratio: float) -> list[tuple[float, float, float]]:
+    peaks, _ = find_peaks(kde.density)
+    valleys, _ = find_peaks(-kde.density)
+    if peaks.size == 0:
+        peaks = np.asarray([int(np.argmax(kde.density))])
+    minimum = float(np.max(kde.density)) * prominence_ratio
+    retained = peaks[peak_prominences(kde.density, peaks)[0] >= minimum]
+    if retained.size == 0:
+        retained = np.asarray([peaks[int(np.argmax(kde.density[peaks]))]])
+    if retained.size == 1:
+        peak = int(retained[0])
+        return [(float(kde.grid[0]), float(kde.grid[-1]), float(kde.grid[peak]))]
+
+    regions: list[tuple[float, float, float]] = []
+    for raw_peak in retained:
+        peak = int(raw_peak)
+        left = valleys[valleys < peak]
+        right = valleys[valleys > peak]
+        left_index = int(left[-1]) if left.size else 0
+        right_index = int(right[0]) if right.size else len(kde.grid) - 1
+        regions.append(
+            (
+                float(kde.grid[left_index]),
+                float(kde.grid[right_index]),
+                float(kde.grid[peak]),
+            )
+        )
+    return regions
+
+
+def _maximum_gap(steps: tuple[int, ...], parameters: BaselineParameters) -> float:
+    if parameters.maximum_step_gap is not None:
+        return parameters.maximum_step_gap
+    differences = np.diff(np.asarray(steps, dtype=float))
+    positive = differences[differences > 0.0]
+    return (
+        math.inf
+        if positive.size == 0
+        else float(np.median(positive)) * parameters.step_gap_factor
+    )
+
+
+def _candidates(
+    steps: tuple[int, ...],
+    values: tuple[float, ...],
+    regions: list[tuple[float, float, float]],
+    maximum_gap: float,
+) -> list[_Segment]:
+    assignments: list[int | None] = []
+    for value in values:
+        eligible = [
+            index
+            for index, (lower, upper, _peak) in enumerate(regions)
+            if lower <= value <= upper
+        ]
+        assignments.append(
+            min(eligible, key=lambda index: (abs(value - regions[index][2]), index))
+            if eligible
+            else None
+        )
+
+    candidates: list[_Segment] = []
+    for region_index in range(len(regions)):
+        run: list[int] = []
+        for index, assignment in enumerate(assignments):
+            gap = bool(run and steps[index] - steps[run[-1]] > maximum_gap)
+            if (assignment != region_index or gap) and run:
+                candidates.append(_segment_from_indexes(run, steps, values))
+                run = []
+            if assignment == region_index:
+                run.append(index)
+        if run:
+            candidates.append(_segment_from_indexes(run, steps, values))
+    return candidates
+
+
+def _segment_from_indexes(
+    indexes: list[int], steps: tuple[int, ...], values: tuple[float, ...]
+) -> _Segment:
+    return _Segment(
+        steps=tuple(steps[index] for index in indexes),
+        values=tuple(values[index] for index in indexes),
+    )
+
+
+def _within(
+    value: float, mean: float, std: float, parameters: BaselineParameters
+) -> bool:
+    if std == 0.0:
+        precision = 8.0 * max(math.ulp(value), math.ulp(mean))
+        return math.isclose(value, mean, rel_tol=0.0, abs_tol=precision)
+    margin = parameters.std_factor * std
+    adjustment = (parameters.within_std_coefficient - 1.0) * margin
+    return mean - margin + adjustment < value < mean + margin - adjustment
+
+
+def _stable(segment: _Segment, parameters: BaselineParameters) -> bool:
+    size = len(segment.values) // 3
+    if size == 0:
+        return False
+    values = np.asarray(segment.values)
+    parts = (values[:size], values[size : 2 * size], values[2 * size :])
+    means = tuple(float(np.mean(part)) for part in parts)
+    deviations = tuple(float(np.std(part, ddof=0)) for part in parts)
+    effective = tuple(
+        max(std, abs(mean) * parameters.mean_tolerance_ratio, 8.0 * math.ulp(mean))
+        for mean, std in zip(means, deviations)
+    )
+    comparisons = ((0, 1), (1, 0), (1, 2), (2, 1), (0, 2), (2, 0))
+    passed = sum(
+        _within(means[target], means[reference], effective[reference], parameters)
+        for target, reference in comparisons
+    )
+    return passed >= parameters.minimum_passed_flags
+
+
+def _outward_lower(value: float, ratio: float) -> float:
+    return value / ratio if value >= 0.0 else value * ratio
+
+
+def _outward_upper(value: float, ratio: float) -> float:
+    return value * ratio if value >= 0.0 else value / ratio
+
+
+DEFAULT_BASELINE_PARAMETERS = BaselineParameters()
+
+
+def fit_series_baseline(
+    frames: list[StepFrame] | tuple[StepFrame, ...],
+    identity: SeriesId,
+    *,
+    parameters: BaselineParameters = DEFAULT_BASELINE_PARAMETERS,
+) -> SeriesBaseline:
+    """Fit independent KDE bounds for every stable mode of one series."""
+
+    observations = tuple(
+        (frame.step, float(value))
+        for frame in frames
+        if (value := frame.values.get(identity)) is not None and math.isfinite(value)
+    )
+    if len(observations) < parameters.minimum_samples:
+        raise InsufficientBaselineDataError(
+            f"{identity.name!r} has {len(observations)} valid samples; "
+            f"at least {parameters.minimum_samples} are required"
+        )
+
+    steps = tuple(step for step, _value in observations)
+    values = tuple(value for _step, value in observations)
+    history_kde = _fit_kde(values, parameters)
+    candidates = _candidates(
+        steps,
+        values,
+        _regions(history_kde, parameters.peak_prominence_ratio),
+        _maximum_gap(steps, parameters),
+    )
+    stable = [segment for segment in candidates if _stable(segment, parameters)]
+    if not stable:
+        raise NoStableSegmentError(f"{identity.name!r} has no stable normal segment")
+
+    ranges: list[NormalRange] = []
+    for mode_id, segment in enumerate(stable):
+        kde = _fit_kde(segment.values, parameters)
+        kde_lower = _quantile(kde, parameters.alpha)
+        kde_upper = _quantile(kde, 1.0 - parameters.alpha)
+        ranges.append(
+            NormalRange(
+                mode_id=mode_id,
+                start_step=segment.steps[0],
+                end_step=segment.steps[-1],
+                sample_count=len(segment.values),
+                kde_lower=kde_lower,
+                kde_upper=kde_upper,
+                lower=_outward_lower(kde_lower, parameters.lower_ratio),
+                upper=_outward_upper(kde_upper, parameters.upper_ratio),
+                bandwidth=kde.bandwidth,
+            )
+        )
+    return SeriesBaseline(
+        identity=identity, sample_count=len(values), ranges=tuple(ranges)
+    )
+
+
+def fit_baselines(
+    frames: list[StepFrame] | tuple[StepFrame, ...],
+    *,
+    parameters: BaselineParameters = DEFAULT_BASELINE_PARAMETERS,
+) -> BaselineFit:
+    """Fit every series present in the frames without hiding sparse inputs."""
+
+    identities = sorted({identity for frame in frames for identity in frame.values})
+    baselines: dict[SeriesId, SeriesBaseline] = {}
+    skipped: dict[SeriesId, str] = {}
+    for identity in identities:
+        try:
+            baselines[identity] = fit_series_baseline(
+                frames, identity, parameters=parameters
+            )
+        except BaselineDataError as exc:
+            skipped[identity] = str(exc)
+    return BaselineFit(baselines=baselines, skipped=skipped)
+
+
+__all__ = [
+    "DEFAULT_BASELINE_PARAMETERS",
+    "BaselineDataError",
+    "BaselineFit",
+    "BaselineParameters",
+    "InsufficientBaselineDataError",
+    "NoStableSegmentError",
+    "NormalRange",
+    "SeriesBaseline",
+    "fit_baselines",
+    "fit_series_baseline",
+]

--- a/experiment/degradation/cli.py
+++ b/experiment/degradation/cli.py
@@ -1,0 +1,134 @@
+"""Command-line entry point for one-shot offline degradation analysis."""
+
+from __future__ import annotations
+
+import argparse
+import datetime as dt
+import json
+import sys
+from pathlib import Path
+
+from .input import DEFAULT_TSDB_DIR, OfflineInputError
+from .offline import OfflineAnalysisError, analyze_offline
+from .state import StateError
+from .window import WindowError
+
+
+def _timestamp(value: str) -> float:
+    try:
+        return float(value)
+    except ValueError:
+        parsed = dt.datetime.fromisoformat(value.replace("Z", "+00:00"))
+        if parsed.tzinfo is None:
+            raise argparse.ArgumentTypeError(
+                "time must be a Unix timestamp or ISO-8601 value with timezone"
+            )
+        return parsed.timestamp()
+
+
+def _range_name(start_time: float, end_time: float) -> str:
+    def stamp(value: float) -> str:
+        return dt.datetime.fromtimestamp(value, dt.timezone.utc).strftime(
+            "%Y%m%dT%H%M%SZ"
+        )
+
+    return f"{stamp(start_time)}_{stamp(end_time)}"
+
+
+def _parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(
+        prog="python -m experiment.degradation.cli",
+        description="Analyze one time range from the local RL-Insight TSDB.",
+    )
+    parser.add_argument("command", choices=("analyze",))
+    parser.add_argument(
+        "--start-time",
+        required=True,
+        type=_timestamp,
+        help="Unix seconds or an ISO-8601 timestamp with timezone.",
+    )
+    parser.add_argument(
+        "--end-time",
+        required=True,
+        type=_timestamp,
+        help="Unix seconds or an ISO-8601 timestamp with timezone.",
+    )
+    parser.add_argument(
+        "--data-dir",
+        type=Path,
+        default=DEFAULT_TSDB_DIR,
+        help="Prometheus TSDB directory (default: ~/.rl-insight/data/prometheus).",
+    )
+    parser.add_argument(
+        "--analysis-dir",
+        type=Path,
+        default=Path("analysis"),
+        help="Root directory for one report folder per selected time range.",
+    )
+    parser.add_argument(
+        "--baseline-file",
+        type=Path,
+        help="Load this baseline, or create it from the first 30 complete steps.",
+    )
+    parser.add_argument("--promtool", type=Path, help="Explicit promtool path.")
+    return parser
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = _parser()
+    args = parser.parse_args(argv)
+    if args.start_time >= args.end_time:
+        parser.error("--start-time must be earlier than --end-time")
+    report_dir = args.analysis_dir.expanduser() / _range_name(
+        args.start_time, args.end_time
+    )
+    baseline = (
+        args.baseline_file.expanduser()
+        if args.baseline_file is not None
+        else report_dir / "standard_data.json"
+    )
+    output = report_dir / "abnormal_data.json"
+    try:
+        result = analyze_offline(
+            args.data_dir,
+            start_time=args.start_time,
+            end_time=args.end_time,
+            baseline_path=baseline,
+            output_path=output,
+            promtool_path=args.promtool,
+        )
+    except (
+        OfflineAnalysisError,
+        OfflineInputError,
+        StateError,
+        WindowError,
+        TypeError,
+        ValueError,
+    ) as exc:
+        error_kind = (
+            "offline_analysis_error"
+            if isinstance(exc, OfflineAnalysisError)
+            else "invalid_input_or_state"
+        )
+        print(
+            json.dumps(
+                {"status": "error", "error_kind": error_kind, "message": str(exc)},
+                indent=2,
+                sort_keys=True,
+            ),
+            file=sys.stderr,
+        )
+        return 1
+    report_data_path = report_dir / "analysis.json"
+    result["analysis"]["report_data_path"] = str(report_data_path.resolve())
+    result["analysis"]["report_path"] = str((report_dir / "report.md").resolve())
+    report_data_path.parent.mkdir(parents=True, exist_ok=True)
+    report_data_path.write_text(
+        json.dumps(result, indent=2, sort_keys=True) + "\n", encoding="utf-8"
+    )
+    print(json.dumps(result, indent=2, sort_keys=True))
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/experiment/degradation/detector.py
+++ b/experiment/degradation/detector.py
@@ -1,0 +1,398 @@
+# Copyright (c) 2026 verl-project authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Classify step values and track confirmed target degradation events."""
+
+from __future__ import annotations
+
+import math
+from collections import deque
+from collections.abc import Mapping
+from dataclasses import dataclass
+from enum import Enum
+
+from .baseline import NormalRange, SeriesBaseline
+from .series import SeriesId
+from .window import StepFrame
+
+
+class DetectorError(ValueError):
+    """The supplied baseline, policy, or point cannot be detected safely."""
+
+
+class Policy(str, Enum):
+    """Directions that make a point abnormal for one metric role."""
+
+    UP = "UP"
+    DOWN = "DOWN"
+    BOTH = "BOTH"
+
+
+class Direction(str, Enum):
+    """A valid value's position relative to all fitted normal ranges."""
+
+    NORMAL = "NORMAL"
+    UP = "UP"
+    DOWN = "DOWN"
+    BETWEEN_MODES = "BETWEEN_MODES"
+
+
+@dataclass(frozen=True)
+class DetectorParameters:
+    """Evidence-window parameters for target event tracking."""
+
+    evidence_window: int = 5
+    minimum_abnormal: int = 3
+
+    def __post_init__(self) -> None:
+        for name in ("evidence_window", "minimum_abnormal"):
+            value = getattr(self, name)
+            if isinstance(value, bool) or not isinstance(value, int):
+                raise TypeError(f"{name} must be an integer")
+            if value <= 0:
+                raise ValueError(f"{name} must be positive")
+        if self.minimum_abnormal > self.evidence_window:
+            raise ValueError("minimum_abnormal must not exceed evidence_window")
+
+
+@dataclass(frozen=True)
+class PointResult:
+    """Point-level classification for one series in one training step."""
+
+    identity: SeriesId
+    step: int
+    start_time: float
+    end_time: float
+    value: float | None
+    policy: Policy
+    direction: Direction | None
+    abnormal: bool
+    matched_mode: int | None
+
+    @property
+    def valid(self) -> bool:
+        return self.value is not None
+
+
+@dataclass
+class _ActiveEvent:
+    """Minimal mutable state for one confirmed target event."""
+
+    identity: SeriesId
+    direction: Direction
+    start_step: int
+    start_time: float
+    confirmed_at_step: int
+    confirmed_at_time: float
+    last_abnormal_step: int
+    last_abnormal_time: float
+    abnormal_points: int
+
+
+@dataclass(frozen=True)
+class DegradationEvent:
+    """Immutable event snapshot emitted at confirmation, closure, or range end."""
+
+    identity: SeriesId
+    direction: Direction
+    start_step: int
+    start_time: float
+    confirmed_at_step: int
+    confirmed_at_time: float
+    end_step: int
+    end_time: float
+    closed_at_step: int | None
+    closed_at_time: float | None
+    abnormal_points: int
+    evidence_points: int
+    evidence_abnormal_points: int
+
+
+@dataclass(frozen=True)
+class EventUpdate:
+    """One tracker update and any lifecycle notification it produced."""
+
+    point: PointResult
+    evidence_abnormal_points: int | None = None
+    confirmed_event: DegradationEvent | None = None
+    closed_event: DegradationEvent | None = None
+
+
+DEFAULT_DETECTOR_PARAMETERS = DetectorParameters()
+
+
+def _policy(value: Policy | str) -> Policy:
+    if isinstance(value, Policy):
+        return value
+    if not isinstance(value, str):
+        raise TypeError("policy must be UP, DOWN, or BOTH")
+    try:
+        return Policy(value.upper())
+    except ValueError as exc:
+        raise DetectorError("policy must be UP, DOWN, or BOTH") from exc
+
+
+def _validated_ranges(baseline: SeriesBaseline) -> tuple[NormalRange, ...]:
+    if not baseline.ranges:
+        raise DetectorError("baseline must contain at least one normal range")
+    for normal_range in baseline.ranges:
+        if not all(
+            math.isfinite(value) for value in (normal_range.lower, normal_range.upper)
+        ):
+            raise DetectorError("normal range bounds must be finite")
+        if normal_range.lower > normal_range.upper:
+            raise DetectorError("normal range lower bound must not exceed upper bound")
+    return baseline.ranges
+
+
+def _abnormal(direction: Direction, policy: Policy) -> bool:
+    if direction is Direction.NORMAL:
+        return False
+    if policy is Policy.BOTH:
+        return True
+    return direction.value == policy.value
+
+
+def classify_point(
+    frame: StepFrame,
+    baseline: SeriesBaseline,
+    *,
+    policy: Policy | str,
+) -> PointResult:
+    """Classify one step value without mutating baseline or runtime state."""
+
+    selected_policy = _policy(policy)
+    ranges = _validated_ranges(baseline)
+    raw_value = frame.values.get(baseline.identity)
+    if raw_value is None:
+        return PointResult(
+            identity=baseline.identity,
+            step=frame.step,
+            start_time=frame.start_time,
+            end_time=frame.end_time,
+            value=None,
+            policy=selected_policy,
+            direction=None,
+            abnormal=False,
+            matched_mode=None,
+        )
+    if isinstance(raw_value, bool) or not math.isfinite(raw_value):
+        raise DetectorError("point value must be finite or None")
+
+    value = float(raw_value)
+    matched = next(
+        (
+            normal_range.mode_id
+            for normal_range in ranges
+            if normal_range.lower <= value <= normal_range.upper
+        ),
+        None,
+    )
+    if matched is not None:
+        direction = Direction.NORMAL
+    elif value > max(normal_range.upper for normal_range in ranges):
+        direction = Direction.UP
+    elif value < min(normal_range.lower for normal_range in ranges):
+        direction = Direction.DOWN
+    else:
+        direction = Direction.BETWEEN_MODES
+
+    return PointResult(
+        identity=baseline.identity,
+        step=frame.step,
+        start_time=frame.start_time,
+        end_time=frame.end_time,
+        value=value,
+        policy=selected_policy,
+        direction=direction,
+        abnormal=_abnormal(direction, selected_policy),
+        matched_mode=matched,
+    )
+
+
+def classify_frame(
+    frame: StepFrame,
+    baselines: Mapping[SeriesId, SeriesBaseline],
+    policies: Mapping[SeriesId, Policy | str],
+) -> dict[SeriesId, PointResult]:
+    """Classify every fitted series in one step using explicit policies."""
+
+    missing = [identity for identity in baselines if identity not in policies]
+    if missing:
+        names = ", ".join(repr(identity) for identity in sorted(missing))
+        raise DetectorError(f"missing policies for series: {names}")
+    return {
+        identity: classify_point(frame, baseline, policy=policies[identity])
+        for identity, baseline in baselines.items()
+    }
+
+
+def _event_snapshot(
+    event: _ActiveEvent,
+    parameters: DetectorParameters,
+    evidence_count: int,
+    closed_by: PointResult | None = None,
+) -> DegradationEvent:
+    return DegradationEvent(
+        identity=event.identity,
+        direction=event.direction,
+        start_step=event.start_step,
+        start_time=event.start_time,
+        confirmed_at_step=event.confirmed_at_step,
+        confirmed_at_time=event.confirmed_at_time,
+        end_step=event.last_abnormal_step,
+        end_time=event.last_abnormal_time,
+        closed_at_step=None if closed_by is None else closed_by.step,
+        closed_at_time=None if closed_by is None else closed_by.end_time,
+        abnormal_points=event.abnormal_points,
+        evidence_points=parameters.evidence_window,
+        evidence_abnormal_points=evidence_count,
+    )
+
+
+class EventTracker:
+    """Track one UP-policy target with a symmetric valid-point window."""
+
+    def __init__(
+        self,
+        identity: SeriesId,
+        *,
+        parameters: DetectorParameters = DEFAULT_DETECTOR_PARAMETERS,
+    ) -> None:
+        if not isinstance(identity, SeriesId):
+            raise TypeError("identity must be a SeriesId")
+        self.identity = identity
+        self.parameters = parameters
+        self.recent_points: deque[PointResult] = deque(
+            maxlen=parameters.evidence_window
+        )
+        self.current_event: _ActiveEvent | None = None
+        self._last_step: int | None = None
+
+    def update(self, point: PointResult) -> EventUpdate:
+        """Consume one classified target point and emit lifecycle transitions."""
+
+        if point.identity != self.identity:
+            raise DetectorError("point identity does not match event tracker")
+        if point.policy is not Policy.UP:
+            raise DetectorError("target event tracking requires policy UP")
+        if self._last_step is not None and point.step != self._last_step + 1:
+            raise DetectorError(
+                f"target steps must be consecutive: expected {self._last_step + 1}, "
+                f"got {point.step}"
+            )
+
+        self._last_step = point.step
+        self.recent_points.append(point)
+        if (
+            self.current_event is not None
+            and point.valid
+            and point.abnormal
+            and point.direction is Direction.UP
+        ):
+            self.current_event.last_abnormal_step = point.step
+            self.current_event.last_abnormal_time = point.end_time
+            self.current_event.abnormal_points += 1
+
+        if len(self.recent_points) < self.parameters.evidence_window:
+            return EventUpdate(point=point)
+        if not all(item.valid for item in self.recent_points):
+            return EventUpdate(point=point)
+
+        up_points = [
+            item
+            for item in self.recent_points
+            if item.abnormal and item.direction is Direction.UP
+        ]
+        evidence_count = len(up_points)
+        has_evidence = evidence_count >= self.parameters.minimum_abnormal
+
+        if self.current_event is not None:
+            if has_evidence:
+                return EventUpdate(
+                    point=point,
+                    evidence_abnormal_points=evidence_count,
+                )
+            closed = _event_snapshot(
+                self.current_event,
+                self.parameters,
+                evidence_count,
+                closed_by=point,
+            )
+            self.current_event = None
+            self.recent_points.clear()
+            return EventUpdate(
+                point=point,
+                evidence_abnormal_points=evidence_count,
+                closed_event=closed,
+            )
+
+        if not has_evidence:
+            return EventUpdate(
+                point=point,
+                evidence_abnormal_points=evidence_count,
+            )
+
+        first, last = up_points[0], up_points[-1]
+        self.current_event = _ActiveEvent(
+            identity=self.identity,
+            direction=Direction.UP,
+            start_step=first.step,
+            start_time=first.start_time,
+            confirmed_at_step=point.step,
+            confirmed_at_time=point.end_time,
+            last_abnormal_step=last.step,
+            last_abnormal_time=last.end_time,
+            abnormal_points=evidence_count,
+        )
+        confirmed = _event_snapshot(
+            self.current_event,
+            self.parameters,
+            evidence_count,
+        )
+        return EventUpdate(
+            point=point,
+            evidence_abnormal_points=evidence_count,
+            confirmed_event=confirmed,
+        )
+
+    def snapshot_open_event(self) -> DegradationEvent | None:
+        """Return the current confirmed event without closing it."""
+
+        if self.current_event is None:
+            return None
+        evidence_count = sum(
+            point.valid and point.abnormal and point.direction is Direction.UP
+            for point in self.recent_points
+        )
+        return _event_snapshot(
+            self.current_event,
+            self.parameters,
+            evidence_count,
+        )
+
+
+__all__ = [
+    "DEFAULT_DETECTOR_PARAMETERS",
+    "DegradationEvent",
+    "DetectorError",
+    "DetectorParameters",
+    "Direction",
+    "EventTracker",
+    "EventUpdate",
+    "PointResult",
+    "Policy",
+    "classify_frame",
+    "classify_point",
+]

--- a/experiment/degradation/input.py
+++ b/experiment/degradation/input.py
@@ -1,0 +1,103 @@
+"""Read a selected time range directly from a local Prometheus TSDB."""
+
+from __future__ import annotations
+
+import json
+import math
+import re
+import shutil
+import subprocess
+from collections import defaultdict
+from pathlib import Path
+
+from .series import Sample, SeriesDataError, SeriesId, TimeSeries
+
+DEFAULT_TSDB_DIR = Path.home() / ".rl-insight" / "data" / "prometheus"
+DEFAULT_PROMTOOL_ROOT = Path.home() / ".rl-insight" / "services" / "prometheus"
+
+_SAMPLE_LINE = re.compile(r"^(\{.*\})\s+(\S+)\s+(-?\d+)$")
+_LABEL = re.compile(r'([a-zA-Z_][a-zA-Z0-9_]*)=("(?:\\.|[^"\\])*")')
+
+
+class OfflineInputError(ValueError):
+    """The local TSDB cannot provide the requested samples."""
+
+
+def _promtool(explicit: Path | None) -> Path:
+    if explicit is not None:
+        return explicit.expanduser()
+    system = shutil.which("promtool")
+    if system:
+        return Path(system)
+    installed = sorted(DEFAULT_PROMTOOL_ROOT.rglob("promtool"))
+    if installed:
+        return installed[-1]
+    raise OfflineInputError("promtool was not found")
+
+
+def _label_set(value: str) -> dict[str, str]:
+    return {
+        match.group(1): json.loads(match.group(2)) for match in _LABEL.finditer(value)
+    }
+
+
+def _parse_dump(output: str) -> tuple[TimeSeries, ...]:
+    merged: dict[SeriesId, dict[float, float]] = defaultdict(dict)
+    for line in output.splitlines():
+        match = _SAMPLE_LINE.match(line.strip())
+        if match is None:
+            continue
+        try:
+            identity = SeriesId.from_label_set(_label_set(match.group(1)))
+            value = float(match.group(2))
+            timestamp = int(match.group(3)) / 1000.0
+        except (SeriesDataError, ValueError, json.JSONDecodeError):
+            continue
+        if math.isfinite(value):
+            merged[identity][timestamp] = value
+    return tuple(
+        TimeSeries(
+            identity=identity,
+            samples=tuple(
+                Sample(timestamp, value) for timestamp, value in sorted(samples.items())
+            ),
+        )
+        for identity, samples in sorted(merged.items())
+        if samples
+    )
+
+
+def load_time_series(
+    data_dir: Path,
+    *,
+    start_time: float,
+    end_time: float,
+    metric_names: frozenset[str],
+    promtool_path: Path | None = None,
+) -> tuple[TimeSeries, ...]:
+    """Dump configured scalar series from the RL-Insight Prometheus TSDB."""
+
+    selector = (
+        '{__name__=~"^(' + "|".join(sorted(map(re.escape, metric_names))) + ')$"}'
+    )
+    command = [
+        str(_promtool(promtool_path)),
+        "tsdb",
+        "dump",
+        f"--min-time={int(start_time * 1000)}",
+        f"--max-time={int(end_time * 1000)}",
+        f"--match={selector}",
+        str(data_dir.expanduser()),
+    ]
+    completed = subprocess.run(command, capture_output=True, text=True, check=False)
+    if completed.returncode:
+        raise OfflineInputError(completed.stderr.strip() or "promtool tsdb dump failed")
+    series = _parse_dump(completed.stdout)
+    if not series:
+        raise OfflineInputError(
+            "the selected time range contains no configured metrics"
+        )
+    return series
+
+
+__all__ = ["DEFAULT_TSDB_DIR", "OfflineInputError", "load_time_series"]

--- a/experiment/degradation/metrics.py
+++ b/experiment/degradation/metrics.py
@@ -1,0 +1,266 @@
+# Copyright (c) 2026 verl-project authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Metric catalog for the degradation experiment."""
+
+from dataclasses import dataclass
+
+GLOBAL_STEP_METRIC = "rl_insight_monitor_training_global_step"
+
+# Fixed scalar latency targets that can trigger degradation events.
+TARGET_METRICS = (
+    "rl_insight_monitor_timing_s_step",
+    "rl_insight_monitor_timing_s_gen",
+    "rl_insight_monitor_timing_s_ref",
+    "rl_insight_monitor_timing_s_adv",
+    "rl_insight_monitor_timing_s_old_log_prob",
+    "rl_insight_monitor_timing_s_update_actor",
+    "rl_insight_monitor_timing_s_update_weights",
+    "rl_insight_monitor_timing_s_testing",
+)
+
+# Histogram families are cataloged but require aggregation before modeling.
+HISTOGRAM_TARGET_METRICS = (
+    "vllm:e2e_request_latency_seconds",
+    "vllm:time_to_first_token_seconds",
+    "vllm:request_time_per_output_token_seconds",
+    "vllm:request_queue_time_seconds",
+    "vllm:request_prefill_time_seconds",
+    "vllm:request_decode_time_seconds",
+    "tq_controller_request_duration_seconds",
+)
+
+
+@dataclass(frozen=True)
+class MetricSpec:
+    """One scalar association candidate and its presentation category."""
+
+    name: str
+    category: str
+
+
+CANDIDATE_CATEGORIES = (
+    "latency",
+    "training_quality",
+    "rollout_quality",
+    "data_characteristics",
+    "hardware_resources",
+    "vllm_engine",
+    "transfer_queue",
+)
+
+# Keep this in runtime order. Every derived candidate view comes from this one
+# catalog, so detection and model-facing presentation cannot drift apart.
+CANDIDATE_METRIC_SPECS = (
+    MetricSpec("rl_insight_monitor_timing_per_token_ms_gen", "latency"),
+    MetricSpec("rl_insight_monitor_timing_per_token_ms_ref", "latency"),
+    MetricSpec("rl_insight_monitor_timing_per_token_ms_adv", "latency"),
+    MetricSpec("rl_insight_monitor_timing_per_token_ms_update_actor", "latency"),
+    MetricSpec("rl_insight_monitor_perf_time_per_step", "latency"),
+    MetricSpec("rl_insight_monitor_perf_throughput", "latency"),
+    MetricSpec("rl_insight_monitor_perf_mfu_actor", "hardware_resources"),
+    MetricSpec("rl_insight_monitor_perf_total_num_tokens", "data_characteristics"),
+    MetricSpec(
+        "rl_insight_monitor_actor_perf_cpu_memory_used_gb", "hardware_resources"
+    ),
+    MetricSpec(
+        "rl_insight_monitor_actor_perf_max_memory_allocated_gb", "hardware_resources"
+    ),
+    MetricSpec(
+        "rl_insight_monitor_actor_perf_max_memory_reserved_gb", "hardware_resources"
+    ),
+    MetricSpec("rl_insight_monitor_prompt_length_mean", "data_characteristics"),
+    MetricSpec("rl_insight_monitor_prompt_length_max", "data_characteristics"),
+    MetricSpec("rl_insight_monitor_prompt_length_min", "data_characteristics"),
+    MetricSpec("rl_insight_monitor_prompt_length_clip_ratio", "data_characteristics"),
+    MetricSpec("rl_insight_monitor_response_length_mean", "data_characteristics"),
+    MetricSpec("rl_insight_monitor_response_length_max", "data_characteristics"),
+    MetricSpec("rl_insight_monitor_response_length_min", "data_characteristics"),
+    MetricSpec("rl_insight_monitor_response_length_clip_ratio", "data_characteristics"),
+    MetricSpec(
+        "rl_insight_monitor_response_length_non_aborted_mean", "data_characteristics"
+    ),
+    MetricSpec(
+        "rl_insight_monitor_response_length_non_aborted_max", "data_characteristics"
+    ),
+    MetricSpec(
+        "rl_insight_monitor_response_length_non_aborted_min", "data_characteristics"
+    ),
+    MetricSpec(
+        "rl_insight_monitor_response_length_non_aborted_clip_ratio",
+        "data_characteristics",
+    ),
+    MetricSpec("rl_insight_monitor_response_aborted_ratio", "rollout_quality"),
+    MetricSpec("rl_insight_monitor_global_seqlen_mean", "data_characteristics"),
+    MetricSpec("rl_insight_monitor_global_seqlen_max", "data_characteristics"),
+    MetricSpec("rl_insight_monitor_global_seqlen_min", "data_characteristics"),
+    MetricSpec("rl_insight_monitor_global_seqlen_minmax_diff", "data_characteristics"),
+    MetricSpec("rl_insight_monitor_global_seqlen_balanced_max", "data_characteristics"),
+    MetricSpec("rl_insight_monitor_global_seqlen_balanced_min", "data_characteristics"),
+    MetricSpec("rl_insight_monitor_actor_loss", "training_quality"),
+    MetricSpec("rl_insight_monitor_actor_pg_loss", "training_quality"),
+    MetricSpec("rl_insight_monitor_actor_kl_loss", "training_quality"),
+    MetricSpec("rl_insight_monitor_actor_entropy_loss", "training_quality"),
+    MetricSpec("rl_insight_monitor_actor_entropy", "training_quality"),
+    MetricSpec("rl_insight_monitor_actor_ppo_kl", "training_quality"),
+    MetricSpec("rl_insight_monitor_actor_kl_coef", "training_quality"),
+    MetricSpec("rl_insight_monitor_actor_pg_clipfrac", "training_quality"),
+    MetricSpec("rl_insight_monitor_actor_pg_clipfrac_lower", "training_quality"),
+    MetricSpec("rl_insight_monitor_actor_grad_norm", "training_quality"),
+    MetricSpec("rl_insight_monitor_actor_lr", "training_quality"),
+    MetricSpec("rl_insight_monitor_critic_score_mean", "training_quality"),
+    MetricSpec("rl_insight_monitor_critic_score_max", "training_quality"),
+    MetricSpec("rl_insight_monitor_critic_score_min", "training_quality"),
+    MetricSpec("rl_insight_monitor_critic_rewards_mean", "training_quality"),
+    MetricSpec("rl_insight_monitor_critic_rewards_max", "training_quality"),
+    MetricSpec("rl_insight_monitor_critic_rewards_min", "training_quality"),
+    MetricSpec("rl_insight_monitor_critic_returns_mean", "training_quality"),
+    MetricSpec("rl_insight_monitor_critic_returns_max", "training_quality"),
+    MetricSpec("rl_insight_monitor_critic_returns_min", "training_quality"),
+    MetricSpec("rl_insight_monitor_critic_advantages_mean", "training_quality"),
+    MetricSpec("rl_insight_monitor_critic_advantages_max", "training_quality"),
+    MetricSpec("rl_insight_monitor_critic_advantages_min", "training_quality"),
+    MetricSpec("rl_insight_monitor_training_epoch", "training_quality"),
+    MetricSpec("rl_insight_monitor_training_num_turns_mean", "data_characteristics"),
+    MetricSpec("rl_insight_monitor_training_num_turns_max", "data_characteristics"),
+    MetricSpec("rl_insight_monitor_training_num_turns_min", "data_characteristics"),
+    MetricSpec(
+        "rl_insight_monitor_training_off_policy_trajectory_staleness_mean",
+        "rollout_quality",
+    ),
+    MetricSpec(
+        "rl_insight_monitor_training_off_policy_trajectory_staleness_max",
+        "rollout_quality",
+    ),
+    MetricSpec(
+        "rl_insight_monitor_training_off_policy_trajectory_staleness_worst_mean",
+        "rollout_quality",
+    ),
+    MetricSpec(
+        "rl_insight_monitor_training_off_policy_trajectory_staleness_worst_max",
+        "rollout_quality",
+    ),
+    MetricSpec(
+        "rl_insight_monitor_training_off_policy_trajectory_staleness_worst_min",
+        "rollout_quality",
+    ),
+    MetricSpec(
+        "rl_insight_monitor_training_off_policy_trajectory_spans_mean",
+        "rollout_quality",
+    ),
+    MetricSpec(
+        "rl_insight_monitor_training_off_policy_trajectory_spans_max", "rollout_quality"
+    ),
+    MetricSpec(
+        "rl_insight_monitor_training_off_policy_trajectory_spans_min", "rollout_quality"
+    ),
+    MetricSpec(
+        "rl_insight_monitor_training_rollout_probs_diff_mean", "rollout_quality"
+    ),
+    MetricSpec("rl_insight_monitor_training_rollout_probs_diff_max", "rollout_quality"),
+    MetricSpec("rl_insight_monitor_training_rollout_probs_diff_std", "rollout_quality"),
+    MetricSpec(
+        "rl_insight_monitor_training_rollout_probs_diff_valid", "rollout_quality"
+    ),
+    MetricSpec(
+        "rl_insight_monitor_training_rollout_actor_probs_pearson_corr",
+        "rollout_quality",
+    ),
+    MetricSpec("rl_insight_monitor_rollout_corr_kl", "rollout_quality"),
+    MetricSpec("rl_insight_monitor_rollout_corr_k3_kl", "rollout_quality"),
+    MetricSpec("rl_insight_monitor_rollout_corr_chi2_seq", "rollout_quality"),
+    MetricSpec("rl_insight_monitor_rollout_corr_chi2_token", "rollout_quality"),
+    MetricSpec("rl_insight_monitor_rollout_corr_log_ppl_diff", "rollout_quality"),
+    MetricSpec("rl_insight_monitor_rollout_corr_log_ppl_diff_max", "rollout_quality"),
+    MetricSpec("rl_insight_monitor_rollout_corr_log_ppl_diff_min", "rollout_quality"),
+    MetricSpec("rl_insight_monitor_rollout_corr_log_ppl_abs_diff", "rollout_quality"),
+    MetricSpec("rl_insight_monitor_rollout_corr_ppl_ratio", "rollout_quality"),
+    MetricSpec("rl_insight_monitor_rollout_corr_rollout_log_ppl", "rollout_quality"),
+    MetricSpec("rl_insight_monitor_rollout_corr_rollout_ppl", "rollout_quality"),
+    MetricSpec("rl_insight_monitor_rollout_corr_training_log_ppl", "rollout_quality"),
+    MetricSpec("rl_insight_monitor_rollout_corr_training_ppl", "rollout_quality"),
+    MetricSpec("rl_insight_monitor_val_aux_num_turns_mean", "data_characteristics"),
+    MetricSpec("rl_insight_monitor_val_aux_num_turns_max", "data_characteristics"),
+    MetricSpec("rl_insight_monitor_val_aux_num_turns_min", "data_characteristics"),
+    MetricSpec("vllm:request_max_num_generation_tokens", "vllm_engine"),
+    MetricSpec("vllm:request_prompt_tokens", "vllm_engine"),
+    MetricSpec("vllm:request_generation_tokens", "vllm_engine"),
+    MetricSpec("vllm:kv_cache_usage_perc", "vllm_engine"),
+    MetricSpec("vllm:num_requests_running", "vllm_engine"),
+    MetricSpec("vllm:num_requests_waiting", "vllm_engine"),
+    MetricSpec("vllm:num_requests_swapped", "vllm_engine"),
+    MetricSpec("tq_storage_request_latency_p50", "transfer_queue"),
+    MetricSpec("tq_storage_request_latency_p99", "transfer_queue"),
+    MetricSpec("tq_controller_uptime_seconds", "transfer_queue"),
+    MetricSpec("tq_controller_memory_rss_bytes", "transfer_queue"),
+    MetricSpec("tq_partition_production_progress", "transfer_queue"),
+    MetricSpec("tq_partition_consumption_progress", "transfer_queue"),
+    MetricSpec("tq_storage_utilization_ratio", "transfer_queue"),
+    MetricSpec("tq_storage_memory_rss_bytes", "transfer_queue"),
+    MetricSpec("tq_storage_request_ops", "transfer_queue"),
+)
+
+# Scalar metrics that can be modeled directly with a BOTH policy.
+CANDIDATE_METRICS = tuple(spec.name for spec in CANDIDATE_METRIC_SPECS)
+CATEGORY_BY_METRIC = {spec.name: spec.category for spec in CANDIDATE_METRIC_SPECS}
+CANDIDATE_METRICS_BY_CATEGORY = {
+    category: tuple(
+        spec.name for spec in CANDIDATE_METRIC_SPECS if spec.category == category
+    )
+    for category in CANDIDATE_CATEGORIES
+}
+
+# Raw counters are cataloged but require rate or increase before modeling.
+RATE_REQUIRED_CANDIDATE_METRICS = (
+    "vllm:generation_tokens_total",
+    "vllm:prompt_tokens_total",
+    "vllm:request_success_total",
+    "vllm:prefix_cache_hits_total",
+    "vllm:prefix_cache_queries_total",
+    "vllm:spec_decode_num_accepted_tokens_total",
+    "vllm:spec_decode_num_draft_tokens_total",
+    "vllm:spec_decode_num_drafts_total",
+    "tq_controller_request_total",
+    "tq_controller_request_samples_total",
+    "tq_partitions_total",
+    "tq_partition_samples_total",
+    "tq_storage_active_keys_total",
+    "tq_storage_capacity_total",
+    "tq_global_index_allocated_total",
+    "tq_global_index_reusable_total",
+)
+
+CATALOG_TARGET_METRICS = TARGET_METRICS + HISTOGRAM_TARGET_METRICS
+CATALOG_CANDIDATE_METRICS = CANDIDATE_METRICS + RATE_REQUIRED_CANDIDATE_METRICS
+METRIC_CATALOG = (
+    GLOBAL_STEP_METRIC,
+    *CATALOG_TARGET_METRICS,
+    *CATALOG_CANDIDATE_METRICS,
+)
+
+__all__ = [
+    "CANDIDATE_CATEGORIES",
+    "CANDIDATE_METRICS",
+    "CANDIDATE_METRICS_BY_CATEGORY",
+    "CANDIDATE_METRIC_SPECS",
+    "CATALOG_CANDIDATE_METRICS",
+    "CATALOG_TARGET_METRICS",
+    "CATEGORY_BY_METRIC",
+    "GLOBAL_STEP_METRIC",
+    "HISTOGRAM_TARGET_METRICS",
+    "METRIC_CATALOG",
+    "RATE_REQUIRED_CANDIDATE_METRICS",
+    "TARGET_METRICS",
+    "MetricSpec",
+]

--- a/experiment/degradation/offline.py
+++ b/experiment/degradation/offline.py
@@ -1,0 +1,317 @@
+"""Run the existing degradation algorithm once over offline Prometheus data."""
+
+from __future__ import annotations
+
+import math
+from collections import Counter, deque
+from collections.abc import Mapping, Sequence
+from pathlib import Path
+from typing import Any
+
+from .association import AssociationParameters, analyze_association
+from .baseline import BaselineParameters, SeriesBaseline, fit_baselines
+from .detector import (
+    DegradationEvent,
+    Direction,
+    EventTracker,
+    PointResult,
+    Policy,
+    classify_frame,
+)
+from .input import load_time_series
+from .metrics import CANDIDATE_METRICS, GLOBAL_STEP_METRIC, TARGET_METRICS
+from .series import SeriesId, TimeSeries
+from .state import (
+    BaselineSnapshot,
+    association_json,
+    event_json,
+    load_baseline,
+    present_events,
+    save_baseline,
+    save_events,
+)
+from .window import StepFrame, build_step_frames
+
+BASELINE_STEPS = 30
+PRE_CONTEXT_STEPS = 30
+TOP_K = 25
+
+
+class OfflineAnalysisError(RuntimeError):
+    """The supplied offline batch cannot complete the analysis."""
+
+
+def _step_number(value: float) -> int:
+    step = round(value)
+    if not math.isclose(value, step, rel_tol=0.0, abs_tol=1.0e-9):
+        raise OfflineAnalysisError("global-step values must be integers")
+    return step
+
+
+def _global_step_series(series: Sequence[TimeSeries]) -> TimeSeries:
+    matches = [item for item in series if item.identity.name == GLOBAL_STEP_METRIC]
+    if len(matches) != 1:
+        raise OfflineAnalysisError(
+            f"{GLOBAL_STEP_METRIC!r} must have exactly one concrete series, "
+            f"got {len(matches)}"
+        )
+    return matches[0]
+
+
+def _step_span(global_steps: TimeSeries) -> tuple[int, int]:
+    """Return the first complete step after range start and the final boundary."""
+
+    if not global_steps.samples:
+        raise OfflineAnalysisError("global-step series is empty")
+    steps = [_step_number(sample.value) for sample in global_steps.samples]
+    return min(steps) + 1, max(steps)
+
+
+def _dominant_direction(
+    context: Sequence[Mapping[SeriesId, PointResult]],
+    identity: SeriesId,
+    *,
+    start_step: int,
+    end_step: int,
+) -> str:
+    counts = Counter(
+        point.direction.value
+        for row in context
+        if (point := row[identity]).valid
+        and point.abnormal
+        and point.direction is not None
+        and start_step <= point.step <= end_step
+    )
+    if not counts:
+        return Direction.NORMAL.value
+    maximum = max(counts.values())
+    leaders = [direction for direction, count in counts.items() if count == maximum]
+    return leaders[0] if len(leaders) == 1 else "MIXED"
+
+
+class OfflineAnalyzer:
+    """Stateful event tracker used only while one offline batch is processed."""
+
+    def __init__(
+        self,
+        baselines: Mapping[SeriesId, SeriesBaseline],
+        *,
+        association_parameters: AssociationParameters | None = None,
+    ) -> None:
+        targets = frozenset(TARGET_METRICS)
+        candidates = frozenset(CANDIDATE_METRICS)
+        self.baselines = {
+            identity: baseline
+            for identity, baseline in baselines.items()
+            if identity.name in targets or identity.name in candidates
+        }
+        self.policies = {
+            identity: Policy.UP if identity.name in targets else Policy.BOTH
+            for identity in self.baselines
+        }
+        target_ids = [
+            identity
+            for identity, policy in self.policies.items()
+            if policy is Policy.UP
+        ]
+        candidate_ids = [
+            identity
+            for identity, policy in self.policies.items()
+            if policy is Policy.BOTH
+        ]
+        if not target_ids:
+            raise OfflineAnalysisError("the baseline contains no configured target")
+        if not candidate_ids:
+            raise OfflineAnalysisError("the baseline contains no configured candidate")
+        self.trackers = {identity: EventTracker(identity) for identity in target_ids}
+        self.association_parameters = association_parameters or AssociationParameters()
+        self.recent: deque[dict[SeriesId, PointResult]] = deque(
+            maxlen=PRE_CONTEXT_STEPS + 5
+        )
+        self.active_contexts: dict[SeriesId, list[dict[SeriesId, PointResult]]] = {}
+        self.events: list[dict[str, Any]] = []
+        self._last_step: int | None = None
+
+    def _association(
+        self,
+        event: DegradationEvent,
+        context: Sequence[Mapping[SeriesId, PointResult]],
+    ) -> dict[str, Any]:
+        result = analyze_association(
+            [row[event.identity] for row in context],
+            {
+                identity: [row[identity] for row in context]
+                for identity, policy in self.policies.items()
+                if policy is Policy.BOTH
+            },
+            event_start_step=event.start_step,
+            parameters=self.association_parameters,
+        )
+        top = result.associations[:TOP_K]
+        directions = {
+            item.identity: _dominant_direction(
+                context,
+                item.identity,
+                start_step=event.start_step,
+                end_step=event.end_step,
+            )
+            for item in top
+        }
+        return association_json(result, top, directions)
+
+    def process(self, frames: Sequence[StepFrame]) -> None:
+        for frame in frames:
+            if self._last_step is not None and frame.step != self._last_step + 1:
+                raise OfflineAnalysisError(
+                    f"detection frames must be consecutive: expected "
+                    f"{self._last_step + 1}, got {frame.step}"
+                )
+            results = classify_frame(frame, self.baselines, self.policies)
+            for context in self.active_contexts.values():
+                context.append(results)
+            self.recent.append(results)
+
+            for identity, tracker in sorted(self.trackers.items()):
+                update = tracker.update(results[identity])
+                if update.confirmed_event is not None:
+                    event = update.confirmed_event
+                    first_step = event.start_step - PRE_CONTEXT_STEPS
+                    context = [
+                        row for row in self.recent if row[identity].step >= first_step
+                    ]
+                    self.active_contexts[identity] = context
+                if update.closed_event is not None:
+                    event = update.closed_event
+                    context = self.active_contexts.pop(identity)
+                    self.events.append(
+                        event_json(
+                            event,
+                            self._association(event, context),
+                            phase="closed",
+                        )
+                    )
+            self._last_step = frame.step
+
+    def finalize_range_end(self) -> None:
+        """Analyze confirmed events that remain open at the selected range end."""
+
+        for identity, tracker in sorted(self.trackers.items()):
+            event = tracker.snapshot_open_event()
+            if event is None:
+                continue
+            context = self.active_contexts.pop(identity)
+            self.events.append(
+                event_json(
+                    event,
+                    self._association(event, context),
+                    phase="open_at_range_end",
+                )
+            )
+
+
+def analyze_offline(
+    data_dir: Path,
+    *,
+    start_time: float,
+    end_time: float,
+    baseline_path: Path,
+    output_path: Path,
+    promtool_path: Path | None = None,
+) -> dict[str, Any]:
+    """Read one TSDB range and analyze each final event once."""
+
+    configured_names = {GLOBAL_STEP_METRIC, *TARGET_METRICS, *CANDIDATE_METRICS}
+    all_series = load_time_series(
+        data_dir,
+        start_time=start_time,
+        end_time=end_time,
+        metric_names=frozenset(configured_names),
+        promtool_path=promtool_path,
+    )
+    selected_series = tuple(
+        item for item in all_series if item.identity.name in configured_names
+    )
+    global_steps = _global_step_series(selected_series)
+    first_step, final_boundary = _step_span(global_steps)
+    metrics = [
+        item for item in selected_series if item.identity != global_steps.identity
+    ]
+
+    if baseline_path.exists():
+        snapshot = load_baseline(baseline_path)
+        baseline_action = "loaded"
+    else:
+        if final_boundary - first_step < BASELINE_STEPS:
+            raise OfflineAnalysisError(
+                f"training a baseline requires {BASELINE_STEPS} complete steps; "
+                f"the batch contains {final_boundary - first_step}"
+            )
+        baseline_frames = build_step_frames(
+            global_steps,
+            metrics,
+            start_step=first_step,
+            step_count=BASELINE_STEPS,
+        )
+        fitted = fit_baselines(baseline_frames, parameters=BaselineParameters())
+        target_count = sum(
+            identity.name in TARGET_METRICS for identity in fitted.baselines
+        )
+        candidate_count = sum(
+            identity.name in CANDIDATE_METRICS for identity in fitted.baselines
+        )
+        if not target_count or not candidate_count:
+            raise OfflineAnalysisError(
+                "baseline fitting requires at least one usable configured target "
+                "and one usable configured candidate"
+            )
+        snapshot = BaselineSnapshot(
+            start_step=baseline_frames[0].step,
+            end_step=baseline_frames[-1].step,
+            global_step_identity=global_steps.identity,
+            parameters=BaselineParameters(),
+            baselines=fitted.baselines,
+        )
+        save_baseline(baseline_path, snapshot)
+        baseline_action = "trained"
+
+    analyzer = OfflineAnalyzer(snapshot.baselines)
+    detection_start = max(first_step, snapshot.end_step + 1)
+    detection_count = max(0, final_boundary - detection_start)
+    if detection_count:
+        analysis_metrics = [
+            item for item in metrics if item.identity in analyzer.baselines
+        ]
+        analyzer.process(
+            build_step_frames(
+                global_steps,
+                analysis_metrics,
+                start_step=detection_start,
+                step_count=detection_count,
+            )
+        )
+        analyzer.finalize_range_end()
+    save_events(output_path, analyzer.events)
+    return {
+        "status": "ok",
+        "baseline": {
+            "action": baseline_action,
+            "path": str(baseline_path.resolve()),
+            "start_step": snapshot.start_step,
+            "end_step": snapshot.end_step,
+            "series_count": len(snapshot.baselines),
+        },
+        "analysis": {
+            "data_dir": str(data_dir.expanduser().resolve()),
+            "start_time": start_time,
+            "end_time": end_time,
+            "detection_start_step": detection_start if detection_count else None,
+            "detection_end_step": final_boundary - 1 if detection_count else None,
+            "processed_step_count": detection_count,
+            "event_count": len(analyzer.events),
+            "result_path": str(output_path.resolve()),
+        },
+        "events": present_events(analyzer.events),
+    }
+
+
+__all__ = ["OfflineAnalysisError", "analyze_offline"]

--- a/experiment/degradation/series.py
+++ b/experiment/degradation/series.py
@@ -1,0 +1,57 @@
+"""Small data model shared by offline input and the analysis algorithm."""
+
+from __future__ import annotations
+
+import math
+from collections.abc import Mapping
+from dataclasses import dataclass
+from typing import Any
+
+
+class SeriesDataError(ValueError):
+    """Offline series data is malformed."""
+
+
+@dataclass(frozen=True, order=True)
+class SeriesId:
+    """A Prometheus series identified by metric name and labels."""
+
+    name: str
+    labels: tuple[tuple[str, str], ...] = ()
+
+    @classmethod
+    def from_label_set(cls, value: Mapping[str, Any]) -> SeriesId:
+        if not isinstance(value, Mapping):
+            raise SeriesDataError("series labels must be an object")
+        name = value.get("__name__")
+        if not isinstance(name, str) or not name:
+            raise SeriesDataError("series is missing __name__")
+        labels = []
+        for key, label_value in value.items():
+            if not isinstance(key, str) or not isinstance(label_value, str):
+                raise SeriesDataError("series labels must be strings")
+            if key != "__name__":
+                labels.append((key, label_value))
+        return cls(name=name, labels=tuple(sorted(labels)))
+
+    def to_label_set(self) -> dict[str, str]:
+        return {"__name__": self.name, **dict(self.labels)}
+
+
+@dataclass(frozen=True)
+class Sample:
+    timestamp: float
+    value: float
+
+    def __post_init__(self) -> None:
+        if not math.isfinite(self.timestamp) or not math.isfinite(self.value):
+            raise SeriesDataError("sample timestamp and value must be finite")
+
+
+@dataclass(frozen=True)
+class TimeSeries:
+    identity: SeriesId
+    samples: tuple[Sample, ...]
+
+
+__all__ = ["Sample", "SeriesDataError", "SeriesId", "TimeSeries"]

--- a/experiment/degradation/state.py
+++ b/experiment/degradation/state.py
@@ -1,0 +1,235 @@
+"""Minimal JSON persistence for an offline baseline and analysis result."""
+
+from __future__ import annotations
+
+import json
+from collections.abc import Mapping, Sequence
+from dataclasses import asdict, dataclass
+from pathlib import Path
+from typing import Any
+
+from .association import AssociationItem, AssociationResult
+from .baseline import BaselineParameters, NormalRange, SeriesBaseline
+from .detector import DegradationEvent
+from .metrics import CANDIDATE_CATEGORIES, CATEGORY_BY_METRIC
+from .series import SeriesId
+
+SCHEMA_VERSION = 1
+
+
+class StateError(RuntimeError):
+    """A baseline or result file cannot be read or written."""
+
+
+@dataclass(frozen=True)
+class BaselineSnapshot:
+    start_step: int
+    end_step: int
+    global_step_identity: SeriesId
+    parameters: BaselineParameters
+    baselines: dict[SeriesId, SeriesBaseline]
+
+
+def _identity_json(identity: SeriesId) -> dict[str, Any]:
+    return {"metric": identity.name, "labels": dict(identity.labels)}
+
+
+def _identity_from_json(value: object) -> SeriesId:
+    if not isinstance(value, Mapping):
+        raise StateError("series identity must be an object")
+    metric = value.get("metric")
+    labels = value.get("labels", {})
+    if not isinstance(metric, str) or not metric or not isinstance(labels, Mapping):
+        raise StateError("series identity is invalid")
+    label_set: dict[str, str] = {"__name__": metric}
+    for key, label_value in labels.items():
+        if not isinstance(key, str) or not isinstance(label_value, str):
+            raise StateError("series labels must be strings")
+        label_set[key] = label_value
+    return SeriesId.from_label_set(label_set)
+
+
+def _write(path: Path, payload: Mapping[str, Any]) -> None:
+    try:
+        path.parent.mkdir(parents=True, exist_ok=True)
+        path.write_text(
+            json.dumps(payload, indent=2, sort_keys=True) + "\n", encoding="utf-8"
+        )
+    except OSError as exc:
+        raise StateError(f"cannot write {path}: {exc}") from exc
+
+
+def save_baseline(path: Path, snapshot: BaselineSnapshot) -> None:
+    series = []
+    for identity, baseline in sorted(snapshot.baselines.items()):
+        series.append(
+            {
+                **_identity_json(identity),
+                "sample_count": baseline.sample_count,
+                "ranges": [asdict(normal_range) for normal_range in baseline.ranges],
+            }
+        )
+    _write(
+        path,
+        {
+            "schema_version": SCHEMA_VERSION,
+            "baseline": {
+                "start_step": snapshot.start_step,
+                "end_step": snapshot.end_step,
+                "global_step": _identity_json(snapshot.global_step_identity),
+                "parameters": asdict(snapshot.parameters),
+                "series": series,
+            },
+        },
+    )
+
+
+def load_baseline(path: Path) -> BaselineSnapshot:
+    try:
+        payload = json.loads(path.read_text(encoding="utf-8"))
+        raw = payload["baseline"]
+        parameters = BaselineParameters(**raw["parameters"])
+        baselines: dict[SeriesId, SeriesBaseline] = {}
+        for item in raw["series"]:
+            identity = _identity_from_json(item)
+            baselines[identity] = SeriesBaseline(
+                identity=identity,
+                sample_count=int(item["sample_count"]),
+                ranges=tuple(NormalRange(**value) for value in item["ranges"]),
+            )
+        snapshot = BaselineSnapshot(
+            start_step=int(raw["start_step"]),
+            end_step=int(raw["end_step"]),
+            global_step_identity=_identity_from_json(raw["global_step"]),
+            parameters=parameters,
+            baselines=baselines,
+        )
+    except (OSError, json.JSONDecodeError, KeyError, TypeError, ValueError) as exc:
+        raise StateError(f"cannot load baseline {path}: {exc}") from exc
+    if payload.get("schema_version") != SCHEMA_VERSION or not snapshot.baselines:
+        raise StateError(f"baseline {path} has an unsupported or empty schema")
+    return snapshot
+
+
+def association_json(
+    result: AssociationResult,
+    top_associations: Sequence[AssociationItem],
+    directions: Mapping[SeriesId, str],
+) -> dict[str, Any]:
+    return {
+        "status": result.status,
+        "top_k": [
+            {
+                **_identity_json(item.identity),
+                "direction": directions[item.identity],
+                "association_percent": item.association_score * 100.0,
+                "pearson": item.pearson,
+                "spearman": item.spearman,
+                "selected_correlation": item.selected_correlation,
+                "selected_correlation_method": item.selected_correlation_method,
+                "correlation_share": item.correlation_share,
+                "random_forest_eligible": item.random_forest_eligible,
+                "random_forest_importance": item.random_forest_importance,
+                "random_forest_share": item.random_forest_share,
+                "aligned_sample_count": item.aligned_sample_count,
+                "coverage_ratio": item.coverage_ratio,
+            }
+            for item in top_associations
+        ],
+        "effective_correlation_weight": result.effective_correlation_weight,
+        "effective_random_forest_weight": result.effective_random_forest_weight,
+        "random_forest_status": result.random_forest_status,
+        "random_forest_reason": result.random_forest_reason,
+        "random_forest_sample_count": result.random_forest_sample_count,
+        "random_forest_validation_score": result.random_forest_validation_score,
+        "skipped_candidates": [
+            {**_identity_json(item.identity), "reason": item.reason}
+            for item in result.skipped_candidates
+        ],
+    }
+
+
+def event_json(
+    event: DegradationEvent,
+    association: Mapping[str, Any],
+    *,
+    phase: str,
+) -> dict[str, Any]:
+    """Serialize one final event view and its single whole-event analysis."""
+
+    if phase not in {"closed", "open_at_range_end"}:
+        raise ValueError("phase must be closed or open_at_range_end")
+
+    return {
+        "target": event.identity.name,
+        "target_labels": dict(event.identity.labels),
+        "direction": event.direction.value,
+        "start_step": event.start_step,
+        "start_time": event.start_time,
+        "end_step": event.end_step,
+        "end_time": event.end_time,
+        "confirmed_at_step": event.confirmed_at_step,
+        "confirmed_at_time": event.confirmed_at_time,
+        "closed_at_step": event.closed_at_step,
+        "closed_at_time": event.closed_at_time,
+        "abnormal_points": event.abnormal_points,
+        "event_state": phase,
+        "association": {phase: dict(association)},
+    }
+
+
+def save_events(path: Path, events: Sequence[Mapping[str, Any]]) -> None:
+    _write(path, {"schema_version": SCHEMA_VERSION, "events": list(events)})
+
+
+def _group_top_k(top_k: Sequence[Mapping[str, Any]]) -> list[dict[str, Any]]:
+    category_order = {name: index for index, name in enumerate(CANDIDATE_CATEGORIES)}
+    groups: dict[str, list[dict[str, Any]]] = {}
+    for rank, raw in enumerate(top_k, start=1):
+        item = dict(raw)
+        item["global_rank"] = rank
+        category = CATEGORY_BY_METRIC.get(str(item["metric"]), "uncategorized")
+        groups.setdefault(category, []).append(item)
+    ordered = sorted(
+        groups.items(),
+        key=lambda pair: (
+            pair[1][0]["global_rank"],
+            category_order.get(pair[0], len(category_order)),
+        ),
+    )
+    return [
+        {
+            "category": category,
+            "distinct_metric_count": len({item["metric"] for item in metrics}),
+            "best_global_rank": metrics[0]["global_rank"],
+            "metrics": metrics,
+        }
+        for category, metrics in ordered
+    ]
+
+
+def present_events(events: Sequence[Mapping[str, Any]]) -> list[dict[str, Any]]:
+    """Present closed and range-end-open event association results."""
+
+    presented = []
+    for event in json.loads(json.dumps(list(events))):
+        phase = str(event.get("event_state", "closed"))
+        association = event["association"].get(phase)
+        if association is None:
+            continue
+        association["top_k_by_category"] = _group_top_k(association.pop("top_k"))
+        event["association"] = {phase: association}
+        presented.append(event)
+    return presented
+
+
+__all__ = [
+    "BaselineSnapshot",
+    "StateError",
+    "association_json",
+    "event_json",
+    "load_baseline",
+    "present_events",
+    "save_baseline",
+    "save_events",
+]

--- a/experiment/degradation/window.py
+++ b/experiment/degradation/window.py
@@ -1,0 +1,155 @@
+# Copyright (c) 2026 verl-project authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Align Prometheus time series to training-step intervals."""
+
+from __future__ import annotations
+
+import math
+from bisect import bisect_left
+from collections.abc import Mapping, Sequence
+from dataclasses import dataclass
+
+from .series import SeriesId, TimeSeries
+
+
+class WindowError(ValueError):
+    """The input time series cannot form valid step frames."""
+
+
+class MissingGlobalStepError(WindowError):
+    """A required global-step boundary is missing."""
+
+
+@dataclass(frozen=True)
+class StepFrame:
+    """Metric snapshots for one half-open training-step interval."""
+
+    step: int
+    start_time: float
+    end_time: float
+    values: Mapping[SeriesId, float | None]
+
+
+def _integer_step(value: float) -> int:
+    if not math.isfinite(value):
+        raise WindowError("global-step values must be finite integers")
+    step = round(value)
+    if not math.isclose(value, step, rel_tol=0.0, abs_tol=1e-9):
+        raise WindowError("global-step values must be finite integers")
+    return step
+
+
+def _step_boundaries(global_steps: TimeSeries) -> dict[int, float]:
+    samples = sorted(global_steps.samples, key=lambda sample: sample.timestamp)
+    if not samples:
+        raise MissingGlobalStepError("global-step series is empty")
+
+    boundaries: dict[int, float] = {}
+    previous: int | None = None
+    for sample in samples:
+        if not math.isfinite(sample.timestamp):
+            raise WindowError("global-step timestamps must be finite")
+        step = _integer_step(sample.value)
+        if previous is not None and step < previous:
+            raise WindowError("global-step values must be monotonic")
+        boundaries.setdefault(step, sample.timestamp)
+        previous = step
+    return boundaries
+
+
+def _finite_points(series: TimeSeries) -> tuple[list[float], list[float]]:
+    points = sorted(
+        (
+            (sample.timestamp, sample.value)
+            for sample in series.samples
+            if math.isfinite(sample.timestamp) and math.isfinite(sample.value)
+        ),
+        key=lambda point: point[0],
+    )
+    return (
+        [timestamp for timestamp, _ in points],
+        [value for _, value in points],
+    )
+
+
+def _last_value(
+    timestamps: Sequence[float],
+    values: Sequence[float],
+    start: float,
+    end: float,
+) -> float | None:
+    left = bisect_left(timestamps, start)
+    right = bisect_left(timestamps, end)
+    return values[right - 1] if left < right else None
+
+
+def build_step_frames(
+    global_steps: TimeSeries,
+    metrics: Sequence[TimeSeries],
+    *,
+    start_step: int,
+    step_count: int,
+) -> list[StepFrame]:
+    """Build step-indexed snapshots using the last value in each interval."""
+
+    if isinstance(start_step, bool) or not isinstance(start_step, int):
+        raise TypeError("start_step must be an integer")
+    if isinstance(step_count, bool) or not isinstance(step_count, int):
+        raise TypeError("step_count must be an integer")
+    if step_count <= 0:
+        raise ValueError("step_count must be positive")
+
+    boundaries = _step_boundaries(global_steps)
+    required_steps = tuple(range(start_step, start_step + step_count + 1))
+    missing = [step for step in required_steps if step not in boundaries]
+    if missing:
+        values = ", ".join(str(step) for step in missing)
+        raise MissingGlobalStepError(f"missing global-step boundaries: {values}")
+
+    interval_times = [boundaries[step] for step in required_steps]
+    if any(start >= end for start, end in zip(interval_times, interval_times[1:])):
+        raise WindowError("global-step boundaries must have increasing timestamps")
+
+    metric_points: dict[SeriesId, tuple[list[float], list[float]]] = {}
+    for metric in metrics:
+        if metric.identity == global_steps.identity:
+            continue
+        if metric.identity in metric_points:
+            raise WindowError(f"duplicate metric series: {metric.identity!r}")
+        metric_points[metric.identity] = _finite_points(metric)
+
+    frames: list[StepFrame] = []
+    for index, step in enumerate(required_steps[:-1]):
+        start, end = interval_times[index : index + 2]
+        frames.append(
+            StepFrame(
+                step=step,
+                start_time=start,
+                end_time=end,
+                values={
+                    identity: _last_value(timestamps, values, start, end)
+                    for identity, (timestamps, values) in metric_points.items()
+                },
+            )
+        )
+    return frames
+
+
+__all__ = [
+    "MissingGlobalStepError",
+    "StepFrame",
+    "WindowError",
+    "build_step_frames",
+]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -24,6 +24,11 @@ dependencies = [
 ]
 
 [project.optional-dependencies]
+degradation = [
+  "numpy",
+  "scikit-learn",
+  "scipy",
+]
 recipe = [
   "numpy",
   "pandas",


### PR DESCRIPTION
# [recipe] feat: add offline degradation association analysis

## What does this PR do?

RL 训练性能劣化后，定位根因往往需要在大量监控指标中人工比对，缺少自动化的"劣化事件 → 关联指标"证据链。本 PR 新增**离线性能劣化关联分析**能力：用户只需选定时间范围，即可从本地 Prometheus TSDB 完成一次性的劣化检测与关联分析，产出每个劣化事件的分组 Top-25 关联证据与根因推断，全部产物落在 `analysis/<start>_<end>/`（`standard_data.json` 基线 / `abnormal_data.json` 事件证据 / `analysis.json` 完整结果 / `report.md` Markdown 报告）：

- **Agent Skill**（`.agent/skills/degradation-association-offline/`）：环境检查 → 驱动一次分析 → 渲染 Top-25 关联报告 → 给出受词表约束的根因推断（两个故障域 + 3–5 个原因，按置信度排序）；
- **确定性算法**（`recipe/perf_analysis/degradation/`）：`promtool tsdb dump` 直读 TSDB → 按 global_step 对齐 → KDE 基线拟合/加载 → 3-of-5 target 事件检测 → 相关 + 随机森林双证据 Top-25 关联排序 → JSON 证据落盘，Skill 据此生成 `report.md`。

定位上与在线监控互补：在线侧负责指标采集与实时监控，本 PR 面向历史时间段提供**一次性、可复现、可验证**的劣化归因分析；检测目标为 8 个时延类指标，候选证据为 102 个标量指标（7 类），覆盖 vllm 引擎、TransferQueue、训练质量与数据特征等维度。

## Test

端到端链路依赖本地 TSDB 与 `promtool`，CI 环境无数据源，算法正确性以实验验证，环境、步骤与结果如下。

### Test environment

- RL-Insight 默认配置；
- 默认本地 Prometheus TSDB：`~/.rl-insight/data/prometheus`；
- 默认报告目录：`analysis/`；
- 未提供已有基线文件，使用检测范围内前 30 个完整 step 重新训练基线；
- reset 使用默认值：No。

### Test steps

1. 启动模型训练任务并确认 RL-Insight 正常采集训练指标。
2. 在仓库根目录调用 `degradation-association-offline` Skill，并提供检测时间范围。
3. 检查 `analysis/<start>_<end>/standard_data.json`，确认基线已成功训练并保存。
4. 在检测阶段中途改变序列长度，引入 workload/data 异常。
5. 检查 `analysis/<start>_<end>/abnormal_data.json`，确认检测到 `rl_insight_monitor_timing_s_step` 异常事件。
6. 检查该事件的 Top-25 关联结果及指标分类。
7. 检查 `analysis.json` 和 `report.md`，确认分析结果及根因推断已保存。

### Test results

检测到的异常事件及其关联分析结果如下。关联评分越高，表示该指标与异常事件在所分析时间窗口内的相关性越强；该评分不代表故障概率或因果关系。

Abnormal target metric: `rl_insight_monitor_timing_s_step`

| Metric category | Metric name | Metric meaning | Association score |
| --- | --- | --- | ---: |
| rollout_quality | rl_insight_monitor_rollout_corr_ppl_ratio | 逐序列 training PPL 与 rollout PPL 比值的平均值。 | 4.93% |
| &nbsp; | rl_insight_monitor_rollout_corr_chi2_seq | 训练策略与 Rollout 策略之间的序列级卡方散度。 | 4.93% |
| &nbsp; | rl_insight_monitor_rollout_corr_chi2_token | 训练策略与 Rollout 策略之间的 token 级卡方散度。 | 4.93% |
| &nbsp; | rl_insight_monitor_rollout_corr_training_log_ppl | 训练策略逐序列 log 困惑度的批次平均值。 | 4.69% |
| &nbsp; | rl_insight_monitor_rollout_corr_training_ppl | 训练策略逐序列困惑度的批次平均值。 | 4.40% |
| &nbsp; | rl_insight_monitor_training_rollout_probs_diff_mean | Rollout 引擎概率与 Actor 重算概率之绝对差的平均值。 | 2.52% |
| &nbsp; | rl_insight_monitor_training_rollout_probs_diff_std | Rollout 引擎概率与 Actor 重算概率之绝对差的标准差。 | 2.01% |
| &nbsp; | rl_insight_monitor_training_rollout_actor_probs_pearson_corr | Rollout 引擎概率与 Actor 重算概率之间的 Pearson 相关系数。 | 2.00% |
| &nbsp; | rl_insight_monitor_rollout_corr_log_ppl_diff_min | 逐序列 log 困惑度差的最小值。 | 1.91% |
| &nbsp; | rl_insight_monitor_rollout_corr_log_ppl_abs_diff | 逐序列 log 困惑度差绝对值的平均值。 | 1.71% |
| latency | rl_insight_monitor_perf_throughput | 按设备数归一化的训练吞吐量（token/s/device）。 | 4.86% |
| hardware_resources | rl_insight_monitor_perf_mfu_actor | Actor 训练的模型浮点运算利用率，即实际计算吞吐相对理论峰值的比例。 | 4.48% |
| &nbsp; | rl_insight_monitor_actor_perf_cpu_memory_used_gb | Actor 所在主机已使用的 CPU 内存（GB）。 | 3.93% |
| &nbsp; | rl_insight_monitor_actor_perf_max_memory_reserved_gb | Actor 运行期间 PyTorch 内存分配器保留的设备内存峰值（GB）。 | 2.16% |
| &nbsp; | rl_insight_monitor_actor_perf_max_memory_allocated_gb | Actor 运行期间 PyTorch 实际分配的设备内存峰值（GB）。 | 2.15% |
| data_characteristics | rl_insight_monitor_global_seqlen_balanced_max | 数据并行负载均衡后，各分区序列总长度的最大值。 | 2.77% |
| &nbsp; | rl_insight_monitor_global_seqlen_balanced_min | 数据并行负载均衡后，各分区序列总长度的最小值。 | 2.77% |
| &nbsp; | rl_insight_monitor_global_seqlen_mean | 数据并行负载均衡前，各分区序列总长度的平均值。 | 2.77% |
| &nbsp; | rl_insight_monitor_perf_total_num_tokens | 当前训练 step 中参与计算的 token 总数。 | 2.77% |
| &nbsp; | rl_insight_monitor_prompt_length_mean | 当前批次 Prompt token 长度的平均值。 | 2.52% |
| &nbsp; | rl_insight_monitor_global_seqlen_max | 数据并行负载均衡前，各分区序列总长度的最大值。 | 2.16% |
| &nbsp; | rl_insight_monitor_response_length_mean | 当前批次生成响应 token 长度的平均值。 | 2.16% |
| &nbsp; | rl_insight_monitor_response_length_non_aborted_mean | 排除中止样本后，响应 token 长度的平均值。 | 2.16% |
| &nbsp; | rl_insight_monitor_prompt_length_max | 当前批次 Prompt token 长度的最大值。 | 2.15% |
| &nbsp; | rl_insight_monitor_global_seqlen_min | 数据并行负载均衡前，各分区序列总长度的最小值。 | 2.11% |

```text
Primary fault domain: Compute (confidence: Low)

Secondary fault domain: HBM (confidence: Low) — Device-memory metrics appear in the association results, but their scores are weak and no direct HBM bandwidth evidence is available.

Likely fault causes:
1. AI Core overload (primary; confidence: Low) — Training throughput and Actor MFU have relatively high association scores, but no direct AI Core utilization or profiler evidence is available.
2. Sequence-length anomaly (confidence: Low) — Sequence-length, prompt-length, response-length, and total-token metrics occupy a substantial portion of the Top-25, but their individual association scores are relatively low.
3. HBM congestion (confidence: Low) — Allocated and reserved device-memory metrics appear in the results, but their weak scores do not directly demonstrate memory-bandwidth congestion.

Reasoning basis: Rollout-quality metrics have the highest association scores, but they are primarily downstream evidence and do not directly identify an infrastructure fault. Throughput and MFU provide indirect Compute evidence, while the substantial sequence-length metric family requires Sequence-length anomaly to be included. Association scores represent temporal association rather than fault probability or causality.
```

### Result assessment

本次实验中途改变了序列长度。分析结果将 Sequence-length anomaly 列为第 2 个可能原因，因此与实验真值部分匹配，但不是 Top-1 命中。结果识别出了较完整的序列长度相关证据；由于这些指标的关联分数低于领先的 rollout-quality 和 Compute 相关指标，当前诊断置信度仍为 Low，不将关联分数解释为故障概率或因果贡献。

## Usage

通过 Agent Skill 使用（示例 Prompt）：

```text
使用 degradation-association-offline 技能开启劣化关联监控
基线：重新训练基线
检测时间段：2026-09-08T09:00:00+08:00 至 2026-09-08T12:00:00+08:00
是否 reset：否
```

一次运行生成以下文件（`analysis/<start>_<end>/`）：

| 文件 | 写入方 | 内容 |
| --- | --- | --- |
| `standard_data.json` | 算法 | 冻结基线（schema v1，拟合 ranges，不含原始 30 步观测） |
| `abnormal_data.json` | 算法 | 最终事件视图（`closed` / `open_at_range_end`）+ 每事件扁平 Top-25 |
| `analysis.json` | CLI | 完整结果（状态、基线动作 trained/loaded、检测步区间、事件数、产物路径） |
| `report.md` | Skill | Top-25 关联表（中文释义）+ 根因推断 |

## Design & Code Changes

### 文件与模块职责

算法子包位于 `recipe/perf_analysis/degradation/`（下表「文件」列除注明外均为该包内文件）：

| 分层 | 文件 | 职责 |
| --- | --- | --- |
| Skill（模型侧） | `.agent/skills/degradation-association-offline/`（`SKILL.md` + `references/`：`algorithm-contract.md`、`metric-name-catalog.md`、`diagnostic-experience.md`） | 新增 Skill：操作流程、算法契约、指标中文释义、根因经验词表 |
| 模型层 | `series.py` | 领域数据模型：`SeriesId`（指标名 + 标签，排序冻结）/ `Sample` / `TimeSeries` 全部 frozen，全链路数据地基；异常 `SeriesDataError` |
| 数据层 | `input.py` | TSDB 读取：定位 promtool（显式路径 → PATH → `~/.rl-insight/services/prometheus/`），把指标全集拼成单个 `__name__=~` selector 一次 `promtool tsdb dump` 拉全，按行解析 `{labels} value timestamp_ms` 合并；坏行跳过、空结果报错。异常 `OfflineInputError` |
| 数据层 | `window.py` | step 对齐：以 global_step 为标尺生成 `StepFrame`（step k = `[t(k), t(k+1))`，区间内 last-value 聚合，缺值保留 `None`）；边界缺步即失败（`MissingGlobalStepError`），绝不推断 |
| 数据层 | `metrics.py` | 指标目录（单一事实来源）：1 个标尺 + 8 个 `timing_s_*` target（UP）+ 102 个标量候选（BOTH，7 类）；直方图与计数器仅目录化；全部角色/类别视图由此派生，检测与呈现不会漂移 |
| 数据层 | `state.py` | 持久化：`SCHEMA_VERSION=1` 基线保存/加载（严格校验，失败 `StateError`）、事件与关联 JSON 化（phase 仅 `closed` / `open_at_range_end`）、`present_events` 按类别分组 |
| 算法层 | `baseline.py` | KDE 基线：多模态拟合（峰谷分割 → 切段 → 稳定性检验 → 逐段 KDE 分位数 → 界外扩 5%）；批量失败进 `skipped` 不阻断；输出 `NormalRange`（起止 step、上下界、bandwidth）。异常族 `BaselineDataError` |
| 算法层 | `detector.py` | 点分类 + 事件状态机：纯函数分类（`NORMAL` / `UP` / `DOWN` / `BETWEEN_MODES`，target 仅认 UP、候选认非 NORMAL）；`EventTracker` 以 5 点窗口按 3-of-5 确认/关闭（UP 异常 ≥3 确认、<3 关闭，关闭即清空窗口）。异常 `DetectorError` |
| 算法层 | `association.py` | 双证据关联打分：Pearson/Spearman 取绝对值较大者 + 随机森林以异常标签建模共现（共同样本 ≥30、时序 70/30 切分、permutation importance），份额归一化加权（单一证据自动满权）。异常 `AssociationError` |
| 编排层 | `offline.py` | 编排：`analyze_offline()` 串起读 TSDB → 基线（加载或前 30 完整步训练）→ 检测 → 收尾 → 落盘；`OfflineAnalyzer` 为批内唯一状态聚合点；常量 `BASELINE_STEPS=30` / `PRE_CONTEXT_STEPS=30` / `TOP_K=25`。异常 `OfflineAnalysisError` |
| 入口层 | `cli.py` | 命令行入口：单一子命令 `analyze`，产物落 `analysis/<startUTC>_<endUTC>/`；统一异常收口（stderr 结构化 JSON 错误 + 退出码 1） |
| 包与文档 | `__init__.py` + `README.md` | 包初始化；模块 README（SKILL 用法 + 算法流程） |
| 配置 | `pyproject.toml` | `[project.optional-dependencies]` recipe extras 并入运行依赖（`numpy` / `scipy` / `scikit-learn`），`pip install -e ".[recipe]"` 即可运行 |

### 设计原则

四条原则贯穿全部模块：

- **离线可用**：`promtool tsdb dump` 直读本地 TSDB，不依赖 Prometheus HTTP 服务；
- **确定性可复现**：算法层纯函数 + frozen 数据类，随机数 seed 固定 42，同一输入必得同一输出；
- **证据与诊断分离**：代码只产出确定性证据，根因诊断由 Skill 依据词表完成，不进入算法；
- **部分成功不阻断**：单序列基线失败、单候选被排除、随机森林失败均降级，不使批次失败。

### 分层架构与依赖关系

模块依赖关系如下（单向无环，算法层单向递进，仅 `offline` 聚合全部）：

```mermaid
graph TD
    subgraph "入口层"
        CLI["cli.py — 命令行入口"]
    end
    subgraph "编排层"
        OFF["offline.py — 事件编排"]
    end
    subgraph "算法层"
        BAS["baseline.py — KDE 基线"]
        DET["detector.py — 3-of-5 检测"]
        ASC["association.py — 关联打分"]
    end
    subgraph "数据层"
        IN["input.py — TSDB 读取"]
        WIN["window.py — step 对齐"]
        STA["state.py — 持久化"]
        MET["metrics.py — 指标目录"]
    end
    subgraph "模型层"
        SER["series.py — 数据模型"]
    end
    CLI --> OFF
    CLI --> IN
    CLI --> STA
    OFF --> IN
    OFF --> WIN
    OFF --> BAS
    OFF --> DET
    OFF --> ASC
    OFF --> MET
    OFF --> STA
    BAS --> WIN
    BAS --> SER
    DET --> BAS
    DET --> WIN
    DET --> SER
    ASC --> DET
    ASC --> SER
    STA --> BAS
    STA --> DET
    STA --> ASC
    STA --> MET
    STA --> SER
    IN --> SER
    WIN --> SER
    BAS -.-> NP["numpy / scipy（KDE、峰检测）"]
    ASC -.-> SK["numpy / scipy / scikit-learn（相关系数、随机森林）"]
    IN -.-> PT["promtool 可执行文件（外部进程）"]
```

依赖规则（读图方式）：

- **分层**：`series` 与 `metrics` 是最底层地基——数据模型与指标目录，自身无内部依赖；数据层（`input` / `window` / `state`）只做读取、对齐、持久化；算法层 `baseline → detector → association` 单向递进，下游只依赖上游、上游不感知下游；`offline` 是唯一聚合全部模块的编排层；`cli` 只依赖编排层与数据层，不直接触碰算法层。
- **单向无环**：依赖图无环，任何模块都不反向依赖其调用方——算法层因此可独立加载、独立单测。
- **外部依赖**（虚线）：仅三处——KDE 与峰检测（numpy/scipy）、相关系数与随机森林（numpy/scipy/scikit-learn）、TSDB dump（promtool 外部进程），其余全为标准库。

### 数据流

```mermaid
flowchart TD
    A["TSDB 块文件"] -->|"input: load_time_series"| B["tuple[TimeSeries]"]
    B -->|"window: build_step_frames"| C["list[StepFrame]"]
    C -->|"前 30 完整步"| D["baseline: fit_baselines"]
    C -->|"检测区间"| E["detector: classify_frame"]
    D --> F["BaselineSnapshot"]
    F -->|"state: save_baseline"| G["standard_data.json"]
    E --> H["每步 PointResult 字典"]
    H -->|"detector: EventTracker（3-of-5）"| I["DegradationEvent"]
    I -->|"association: analyze_association"| J["AssociationResult（Top-25）"]
    J -->|"state: event_json + save_events"| K["abnormal_data.json"]
    J -->|"cli: 汇总完整结果"| L["analysis.json"]
    L -.->|"Skill 渲染"| M["report.md"]
```

数据约定：

- **两段用途**：StepFrame 前 30 个完整步拟合基线，基线末步之后进入检测，两段互不重叠；
- **缺值语义**：缺失值以 `None` 贯穿全链路，不丢弃、不插值；
- **不可变性**：跨模块传递的数据全部是 frozen dataclass / tuple，算法层无副作用，可独立测试、可重放。
