### PR TITLE
[monitor-config, ci] refactor: generate engine dashboards with Jsonnet

### DIFF
--- a/.github/workflows/monitor_unit_test.yml
+++ b/.github/workflows/monitor_unit_test.yml
@@ -13,8 +13,10 @@ on:
       - "rl_insight/api.py"
       - "rl_insight/client/**"
       - "rl_insight/collector/**"
+      - "rl_insight/config/services/grafana/dashboards/verl/**"
       - "rl_insight/utils/**"
       - "tests/monitor/ut/**"
+      - "tools/grafana/**"
       - ".github/workflows/monitor_unit_test.yml"
 
 concurrency:
@@ -39,6 +41,15 @@ jobs:
         uses: actions/setup-python@0b93645e9fea7318ecaed2b359559ac225c90a2b # v5.3.0
         with:
           python-version: ${{ matrix.python-version }}
+
+      - name: Set up Go
+        uses: actions/setup-go@d35c59abb061a4a6fb18e82ac0862c26744d6ab5 # v5.5.0
+        with:
+          go-version: "1.24"
+          cache: false
+
+      - name: Install Jsonnet
+        run: go install github.com/google/go-jsonnet/cmd/jsonnet@v0.22.0
 
       - name: Install monitor test dependencies
         run: pip install -e ".[test]"

--- a/tests/monitor/ut/test_grafana_dashboards.py
+++ b/tests/monitor/ut/test_grafana_dashboards.py
@@ -16,9 +16,19 @@
 
 from __future__ import annotations
 
+import json
+import subprocess
+import sys
+from pathlib import Path
+
 from omegaconf import OmegaConf
 
 from rl_insight.server.runtime import _stage_grafana_dashboards
+
+
+ROOT = Path(__file__).resolve().parents[3]
+GRAFANA_TOOLS = ROOT / "tools/grafana"
+DASHBOARD_DIR = ROOT / "rl_insight/config/services/grafana/dashboards/verl"
 
 
 def test_stage_copies_dashboard_subdirectories(tmp_path) -> None:
@@ -31,3 +41,81 @@ def test_stage_copies_dashboard_subdirectories(tmp_path) -> None:
     staged = _stage_grafana_dashboards(conf, runtime_dir)
 
     assert (staged / "verl" / "board.json").is_file()
+
+
+def test_generated_dashboards_are_up_to_date() -> None:
+    completed = subprocess.run(
+        [sys.executable, GRAFANA_TOOLS / "generate_dashboards.py", "--check"],
+        cwd=ROOT,
+        check=False,
+    )
+
+    assert completed.returncode == 0
+
+
+def test_jsonnet_modules_keep_engine_differences_explicit() -> None:
+    expression = """
+      local common = import 'tools/grafana/dashboards/common.libsonnet';
+      local vllm = import 'tools/grafana/dashboards/vllm.libsonnet';
+      local sglang = import 'tools/grafana/dashboards/sglang.libsonnet';
+      {
+        common: std.length(common.panels) + std.length(common.trainingMetrics),
+        vllm: std.length(vllm.panels),
+        sglang: std.length(sglang.panels),
+      }
+    """
+    completed = subprocess.run(
+        ["jsonnet", "-e", expression],
+        cwd=ROOT,
+        check=True,
+        capture_output=True,
+        text=True,
+    )
+
+    assert json.loads(completed.stdout) == {"common": 116, "vllm": 30, "sglang": 8}
+
+
+def test_engine_dashboards_share_only_identical_panels() -> None:
+    dashboards = {
+        engine: json.loads(
+            (DASHBOARD_DIR / f"verl_tainer_v1_with_{engine}_engine.json").read_text(
+                encoding="utf-8"
+            )
+        )
+        for engine in ("vllm", "sglang")
+    }
+    vllm_elements = dashboards["vllm"]["spec"]["elements"]
+    sglang_elements = dashboards["sglang"]["spec"]["elements"]
+
+    identical_panels = {
+        key
+        for key in vllm_elements.keys() & sglang_elements.keys()
+        if vllm_elements[key] == sglang_elements[key]
+    }
+
+    assert len(identical_panels) == 116
+    assert len(vllm_elements) == 146
+    assert len(sglang_elements) == 124
+
+    variable_names = {
+        engine: {
+            variable["spec"]["name"] for variable in dashboard["spec"]["variables"]
+        }
+        for engine, dashboard in dashboards.items()
+    }
+    assert "npu_instance" in variable_names["vllm"]
+    assert "npu_instance" not in variable_names["sglang"]
+
+    def references(value):
+        if isinstance(value, dict):
+            if value.get("kind") == "ElementReference":
+                yield value["name"]
+            for child in value.values():
+                yield from references(child)
+        elif isinstance(value, list):
+            for child in value:
+                yield from references(child)
+
+    for dashboard in dashboards.values():
+        elements = dashboard["spec"]["elements"]
+        assert set(references(dashboard["spec"]["layout"])) <= elements.keys()

--- a/tools/grafana/dashboards.jsonnet
+++ b/tools/grafana/dashboards.jsonnet
@@ -1,0 +1,7 @@
+local common = import 'dashboards/common.libsonnet';
+local dashboard = import 'dashboards/base/dashboard.libsonnet';
+
+{
+  vllm: dashboard.build(common, import 'dashboards/vllm.libsonnet'),
+  sglang: dashboard.build(common, import 'dashboards/sglang.libsonnet'),
+}

--- a/tools/grafana/dashboards/base/dashboard.libsonnet
+++ b/tools/grafana/dashboards/base/dashboard.libsonnet
@@ -1,0 +1,115 @@
+local viz = import 'viz.libsonnet';
+
+local has(object, field) = std.objectHas(object, field);
+
+// Apply an RFC 7396-style merge patch.  Panel modules only describe the
+// fields that differ from the shared visualization defaults.
+local mergePatch(base, patch) =
+  if std.type(base) != 'object' || std.type(patch) != 'object' then patch
+  else
+    {
+      [field]: base[field]
+      for field in std.objectFields(base)
+      if !has(patch, field)
+    } + {
+      [field]:
+        if has(base, field) then mergePatch(base[field], patch[field])
+        else patch[field]
+      for field in std.objectFields(patch)
+      if patch[field] != null
+    };
+
+local prometheusQuery(query) = {
+  kind: 'DataQuery',
+  group: 'prometheus',
+  version: 'v0',
+  spec: {
+    editorMode: if has(query, 'editorMode') then query.editorMode else 'builder',
+    expr: query.expr,
+    legendFormat: if has(query, 'legend') then query.legend else '{{__name__}}',
+    range: true,
+  } + (if has(query, 'extra') then query.extra else {}),
+} + (if has(query, 'labels') then { labels: query.labels } else {});
+
+local panelQuery(query, index) = {
+  kind: 'PanelQuery',
+  spec: {
+    query: if has(query, 'raw') then query.raw else prometheusQuery(query),
+    refId: if has(query, 'refId') then query.refId else std.char(std.codepoint('A') + index),
+    hidden: if has(query, 'hidden') then query.hidden else false,
+  },
+};
+
+local panel(record) = {
+  kind: 'Panel',
+  spec: {
+    id: record.id,
+    title: record.title,
+    description: if has(record, 'description') then record.description else '',
+    links: if has(record, 'links') then record.links else [],
+    data: {
+      kind: 'QueryGroup',
+      spec: {
+        queries: std.mapWithIndex(function(index, query) panelQuery(query, index), record.queries),
+        transformations: if has(record, 'transformations') then record.transformations else [],
+        queryOptions: if has(record, 'queryOptions') then record.queryOptions else {},
+      },
+    },
+    vizConfig: mergePatch(
+      viz[if has(record, 'vizBase') then record.vizBase else 'timeseries'],
+      if has(record, 'vizPatch') then record.vizPatch else {}
+    ),
+  },
+};
+
+local trainingPanel(metric) =
+  local title = metric[3];
+  local metricName =
+    if std.startsWith(title, 'rl_insight_monitor_') then title
+    else 'rl_insight_monitor_' + (if std.startsWith(title, '_') then title[1:] else title);
+  {
+    key: metric[0],
+    outputKey: metric[1],
+    id: metric[2],
+    title: title,
+    queries: [{
+      expr: metricName + '{project=~"$project", experiment_name=~"$experiment_name"}',
+    }],
+  };
+
+local replaceReferences(value, outputKeys) =
+  if std.type(value) == 'array' then
+    [replaceReferences(item, outputKeys) for item in value]
+  else if std.type(value) == 'object' then
+    if has(value, 'kind') && value.kind == 'ElementReference' then
+      value { name: outputKeys[value.name] }
+    else
+      { [field]: replaceReferences(value[field], outputKeys) for field in std.objectFields(value) }
+  else value;
+
+local build(common, engine) =
+  local records = common.panels + [trainingPanel(metric) for metric in common.trainingMetrics] + engine.panels;
+  local outputKeys = { [record.key]: record.outputKey for record in records };
+  local rows = common.rows + engine.rows;
+  local variables = common.variables + engine.variables;
+  {
+    apiVersion: 'dashboard.grafana.app/v2',
+    kind: 'Dashboard',
+    metadata: engine.metadata,
+    spec: common.spec {
+      elements: { [record.outputKey]: panel(record) for record in records },
+      layout: {
+        kind: 'RowsLayout',
+        spec: {
+          rows: [replaceReferences(rows[name], outputKeys) for name in engine.rowOrder],
+        },
+      },
+      title: engine.title,
+      variables: [variables[name] for name in engine.variableOrder],
+      tags: engine.tags,
+    },
+  };
+
+{
+  build: build,
+}

--- a/tools/grafana/dashboards/base/viz.libsonnet
+++ b/tools/grafana/dashboards/base/viz.libsonnet
@@ -1,0 +1,396 @@
+// Generated once from the existing dashboards; maintained as Jsonnet source.
+{
+  heatmap: {
+    group: 'heatmap',
+    kind: 'VizConfig',
+    spec: {
+      fieldConfig: {
+        defaults: {
+          custom: {
+            hideFrom: {
+              legend: false,
+              tooltip: false,
+              viz: false,
+            },
+            scaleDistribution: {
+              type: 'linear',
+            },
+          },
+        },
+        overrides: [],
+      },
+      options: {
+        annotations: {
+          clustering: -1,
+          multiLane: false,
+        },
+        calculate: false,
+        cellGap: 1,
+        cellValues: {
+          unit: 'none',
+        },
+        color: {
+          exponent: 0.5,
+          fill: 'dark-orange',
+          min: 0,
+          mode: 'scheme',
+          reverse: false,
+          scale: 'exponential',
+          scheme: 'Spectral',
+          steps: 64,
+        },
+        exemplars: {
+          color: 'rgba(255,0,255,0.7)',
+        },
+        filterValues: {
+          le: 1e-09,
+        },
+        legend: {
+          show: true,
+          showLegend: true,
+        },
+        rowsFrame: {
+          layout: 'auto',
+          value: 'Request count',
+        },
+        tooltip: {
+          mode: 'single',
+          showColorScale: false,
+          yHistogram: true,
+        },
+        yAxis: {
+          axisPlacement: 'left',
+          reverse: false,
+          unit: 'none',
+        },
+      },
+    },
+    version: '13.0.2',
+  },
+  stat: {
+    group: 'stat',
+    kind: 'VizConfig',
+    spec: {
+      fieldConfig: {
+        defaults: {
+          color: {
+            mode: 'thresholds',
+          },
+          thresholds: {
+            mode: 'absolute',
+            steps: [
+              {
+                color: 'green',
+                value: 0,
+              },
+            ],
+          },
+          unit: 's',
+        },
+        overrides: [],
+      },
+      options: {
+        colorMode: 'value',
+        graphMode: 'none',
+        justifyMode: 'auto',
+        orientation: 'auto',
+        percentChangeColorMode: 'standard',
+        reduceOptions: {
+          calcs: [
+            'lastNotNull',
+          ],
+          fields: '',
+          values: false,
+        },
+        showPercentChange: false,
+        text: {},
+        textMode: 'auto',
+        wideLayout: true,
+      },
+    },
+    version: '13.0.2',
+  },
+  bargauge: {
+    group: 'bargauge',
+    kind: 'VizConfig',
+    spec: {
+      fieldConfig: {
+        defaults: {
+          color: {
+            mode: 'continuous-GrYlRd',
+          },
+          max: 1,
+          min: 0,
+          thresholds: {
+            mode: 'absolute',
+            steps: [
+              {
+                color: 'green',
+                value: 0,
+              },
+              {
+                color: 'yellow',
+                value: 0.7,
+              },
+              {
+                color: 'red',
+                value: 0.9,
+              },
+            ],
+          },
+          unit: 'percentunit',
+        },
+        overrides: [],
+      },
+      options: {
+        displayMode: 'gradient',
+        legend: {
+          calcs: [],
+          displayMode: 'list',
+          placement: 'bottom',
+          showLegend: false,
+        },
+        maxVizHeight: 300,
+        minVizHeight: 10,
+        minVizWidth: 0,
+        namePlacement: 'auto',
+        orientation: 'horizontal',
+        reduceOptions: {
+          calcs: [
+            'lastNotNull',
+          ],
+          fields: '',
+          values: false,
+        },
+        showUnfilled: true,
+        sizing: 'auto',
+        valueMode: 'color',
+      },
+    },
+    version: '13.0.2',
+  },
+  'state-timeline': {
+    group: 'state-timeline',
+    kind: 'VizConfig',
+    spec: {
+      fieldConfig: {
+        defaults: {
+          color: {
+            mode: 'thresholds',
+          },
+          custom: {
+            axisPlacement: 'auto',
+            fillOpacity: 70,
+            hideFrom: {
+              legend: false,
+              tooltip: false,
+              viz: false,
+            },
+            insertNulls: false,
+            lineWidth: 0,
+            spanNulls: false,
+          },
+          mappings: [
+            {
+              options: {
+                pattern: '.*compute_log_prob.*',
+                result: {
+                  color: 'yellow',
+                  index: 0,
+                },
+              },
+              type: 'regex',
+            },
+            {
+              options: {
+                pattern: '.*generate.*',
+                result: {
+                  color: 'blue',
+                  index: 1,
+                },
+              },
+              type: 'regex',
+            },
+            {
+              options: {
+                pattern: '.*compute_ref_log_prob.*',
+                result: {
+                  color: 'purple',
+                  index: 2,
+                },
+              },
+              type: 'regex',
+            },
+          ],
+          thresholds: {
+            mode: 'absolute',
+            steps: [
+              {
+                color: 'green',
+                value: 0,
+              },
+            ],
+          },
+        },
+        overrides: [],
+      },
+      options: {
+        alignValue: 'left',
+        annotations: {
+          clustering: -1,
+          multiLane: false,
+        },
+        legend: {
+          displayMode: 'list',
+          placement: 'bottom',
+          showLegend: true,
+        },
+        mergeValues: true,
+        perPage: 64,
+        rowHeight: 0.9,
+        showValue: 'auto',
+        tooltip: {
+          hideZeros: false,
+          mode: 'single',
+          sort: 'none',
+        },
+      },
+    },
+    version: '13.0.2',
+  },
+  gauge: {
+    group: 'gauge',
+    kind: 'VizConfig',
+    spec: {
+      fieldConfig: {
+        defaults: {
+          color: {
+            mode: 'thresholds',
+          },
+          thresholds: {
+            mode: 'absolute',
+            steps: [
+              {
+                color: 'green',
+                value: 0,
+              },
+              {
+                color: 'red',
+                value: 80,
+              },
+            ],
+          },
+        },
+        overrides: [],
+      },
+      options: {
+        barShape: 'flat',
+        barWidthFactor: 0.5,
+        effects: {
+          barGlow: false,
+          centerGlow: false,
+          gradient: true,
+        },
+        endpointMarker: 'point',
+        minVizHeight: 75,
+        minVizWidth: 75,
+        orientation: 'auto',
+        reduceOptions: {
+          calcs: [
+            'lastNotNull',
+          ],
+          fields: '',
+          values: false,
+        },
+        segmentCount: 1,
+        segmentSpacing: 0.3,
+        shape: 'gauge',
+        showThresholdLabels: false,
+        showThresholdMarkers: true,
+        sizing: 'auto',
+        sparkline: true,
+        textMode: 'auto',
+      },
+    },
+    version: '13.0.2',
+  },
+  timeseries: {
+    group: 'timeseries',
+    kind: 'VizConfig',
+    spec: {
+      fieldConfig: {
+        defaults: {
+          color: {
+            mode: 'palette-classic',
+          },
+          custom: {
+            axisBorderShow: false,
+            axisCenteredZero: false,
+            axisColorMode: 'text',
+            axisLabel: '',
+            axisPlacement: 'auto',
+            barAlignment: 0,
+            barWidthFactor: 0.6,
+            drawStyle: 'line',
+            fillOpacity: 8,
+            gradientMode: 'none',
+            hideFrom: {
+              legend: false,
+              tooltip: false,
+              viz: false,
+            },
+            insertNulls: false,
+            lineInterpolation: 'linear',
+            lineWidth: 2,
+            pointSize: 5,
+            scaleDistribution: {
+              type: 'linear',
+            },
+            showPoints: 'never',
+            showValues: false,
+            spanNulls: false,
+            stacking: {
+              group: 'A',
+              mode: 'none',
+            },
+            thresholdsStyle: {
+              mode: 'off',
+            },
+          },
+          thresholds: {
+            mode: 'absolute',
+            steps: [
+              {
+                color: 'green',
+                value: 0,
+              },
+              {
+                color: 'red',
+                value: 80,
+              },
+            ],
+          },
+        },
+        overrides: [],
+      },
+      options: {
+        annotations: {
+          clustering: -1,
+          multiLane: false,
+        },
+        legend: {
+          calcs: [],
+          displayMode: 'list',
+          placement: 'bottom',
+          showLegend: true,
+        },
+        tooltip: {
+          hideZeros: false,
+          mode: 'single',
+          sort: 'none',
+        },
+      },
+    },
+    version: '13.0.2',
+  },
+}

--- a/tools/grafana/dashboards/common.libsonnet
+++ b/tools/grafana/dashboards/common.libsonnet
@@ -1,0 +1,3133 @@
+// Shared by the vLLM and SGLang dashboards.
+{
+  spec: {
+    annotations: [
+      {
+        kind: 'AnnotationQuery',
+        spec: {
+          query: {
+            kind: 'DataQuery',
+            group: 'grafana',
+            version: 'v0',
+            spec: {},
+          },
+          enable: true,
+          hide: true,
+          iconColor: 'rgba(0, 211, 255, 1)',
+          name: 'Annotations & Alerts',
+          builtIn: true,
+        },
+      },
+    ],
+    cursorSync: 'Crosshair',
+    editable: true,
+    links: [],
+    liveNow: false,
+    preload: false,
+    timeSettings: {
+      timezone: 'browser',
+      from: 'now-15m',
+      to: 'now',
+      autoRefresh: '',
+      autoRefreshIntervals: [
+        '5s',
+        '10s',
+        '30s',
+        '1m',
+        '5m',
+        '15m',
+        '30m',
+        '1h',
+        '2h',
+        '1d',
+      ],
+      hideTimepicker: false,
+      fiscalYearStartMonth: 0,
+    },
+  },
+  panels: [
+    {
+      key: 'trajectory.metric.state_timeline',
+      outputKey: 'panel-40',
+      id: 40,
+      title: 'state timeline',
+      queries: [
+        {
+          raw: {
+            kind: 'DataQuery',
+            group: 'tempo',
+            version: 'v0',
+            spec: {
+              limit: 10000,
+              metricsQueryType: 'range',
+              query: '{span.state_lane_id!=""}',
+              queryType: 'traceql',
+              serviceMapUseNativeHistograms: false,
+              spss: 100,
+              tableType: 'spans',
+            },
+          },
+        },
+      ],
+      transformations: [
+        {
+          kind: 'Transformation',
+          group: 'calculateField',
+          spec: {
+            options: {
+              binary: {
+                left: {
+                  matcher: {
+                    id: 'byName',
+                    options: 'Duration',
+                  },
+                },
+                operator: '/',
+                right: {
+                  fixed: '1000000',
+                },
+              },
+              mode: 'binary',
+              reduce: {
+                reducer: 'sum',
+              },
+            },
+          },
+        },
+        {
+          kind: 'Transformation',
+          group: 'calculateField',
+          spec: {
+            options: {
+              alias: 'End time',
+              mode: 'reduceRow',
+              reduce: {
+                include: [
+                  'Start time',
+                  'Duration / 1000000',
+                ],
+                reducer: 'sum',
+              },
+            },
+          },
+        },
+        {
+          kind: 'Transformation',
+          group: 'extractFields',
+          spec: {
+            options: {
+              source: 'state_lane_id',
+              format: 'regexp',
+              replace: false,
+              regExp: '/^(?<state_lane_prefix>.+?)(?:[_-](?<state_lane_num>\\d+))?$/',
+            },
+          },
+        },
+        {
+          kind: 'Transformation',
+          group: 'convertFieldType',
+          spec: {
+            options: {
+              conversions: [
+                {
+                  destinationType: 'time',
+                  targetField: 'Start time',
+                },
+                {
+                  destinationType: 'time',
+                  targetField: 'End time',
+                },
+                {
+                  destinationType: 'number',
+                  targetField: 'state_lane_num',
+                },
+              ],
+              fields: {},
+            },
+          },
+        },
+        {
+          kind: 'Transformation',
+          group: 'sortBy',
+          spec: {
+            options: {
+              fields: {},
+              sort: [
+                {
+                  field: 'state_lane_num',
+                },
+              ],
+            },
+          },
+        },
+        {
+          kind: 'Transformation',
+          group: 'sortBy',
+          spec: {
+            options: {
+              fields: {},
+              sort: [
+                {
+                  field: 'state_lane_prefix',
+                },
+              ],
+            },
+          },
+        },
+        {
+          kind: 'Transformation',
+          group: 'organize',
+          spec: {
+            options: {
+              excludeByName: {
+                Duration: true,
+                'Duration / 1000000': true,
+                Name: true,
+                'Span ID': true,
+                'Trace Service': true,
+                traceIdHidden: true,
+                state_lane_prefix: true,
+                state_lane_num: true,
+              },
+              includeByName: {},
+              indexByName: {},
+              renameByName: {},
+            },
+          },
+        },
+        {
+          kind: 'Transformation',
+          group: 'partitionByValues',
+          spec: {
+            options: {
+              fields: [
+                'state_lane_id',
+              ],
+              keepFields: false,
+            },
+          },
+        },
+      ],
+      vizBase: 'state-timeline',
+    },
+    {
+      key: 'training.actor.actor_entropy',
+      outputKey: 'panel-184',
+      id: 184,
+      title: 'actor_entropy',
+      queries: [
+        {
+          expr: 'rl_insight_monitor_actor_entropy{project=~"$project", experiment_name=~"$experiment_name"}',
+          extra: {
+            instant: false,
+          },
+        },
+      ],
+    },
+    {
+      key: 'training.critic.critic_score_max',
+      outputKey: 'panel-207',
+      id: 207,
+      title: 'critic_score_max',
+      queries: [
+        {
+          expr: 'rl_insight_monitor_critic_score_max{project=~"$project", experiment_name=~"$experiment_name"}',
+        },
+      ],
+      vizPatch: {
+        version: '13.0.1',
+      },
+    },
+    {
+      key: 'training.critic.critic_score_mean',
+      outputKey: 'panel-208',
+      id: 208,
+      title: 'critic_score_mean',
+      queries: [
+        {
+          expr: 'rl_insight_monitor_critic_score_mean{project=~"$project", experiment_name=~"$experiment_name"}',
+        },
+      ],
+      vizPatch: {
+        version: '13.0.1',
+      },
+    },
+    {
+      key: 'training.critic.critic_score_min',
+      outputKey: 'panel-209',
+      id: 209,
+      title: 'critic_score_min',
+      queries: [
+        {
+          expr: 'rl_insight_monitor_critic_score_min{project=~"$project", experiment_name=~"$experiment_name"}',
+        },
+      ],
+      vizPatch: {
+        version: '13.0.1',
+      },
+    },
+    {
+      key: 'training.training.training_epoch',
+      outputKey: 'panel-283',
+      id: 283,
+      title: 'training_epoch',
+      queries: [
+        {
+          expr: 'rl_insight_monitor_training_epoch{project=~"$project", experiment_name=~"$experiment_name"}',
+        },
+      ],
+      vizBase: 'gauge',
+    },
+    {
+      key: 'training.training.training_global_step',
+      outputKey: 'panel-284',
+      id: 284,
+      title: 'training_global_step',
+      queries: [
+        {
+          expr: 'rl_insight_monitor_training_global_step{project=~"$project", experiment_name=~"$experiment_name"}',
+        },
+      ],
+      vizBase: 'gauge',
+    },
+    {
+      key: 'controller.controller_overview.controller_uptime',
+      outputKey: 'panel-295',
+      id: 295,
+      title: 'Controller Uptime',
+      queries: [
+        {
+          expr: 'tq_controller_uptime_seconds',
+          editorMode: 'code',
+          legend: '',
+          labels: {
+            'grafana.app/export-label': 'prometheus-1',
+          },
+        },
+      ],
+      vizBase: 'stat',
+    },
+    {
+      key: 'controller.controller_overview.controller_rss_memory',
+      outputKey: 'panel-296',
+      id: 296,
+      title: 'Controller RSS Memory',
+      queries: [
+        {
+          expr: 'tq_controller_memory_rss_bytes',
+          editorMode: 'code',
+          legend: '',
+          labels: {
+            'grafana.app/export-label': 'prometheus-1',
+          },
+        },
+      ],
+      vizBase: 'stat',
+      vizPatch: {
+        spec: {
+          options: {
+            graphMode: 'area',
+          },
+          fieldConfig: {
+            defaults: {
+              unit: 'bytes',
+              thresholds: {
+                steps: [
+                  {
+                    value: 0,
+                    color: 'green',
+                  },
+                  {
+                    value: 2147483648,
+                    color: 'yellow',
+                  },
+                  {
+                    value: 4294967296,
+                    color: 'red',
+                  },
+                ],
+              },
+            },
+          },
+        },
+      },
+    },
+    {
+      key: 'controller.controller_overview.active_partitions',
+      outputKey: 'panel-297',
+      id: 297,
+      title: 'Active Partitions',
+      queries: [
+        {
+          expr: 'tq_partitions_total',
+          editorMode: 'code',
+          legend: '',
+          labels: {
+            'grafana.app/export-label': 'prometheus-1',
+          },
+        },
+      ],
+      vizBase: 'stat',
+      vizPatch: {
+        spec: {
+          fieldConfig: {
+            defaults: {
+              unit: null,
+              thresholds: {
+                steps: [
+                  {
+                    value: 0,
+                    color: 'blue',
+                  },
+                ],
+              },
+            },
+          },
+        },
+      },
+    },
+    {
+      key: 'controller.controller_overview.global_indexes_allocated',
+      outputKey: 'panel-298',
+      id: 298,
+      title: 'Global Indexes Allocated',
+      queries: [
+        {
+          expr: 'tq_global_index_allocated_total',
+          editorMode: 'code',
+          legend: '',
+          labels: {
+            'grafana.app/export-label': 'prometheus-1',
+          },
+        },
+      ],
+      vizBase: 'stat',
+      vizPatch: {
+        spec: {
+          fieldConfig: {
+            defaults: {
+              unit: null,
+              thresholds: {
+                steps: [
+                  {
+                    value: 0,
+                    color: 'purple',
+                  },
+                ],
+              },
+            },
+          },
+        },
+      },
+    },
+    {
+      key: 'controller.controller_overview.reusable_indexes',
+      outputKey: 'panel-299',
+      id: 299,
+      title: 'Reusable Indexes',
+      queries: [
+        {
+          expr: 'tq_global_index_reusable_total',
+          editorMode: 'code',
+          legend: '',
+          labels: {
+            'grafana.app/export-label': 'prometheus-1',
+          },
+        },
+      ],
+      vizBase: 'stat',
+      vizPatch: {
+        spec: {
+          fieldConfig: {
+            defaults: {
+              unit: null,
+              thresholds: {
+                steps: [
+                  {
+                    value: 0,
+                    color: 'orange',
+                  },
+                ],
+              },
+            },
+          },
+        },
+      },
+    },
+    {
+      key: 'controller.request_throughput_latency.controller_request_rate_per_second',
+      outputKey: 'panel-300',
+      id: 300,
+      title: 'Controller Request Rate (per second)',
+      queries: [
+        {
+          expr: 'sum by (op_type) (rate(tq_controller_request_total{op_type=~"$op_type"}[$__rate_interval]))',
+          editorMode: 'code',
+          legend: '{{ op_type }}',
+          labels: {
+            'grafana.app/export-label': 'prometheus-1',
+          },
+        },
+      ],
+      vizPatch: {
+        spec: {
+          options: {
+            legend: {
+              calcs: [
+                'mean',
+                'max',
+              ],
+              displayMode: 'table',
+            },
+            tooltip: {
+              mode: 'multi',
+            },
+          },
+          fieldConfig: {
+            defaults: {
+              unit: 'ops',
+              thresholds: {
+                steps: [
+                  {
+                    value: 0,
+                    color: 'green',
+                  },
+                ],
+              },
+              custom: {
+                fillOpacity: 20,
+                showPoints: 'auto',
+              },
+            },
+          },
+        },
+      },
+    },
+    {
+      key: 'controller.request_throughput_latency.controller_request_latency_p50_p99',
+      outputKey: 'panel-301',
+      id: 301,
+      title: 'Controller Request Latency P50 / P99',
+      queries: [
+        {
+          expr: 'histogram_quantile(0.50, sum by (op_type, le) (rate(tq_controller_request_duration_seconds_bucket{op_type=~"$op_type"}[$__rate_interval])))',
+          editorMode: 'code',
+          legend: 'p50 {{ op_type }}',
+          labels: {
+            'grafana.app/export-label': 'prometheus-1',
+          },
+        },
+        {
+          expr: 'histogram_quantile(0.99, sum by (op_type, le) (rate(tq_controller_request_duration_seconds_bucket{op_type=~"$op_type"}[$__rate_interval])))',
+          editorMode: 'code',
+          legend: 'p99 {{ op_type }}',
+          labels: {
+            'grafana.app/export-label': 'prometheus-1',
+          },
+        },
+      ],
+      transformations: [
+        {
+          kind: 'Transformation',
+          group: 'filterFieldsByName',
+          spec: {
+            options: {
+              include: {
+                pattern: 'Time|(${quantile:regex}).*',
+              },
+            },
+          },
+        },
+      ],
+      vizPatch: {
+        spec: {
+          options: {
+            legend: {
+              calcs: [
+                'mean',
+                'max',
+              ],
+              displayMode: 'table',
+            },
+            tooltip: {
+              mode: 'multi',
+            },
+          },
+          fieldConfig: {
+            defaults: {
+              unit: 's',
+              thresholds: {
+                steps: [
+                  {
+                    value: 0,
+                    color: 'green',
+                  },
+                ],
+              },
+              custom: {
+                fillOpacity: 10,
+                showPoints: 'auto',
+              },
+            },
+          },
+        },
+      },
+    },
+    {
+      key: 'storage.partition_status.samples_per_partition',
+      outputKey: 'panel-302',
+      id: 302,
+      title: 'Samples per Partition',
+      queries: [
+        {
+          expr: 'tq_partition_samples_total',
+          editorMode: 'code',
+          legend: '{{ partition_id }}',
+          labels: {
+            'grafana.app/export-label': 'prometheus-1',
+          },
+        },
+      ],
+      vizPatch: {
+        spec: {
+          options: {
+            legend: {
+              calcs: [
+                'lastNotNull',
+              ],
+              displayMode: 'table',
+            },
+            tooltip: {
+              mode: 'multi',
+            },
+          },
+          fieldConfig: {
+            defaults: {
+              thresholds: {
+                steps: [
+                  {
+                    value: 0,
+                    color: 'green',
+                  },
+                ],
+              },
+              custom: {
+                fillOpacity: 10,
+                showPoints: 'auto',
+              },
+            },
+          },
+        },
+      },
+    },
+    {
+      key: 'storage.partition_status.production_progress',
+      outputKey: 'panel-303',
+      id: 303,
+      title: 'Production Progress',
+      queries: [
+        {
+          expr: 'tq_partition_production_progress{task_name=~"$task_name"}',
+          editorMode: 'code',
+          legend: '{{ partition_id }} / {{ task_name }}',
+          labels: {
+            'grafana.app/export-label': 'prometheus-1',
+          },
+        },
+      ],
+      vizPatch: {
+        spec: {
+          options: {
+            legend: {
+              calcs: [
+                'lastNotNull',
+              ],
+              displayMode: 'table',
+            },
+            tooltip: {
+              mode: 'multi',
+            },
+          },
+          fieldConfig: {
+            defaults: {
+              unit: 'percentunit',
+              min: 0,
+              max: 1,
+              thresholds: {
+                steps: [
+                  {
+                    value: 0,
+                    color: 'green',
+                  },
+                ],
+              },
+              color: {
+                mode: 'continuous-GrYlRd',
+              },
+              custom: {
+                fillOpacity: 20,
+                showPoints: 'auto',
+              },
+            },
+          },
+        },
+      },
+    },
+    {
+      key: 'storage.partition_status.consumption_progress',
+      outputKey: 'panel-304',
+      id: 304,
+      title: 'Consumption Progress',
+      queries: [
+        {
+          expr: 'tq_partition_consumption_progress{task_name=~"$task_name"}',
+          editorMode: 'code',
+          legend: '{{ partition_id }} / {{ task_name }}',
+          labels: {
+            'grafana.app/export-label': 'prometheus-1',
+          },
+        },
+      ],
+      vizPatch: {
+        spec: {
+          options: {
+            legend: {
+              calcs: [
+                'lastNotNull',
+              ],
+              displayMode: 'table',
+            },
+            tooltip: {
+              mode: 'multi',
+            },
+          },
+          fieldConfig: {
+            defaults: {
+              unit: 'percentunit',
+              min: 0,
+              max: 1,
+              thresholds: {
+                steps: [
+                  {
+                    value: 0,
+                    color: 'green',
+                  },
+                ],
+              },
+              color: {
+                mode: 'continuous-GrYlRd',
+              },
+              custom: {
+                fillOpacity: 20,
+                showPoints: 'auto',
+              },
+            },
+          },
+        },
+      },
+    },
+    {
+      key: 'storage.storage_units.storage_utilization',
+      outputKey: 'panel-305',
+      id: 305,
+      title: 'Storage Utilization',
+      queries: [
+        {
+          expr: 'tq_storage_utilization_ratio',
+          editorMode: 'code',
+          legend: '{{ storage_unit_id }}',
+          labels: {
+            'grafana.app/export-label': 'prometheus-1',
+          },
+        },
+      ],
+      vizBase: 'bargauge',
+    },
+    {
+      key: 'storage.storage_units.active_keys_per_storage_unit',
+      outputKey: 'panel-306',
+      id: 306,
+      title: 'Active Keys per Storage Unit',
+      queries: [
+        {
+          expr: 'tq_storage_active_keys_total',
+          editorMode: 'code',
+          legend: '{{ storage_unit_id }}',
+          labels: {
+            'grafana.app/export-label': 'prometheus-1',
+          },
+        },
+      ],
+      vizPatch: {
+        spec: {
+          options: {
+            legend: {
+              calcs: [
+                'lastNotNull',
+              ],
+              displayMode: 'table',
+            },
+            tooltip: {
+              mode: 'multi',
+            },
+          },
+          fieldConfig: {
+            defaults: {
+              thresholds: {
+                steps: [
+                  {
+                    value: 0,
+                    color: 'green',
+                  },
+                ],
+              },
+              custom: {
+                fillOpacity: 10,
+                showPoints: 'auto',
+              },
+            },
+          },
+        },
+      },
+    },
+    {
+      key: 'storage.storage_units.storage_capacity_vs_active_keys',
+      outputKey: 'panel-307',
+      id: 307,
+      title: 'Storage Capacity vs Active Keys',
+      queries: [
+        {
+          expr: 'tq_storage_capacity_total',
+          editorMode: 'code',
+          legend: 'capacity {{ storage_unit_id }}',
+          labels: {
+            'grafana.app/export-label': 'prometheus-1',
+          },
+        },
+        {
+          expr: 'tq_storage_active_keys_total',
+          editorMode: 'code',
+          legend: 'active {{ storage_unit_id }}',
+          labels: {
+            'grafana.app/export-label': 'prometheus-1',
+          },
+        },
+      ],
+      vizPatch: {
+        spec: {
+          options: {
+            legend: {
+              calcs: [
+                'lastNotNull',
+              ],
+              displayMode: 'table',
+            },
+            tooltip: {
+              mode: 'multi',
+            },
+          },
+          fieldConfig: {
+            defaults: {
+              thresholds: {
+                steps: [
+                  {
+                    value: 0,
+                    color: 'green',
+                  },
+                ],
+              },
+              custom: {
+                fillOpacity: 10,
+                showPoints: 'auto',
+              },
+            },
+          },
+        },
+      },
+    },
+    {
+      key: 'storage.storage_units.storage_process_rss_memory',
+      outputKey: 'panel-308',
+      id: 308,
+      title: 'Storage Process RSS Memory',
+      queries: [
+        {
+          expr: 'tq_storage_memory_rss_bytes',
+          editorMode: 'code',
+          legend: '{{ storage_unit_id }}',
+          labels: {
+            'grafana.app/export-label': 'prometheus-1',
+          },
+        },
+      ],
+      vizPatch: {
+        spec: {
+          options: {
+            legend: {
+              calcs: [
+                'lastNotNull',
+              ],
+              displayMode: 'table',
+            },
+            tooltip: {
+              mode: 'multi',
+            },
+          },
+          fieldConfig: {
+            defaults: {
+              unit: 'bytes',
+              thresholds: {
+                steps: [
+                  {
+                    value: 0,
+                    color: 'green',
+                  },
+                ],
+              },
+              custom: {
+                fillOpacity: 10,
+                showPoints: 'auto',
+              },
+            },
+          },
+        },
+      },
+    },
+    {
+      key: 'storage.storage_units.storage_request_rate_per_second',
+      outputKey: 'panel-309',
+      id: 309,
+      title: 'Storage Request Rate (per second)',
+      queries: [
+        {
+          expr: 'sum by (op_type) (rate(tq_storage_request_ops{op_type=~"$op_type"}[$__rate_interval]))',
+          editorMode: 'code',
+          legend: '{{ op_type }}',
+          labels: {
+            'grafana.app/export-label': 'prometheus-1',
+          },
+        },
+      ],
+      vizPatch: {
+        spec: {
+          options: {
+            legend: {
+              calcs: [
+                'mean',
+                'max',
+              ],
+              displayMode: 'table',
+            },
+            tooltip: {
+              mode: 'multi',
+            },
+          },
+          fieldConfig: {
+            defaults: {
+              unit: 'ops',
+              thresholds: {
+                steps: [
+                  {
+                    value: 0,
+                    color: 'green',
+                  },
+                ],
+              },
+              custom: {
+                fillOpacity: 20,
+                showPoints: 'auto',
+              },
+            },
+          },
+        },
+      },
+    },
+    {
+      key: 'storage.storage_units.storage_request_latency_p50_p99',
+      outputKey: 'panel-310',
+      id: 310,
+      title: 'Storage Request Latency P50 / P99',
+      queries: [
+        {
+          expr: 'tq_storage_request_latency_p50{op_type=~"$op_type"}',
+          editorMode: 'code',
+          legend: 'p50 {{ op_type }} ({{ storage_unit_id }})',
+          labels: {
+            'grafana.app/export-label': 'prometheus-1',
+          },
+        },
+        {
+          expr: 'tq_storage_request_latency_p99{op_type=~"$op_type"}',
+          editorMode: 'code',
+          legend: 'p99 {{ op_type }} ({{ storage_unit_id }})',
+          labels: {
+            'grafana.app/export-label': 'prometheus-1',
+          },
+        },
+      ],
+      transformations: [
+        {
+          kind: 'Transformation',
+          group: 'filterFieldsByName',
+          spec: {
+            options: {
+              include: {
+                pattern: 'Time|(${quantile:regex}).*',
+              },
+            },
+          },
+        },
+      ],
+      vizPatch: {
+        spec: {
+          options: {
+            legend: {
+              calcs: [
+                'mean',
+                'max',
+              ],
+              displayMode: 'table',
+            },
+            tooltip: {
+              mode: 'multi',
+            },
+          },
+          fieldConfig: {
+            defaults: {
+              unit: 's',
+              thresholds: {
+                steps: [
+                  {
+                    value: 0,
+                    color: 'green',
+                  },
+                ],
+              },
+              custom: {
+                fillOpacity: 10,
+                showPoints: 'auto',
+              },
+            },
+          },
+        },
+      },
+    },
+    {
+      key: 'storage.storage_units.produced_vs_cleared_samples_per_second',
+      outputKey: 'panel-311',
+      id: 311,
+      title: 'Produced vs Cleared Samples (per second)',
+      queries: [
+        {
+          expr: 'sum(rate(tq_controller_request_samples_total{op_type="NOTIFY_DATA_UPDATE"}[$__rate_interval]))',
+          editorMode: 'code',
+          legend: 'Produced samples/s',
+          labels: {
+            'grafana.app/export-label': 'prometheus-1',
+          },
+        },
+        {
+          expr: 'sum(rate(tq_controller_request_samples_total{op_type="CLEAR_META"}[$__rate_interval]))',
+          editorMode: 'code',
+          legend: 'Cleared samples/s',
+          labels: {
+            'grafana.app/export-label': 'prometheus-1',
+          },
+        },
+      ],
+      vizPatch: {
+        spec: {
+          options: {
+            legend: {
+              calcs: [
+                'mean',
+                'max',
+              ],
+              displayMode: 'table',
+            },
+            tooltip: {
+              mode: 'multi',
+            },
+          },
+          fieldConfig: {
+            defaults: {
+              unit: 'short',
+              thresholds: {
+                steps: [
+                  {
+                    value: 0,
+                    color: 'green',
+                  },
+                ],
+              },
+              custom: {
+                fillOpacity: 15,
+                showPoints: 'auto',
+              },
+            },
+          },
+        },
+      },
+    },
+    {
+      key: 'storage.storage_units.active_keys_delta_put_clear_accumulation',
+      outputKey: 'panel-312',
+      id: 312,
+      title: 'Active Keys Delta (PUT - CLEAR accumulation)',
+      queries: [
+        {
+          expr: 'sum(tq_storage_active_keys_total)',
+          editorMode: 'code',
+          legend: 'Total Active Keys (all storage units)',
+          labels: {
+            'grafana.app/export-label': 'prometheus-1',
+          },
+        },
+      ],
+      vizPatch: {
+        spec: {
+          options: {
+            legend: {
+              calcs: [
+                'lastNotNull',
+                'max',
+              ],
+              displayMode: 'table',
+            },
+            tooltip: {
+              mode: 'multi',
+            },
+          },
+          fieldConfig: {
+            defaults: {
+              unit: 'short',
+              thresholds: {
+                steps: [
+                  {
+                    value: 0,
+                    color: 'green',
+                  },
+                ],
+              },
+              color: {
+                mode: 'continuous-GrYlRd',
+              },
+              custom: {
+                fillOpacity: 20,
+                showPoints: 'auto',
+              },
+            },
+          },
+        },
+      },
+    },
+  ],
+  rows: {
+    'rl state timeline': {
+      kind: 'RowsLayoutRow',
+      spec: {
+        title: 'rl state timeline',
+        collapse: true,
+        layout: {
+          kind: 'GridLayout',
+          spec: {
+            items: [
+              {
+                kind: 'GridLayoutItem',
+                spec: {
+                  x: 0,
+                  y: 0,
+                  width: 24,
+                  height: 18,
+                  element: {
+                    kind: 'ElementReference',
+                    name: 'trajectory.metric.state_timeline',
+                  },
+                },
+              },
+            ],
+          },
+        },
+      },
+    },
+    'training metric': {
+      kind: 'RowsLayoutRow',
+      spec: {
+        title: 'training metric',
+        collapse: true,
+        layout: {
+          kind: 'RowsLayout',
+          spec: {
+            rows: [
+              {
+                kind: 'RowsLayoutRow',
+                spec: {
+                  title: 'actor',
+                  collapse: true,
+                  layout: {
+                    kind: 'GridLayout',
+                    spec: {
+                      items: [
+                        {
+                          kind: 'GridLayoutItem',
+                          spec: {
+                            x: 0,
+                            y: 0,
+                            width: 8,
+                            height: 8,
+                            element: {
+                              kind: 'ElementReference',
+                              name: 'training.actor.actor_entropy',
+                            },
+                          },
+                        },
+                        {
+                          kind: 'GridLayoutItem',
+                          spec: {
+                            x: 8,
+                            y: 0,
+                            width: 8,
+                            height: 8,
+                            element: {
+                              kind: 'ElementReference',
+                              name: 'training.actor.actor_entropy_loss',
+                            },
+                          },
+                        },
+                        {
+                          kind: 'GridLayoutItem',
+                          spec: {
+                            x: 16,
+                            y: 0,
+                            width: 8,
+                            height: 8,
+                            element: {
+                              kind: 'ElementReference',
+                              name: 'training.actor.actor_grad_norm',
+                            },
+                          },
+                        },
+                        {
+                          kind: 'GridLayoutItem',
+                          spec: {
+                            x: 0,
+                            y: 8,
+                            width: 8,
+                            height: 8,
+                            element: {
+                              kind: 'ElementReference',
+                              name: 'training.actor.actor_kl_coef',
+                            },
+                          },
+                        },
+                        {
+                          kind: 'GridLayoutItem',
+                          spec: {
+                            x: 8,
+                            y: 8,
+                            width: 8,
+                            height: 8,
+                            element: {
+                              kind: 'ElementReference',
+                              name: 'training.actor.actor_kl_loss',
+                            },
+                          },
+                        },
+                        {
+                          kind: 'GridLayoutItem',
+                          spec: {
+                            x: 16,
+                            y: 8,
+                            width: 8,
+                            height: 8,
+                            element: {
+                              kind: 'ElementReference',
+                              name: 'training.actor.actor_loss',
+                            },
+                          },
+                        },
+                        {
+                          kind: 'GridLayoutItem',
+                          spec: {
+                            x: 0,
+                            y: 16,
+                            width: 8,
+                            height: 8,
+                            element: {
+                              kind: 'ElementReference',
+                              name: 'training.actor.actor_lr',
+                            },
+                          },
+                        },
+                        {
+                          kind: 'GridLayoutItem',
+                          spec: {
+                            x: 8,
+                            y: 16,
+                            width: 8,
+                            height: 8,
+                            element: {
+                              kind: 'ElementReference',
+                              name: 'training.actor.actor_perf_cpu_memory_used_gb',
+                            },
+                          },
+                        },
+                        {
+                          kind: 'GridLayoutItem',
+                          spec: {
+                            x: 16,
+                            y: 16,
+                            width: 8,
+                            height: 8,
+                            element: {
+                              kind: 'ElementReference',
+                              name: 'training.actor.actor_perf_max_memory_allocated_gb',
+                            },
+                          },
+                        },
+                        {
+                          kind: 'GridLayoutItem',
+                          spec: {
+                            x: 0,
+                            y: 24,
+                            width: 8,
+                            height: 8,
+                            element: {
+                              kind: 'ElementReference',
+                              name: 'training.actor.actor_perf_max_memory_reserved_gb',
+                            },
+                          },
+                        },
+                        {
+                          kind: 'GridLayoutItem',
+                          spec: {
+                            x: 8,
+                            y: 24,
+                            width: 8,
+                            height: 8,
+                            element: {
+                              kind: 'ElementReference',
+                              name: 'training.actor.actor_pg_clipfrac',
+                            },
+                          },
+                        },
+                        {
+                          kind: 'GridLayoutItem',
+                          spec: {
+                            x: 16,
+                            y: 24,
+                            width: 8,
+                            height: 8,
+                            element: {
+                              kind: 'ElementReference',
+                              name: 'training.actor.actor_pg_clipfrac_lower',
+                            },
+                          },
+                        },
+                        {
+                          kind: 'GridLayoutItem',
+                          spec: {
+                            x: 0,
+                            y: 32,
+                            width: 8,
+                            height: 8,
+                            element: {
+                              kind: 'ElementReference',
+                              name: 'training.actor.actor_pg_loss',
+                            },
+                          },
+                        },
+                        {
+                          kind: 'GridLayoutItem',
+                          spec: {
+                            x: 8,
+                            y: 32,
+                            width: 8,
+                            height: 8,
+                            element: {
+                              kind: 'ElementReference',
+                              name: 'training.actor.actor_ppo_kl',
+                            },
+                          },
+                        },
+                      ],
+                    },
+                  },
+                },
+              },
+              {
+                kind: 'RowsLayoutRow',
+                spec: {
+                  title: 'critic',
+                  collapse: true,
+                  layout: {
+                    kind: 'GridLayout',
+                    spec: {
+                      items: [
+                        {
+                          kind: 'GridLayoutItem',
+                          spec: {
+                            x: 0,
+                            y: 0,
+                            width: 8,
+                            height: 8,
+                            element: {
+                              kind: 'ElementReference',
+                              name: 'training.critic.critic_advantages_max',
+                            },
+                          },
+                        },
+                        {
+                          kind: 'GridLayoutItem',
+                          spec: {
+                            x: 8,
+                            y: 0,
+                            width: 8,
+                            height: 8,
+                            element: {
+                              kind: 'ElementReference',
+                              name: 'training.critic.critic_advantages_mean',
+                            },
+                          },
+                        },
+                        {
+                          kind: 'GridLayoutItem',
+                          spec: {
+                            x: 16,
+                            y: 0,
+                            width: 8,
+                            height: 8,
+                            element: {
+                              kind: 'ElementReference',
+                              name: 'training.critic.critic_advantages_min',
+                            },
+                          },
+                        },
+                        {
+                          kind: 'GridLayoutItem',
+                          spec: {
+                            x: 0,
+                            y: 8,
+                            width: 8,
+                            height: 8,
+                            element: {
+                              kind: 'ElementReference',
+                              name: 'training.critic.critic_returns_max',
+                            },
+                          },
+                        },
+                        {
+                          kind: 'GridLayoutItem',
+                          spec: {
+                            x: 8,
+                            y: 8,
+                            width: 8,
+                            height: 8,
+                            element: {
+                              kind: 'ElementReference',
+                              name: 'training.critic.critic_returns_mean',
+                            },
+                          },
+                        },
+                        {
+                          kind: 'GridLayoutItem',
+                          spec: {
+                            x: 16,
+                            y: 8,
+                            width: 8,
+                            height: 8,
+                            element: {
+                              kind: 'ElementReference',
+                              name: 'training.critic.critic_returns_min',
+                            },
+                          },
+                        },
+                        {
+                          kind: 'GridLayoutItem',
+                          spec: {
+                            x: 0,
+                            y: 16,
+                            width: 8,
+                            height: 8,
+                            element: {
+                              kind: 'ElementReference',
+                              name: 'training.critic.critic_rewards_max',
+                            },
+                          },
+                        },
+                        {
+                          kind: 'GridLayoutItem',
+                          spec: {
+                            x: 8,
+                            y: 16,
+                            width: 8,
+                            height: 8,
+                            element: {
+                              kind: 'ElementReference',
+                              name: 'training.critic.critic_rewards_mean',
+                            },
+                          },
+                        },
+                        {
+                          kind: 'GridLayoutItem',
+                          spec: {
+                            x: 16,
+                            y: 16,
+                            width: 8,
+                            height: 8,
+                            element: {
+                              kind: 'ElementReference',
+                              name: 'training.critic.critic_rewards_min',
+                            },
+                          },
+                        },
+                        {
+                          kind: 'GridLayoutItem',
+                          spec: {
+                            x: 0,
+                            y: 24,
+                            width: 8,
+                            height: 8,
+                            element: {
+                              kind: 'ElementReference',
+                              name: 'training.critic.critic_score_max',
+                            },
+                          },
+                        },
+                        {
+                          kind: 'GridLayoutItem',
+                          spec: {
+                            x: 8,
+                            y: 24,
+                            width: 8,
+                            height: 8,
+                            element: {
+                              kind: 'ElementReference',
+                              name: 'training.critic.critic_score_mean',
+                            },
+                          },
+                        },
+                        {
+                          kind: 'GridLayoutItem',
+                          spec: {
+                            x: 16,
+                            y: 24,
+                            width: 8,
+                            height: 8,
+                            element: {
+                              kind: 'ElementReference',
+                              name: 'training.critic.critic_score_min',
+                            },
+                          },
+                        },
+                      ],
+                    },
+                  },
+                },
+              },
+              {
+                kind: 'RowsLayoutRow',
+                spec: {
+                  title: 'global_seqlen',
+                  collapse: true,
+                  layout: {
+                    kind: 'GridLayout',
+                    spec: {
+                      items: [
+                        {
+                          kind: 'GridLayoutItem',
+                          spec: {
+                            x: 0,
+                            y: 0,
+                            width: 8,
+                            height: 8,
+                            element: {
+                              kind: 'ElementReference',
+                              name: 'training.global_seqlen.global_seqlen_balanced_max',
+                            },
+                          },
+                        },
+                        {
+                          kind: 'GridLayoutItem',
+                          spec: {
+                            x: 8,
+                            y: 0,
+                            width: 8,
+                            height: 8,
+                            element: {
+                              kind: 'ElementReference',
+                              name: 'training.global_seqlen.global_seqlen_balanced_min',
+                            },
+                          },
+                        },
+                        {
+                          kind: 'GridLayoutItem',
+                          spec: {
+                            x: 16,
+                            y: 0,
+                            width: 8,
+                            height: 8,
+                            element: {
+                              kind: 'ElementReference',
+                              name: 'training.global_seqlen.global_seqlen_max',
+                            },
+                          },
+                        },
+                        {
+                          kind: 'GridLayoutItem',
+                          spec: {
+                            x: 0,
+                            y: 8,
+                            width: 8,
+                            height: 8,
+                            element: {
+                              kind: 'ElementReference',
+                              name: 'training.global_seqlen.global_seqlen_mean',
+                            },
+                          },
+                        },
+                        {
+                          kind: 'GridLayoutItem',
+                          spec: {
+                            x: 8,
+                            y: 8,
+                            width: 8,
+                            height: 8,
+                            element: {
+                              kind: 'ElementReference',
+                              name: 'training.global_seqlen.global_seqlen_min',
+                            },
+                          },
+                        },
+                        {
+                          kind: 'GridLayoutItem',
+                          spec: {
+                            x: 16,
+                            y: 8,
+                            width: 8,
+                            height: 8,
+                            element: {
+                              kind: 'ElementReference',
+                              name: 'training.global_seqlen.global_seqlen_minmax_diff',
+                            },
+                          },
+                        },
+                      ],
+                    },
+                  },
+                },
+              },
+              {
+                kind: 'RowsLayoutRow',
+                spec: {
+                  title: 'perf',
+                  collapse: true,
+                  layout: {
+                    kind: 'GridLayout',
+                    spec: {
+                      items: [
+                        {
+                          kind: 'GridLayoutItem',
+                          spec: {
+                            x: 0,
+                            y: 0,
+                            width: 8,
+                            height: 8,
+                            element: {
+                              kind: 'ElementReference',
+                              name: 'training.perf.perf_mfu_actor',
+                            },
+                          },
+                        },
+                        {
+                          kind: 'GridLayoutItem',
+                          spec: {
+                            x: 8,
+                            y: 0,
+                            width: 8,
+                            height: 8,
+                            element: {
+                              kind: 'ElementReference',
+                              name: 'training.perf.perf_total_num_tokens',
+                            },
+                          },
+                        },
+                        {
+                          kind: 'GridLayoutItem',
+                          spec: {
+                            x: 16,
+                            y: 0,
+                            width: 8,
+                            height: 8,
+                            element: {
+                              kind: 'ElementReference',
+                              name: 'training.perf.perf_throughput',
+                            },
+                          },
+                        },
+                        {
+                          kind: 'GridLayoutItem',
+                          spec: {
+                            x: 0,
+                            y: 8,
+                            width: 8,
+                            height: 8,
+                            element: {
+                              kind: 'ElementReference',
+                              name: 'training.perf.perf_time_per_step',
+                            },
+                          },
+                        },
+                      ],
+                    },
+                  },
+                },
+              },
+              {
+                kind: 'RowsLayoutRow',
+                spec: {
+                  title: 'prompt_length',
+                  collapse: true,
+                  layout: {
+                    kind: 'GridLayout',
+                    spec: {
+                      items: [
+                        {
+                          kind: 'GridLayoutItem',
+                          spec: {
+                            x: 0,
+                            y: 0,
+                            width: 8,
+                            height: 8,
+                            element: {
+                              kind: 'ElementReference',
+                              name: 'training.prompt_length.prompt_length_clip_ratio',
+                            },
+                          },
+                        },
+                        {
+                          kind: 'GridLayoutItem',
+                          spec: {
+                            x: 8,
+                            y: 0,
+                            width: 8,
+                            height: 8,
+                            element: {
+                              kind: 'ElementReference',
+                              name: 'training.prompt_length.prompt_length_max',
+                            },
+                          },
+                        },
+                        {
+                          kind: 'GridLayoutItem',
+                          spec: {
+                            x: 16,
+                            y: 0,
+                            width: 8,
+                            height: 8,
+                            element: {
+                              kind: 'ElementReference',
+                              name: 'training.prompt_length.prompt_length_mean',
+                            },
+                          },
+                        },
+                        {
+                          kind: 'GridLayoutItem',
+                          spec: {
+                            x: 0,
+                            y: 8,
+                            width: 8,
+                            height: 8,
+                            element: {
+                              kind: 'ElementReference',
+                              name: 'training.prompt_length.prompt_length_min',
+                            },
+                          },
+                        },
+                      ],
+                    },
+                  },
+                },
+              },
+              {
+                kind: 'RowsLayoutRow',
+                spec: {
+                  title: 'response',
+                  collapse: true,
+                  layout: {
+                    kind: 'GridLayout',
+                    spec: {
+                      items: [
+                        {
+                          kind: 'GridLayoutItem',
+                          spec: {
+                            x: 0,
+                            y: 0,
+                            width: 8,
+                            height: 8,
+                            element: {
+                              kind: 'ElementReference',
+                              name: 'training.response.response_aborted_ratio',
+                            },
+                          },
+                        },
+                        {
+                          kind: 'GridLayoutItem',
+                          spec: {
+                            x: 8,
+                            y: 0,
+                            width: 8,
+                            height: 8,
+                            element: {
+                              kind: 'ElementReference',
+                              name: 'training.response.response_length_clip_ratio',
+                            },
+                          },
+                        },
+                        {
+                          kind: 'GridLayoutItem',
+                          spec: {
+                            x: 16,
+                            y: 0,
+                            width: 8,
+                            height: 8,
+                            element: {
+                              kind: 'ElementReference',
+                              name: 'training.response.response_length_max',
+                            },
+                          },
+                        },
+                        {
+                          kind: 'GridLayoutItem',
+                          spec: {
+                            x: 0,
+                            y: 8,
+                            width: 8,
+                            height: 8,
+                            element: {
+                              kind: 'ElementReference',
+                              name: 'training.response.response_length_mean',
+                            },
+                          },
+                        },
+                        {
+                          kind: 'GridLayoutItem',
+                          spec: {
+                            x: 8,
+                            y: 8,
+                            width: 8,
+                            height: 8,
+                            element: {
+                              kind: 'ElementReference',
+                              name: 'training.response.response_length_min',
+                            },
+                          },
+                        },
+                        {
+                          kind: 'GridLayoutItem',
+                          spec: {
+                            x: 16,
+                            y: 8,
+                            width: 8,
+                            height: 8,
+                            element: {
+                              kind: 'ElementReference',
+                              name: 'training.response.response_length_non_aborted_clip_ratio',
+                            },
+                          },
+                        },
+                        {
+                          kind: 'GridLayoutItem',
+                          spec: {
+                            x: 0,
+                            y: 16,
+                            width: 8,
+                            height: 8,
+                            element: {
+                              kind: 'ElementReference',
+                              name: 'training.response.response_length_non_aborted_max',
+                            },
+                          },
+                        },
+                        {
+                          kind: 'GridLayoutItem',
+                          spec: {
+                            x: 8,
+                            y: 16,
+                            width: 8,
+                            height: 8,
+                            element: {
+                              kind: 'ElementReference',
+                              name: 'training.response.response_length_non_aborted_mean',
+                            },
+                          },
+                        },
+                        {
+                          kind: 'GridLayoutItem',
+                          spec: {
+                            x: 16,
+                            y: 16,
+                            width: 8,
+                            height: 8,
+                            element: {
+                              kind: 'ElementReference',
+                              name: 'training.response.response_length_non_aborted_min',
+                            },
+                          },
+                        },
+                      ],
+                    },
+                  },
+                },
+              },
+              {
+                kind: 'RowsLayoutRow',
+                spec: {
+                  title: 'rollout',
+                  collapse: true,
+                  layout: {
+                    kind: 'GridLayout',
+                    spec: {
+                      items: [
+                        {
+                          kind: 'GridLayoutItem',
+                          spec: {
+                            x: 0,
+                            y: 0,
+                            width: 8,
+                            height: 8,
+                            element: {
+                              kind: 'ElementReference',
+                              name: 'training.rollout.rollout_corr_chi2_seq',
+                            },
+                          },
+                        },
+                        {
+                          kind: 'GridLayoutItem',
+                          spec: {
+                            x: 8,
+                            y: 0,
+                            width: 8,
+                            height: 8,
+                            element: {
+                              kind: 'ElementReference',
+                              name: 'training.rollout.rollout_corr_chi2_token',
+                            },
+                          },
+                        },
+                        {
+                          kind: 'GridLayoutItem',
+                          spec: {
+                            x: 16,
+                            y: 0,
+                            width: 8,
+                            height: 8,
+                            element: {
+                              kind: 'ElementReference',
+                              name: 'training.rollout.rollout_corr_k3_kl',
+                            },
+                          },
+                        },
+                        {
+                          kind: 'GridLayoutItem',
+                          spec: {
+                            x: 0,
+                            y: 8,
+                            width: 8,
+                            height: 8,
+                            element: {
+                              kind: 'ElementReference',
+                              name: 'training.rollout.rollout_corr_kl',
+                            },
+                          },
+                        },
+                        {
+                          kind: 'GridLayoutItem',
+                          spec: {
+                            x: 8,
+                            y: 8,
+                            width: 8,
+                            height: 8,
+                            element: {
+                              kind: 'ElementReference',
+                              name: 'training.rollout.rollout_corr_log_ppl_abs_diff',
+                            },
+                          },
+                        },
+                        {
+                          kind: 'GridLayoutItem',
+                          spec: {
+                            x: 16,
+                            y: 8,
+                            width: 8,
+                            height: 8,
+                            element: {
+                              kind: 'ElementReference',
+                              name: 'training.rollout.rollout_corr_log_ppl_diff',
+                            },
+                          },
+                        },
+                        {
+                          kind: 'GridLayoutItem',
+                          spec: {
+                            x: 0,
+                            y: 16,
+                            width: 8,
+                            height: 8,
+                            element: {
+                              kind: 'ElementReference',
+                              name: 'training.rollout.rollout_corr_log_ppl_diff_max',
+                            },
+                          },
+                        },
+                        {
+                          kind: 'GridLayoutItem',
+                          spec: {
+                            x: 8,
+                            y: 16,
+                            width: 8,
+                            height: 8,
+                            element: {
+                              kind: 'ElementReference',
+                              name: 'training.rollout.rollout_corr_log_ppl_diff_min',
+                            },
+                          },
+                        },
+                        {
+                          kind: 'GridLayoutItem',
+                          spec: {
+                            x: 16,
+                            y: 16,
+                            width: 8,
+                            height: 8,
+                            element: {
+                              kind: 'ElementReference',
+                              name: 'training.rollout.rollout_corr_ppl_ratio',
+                            },
+                          },
+                        },
+                        {
+                          kind: 'GridLayoutItem',
+                          spec: {
+                            x: 0,
+                            y: 24,
+                            width: 8,
+                            height: 8,
+                            element: {
+                              kind: 'ElementReference',
+                              name: 'training.rollout.rollout_corr_rollout_log_ppl',
+                            },
+                          },
+                        },
+                        {
+                          kind: 'GridLayoutItem',
+                          spec: {
+                            x: 8,
+                            y: 24,
+                            width: 8,
+                            height: 8,
+                            element: {
+                              kind: 'ElementReference',
+                              name: 'training.rollout.rollout_corr_rollout_ppl',
+                            },
+                          },
+                        },
+                        {
+                          kind: 'GridLayoutItem',
+                          spec: {
+                            x: 16,
+                            y: 24,
+                            width: 8,
+                            height: 8,
+                            element: {
+                              kind: 'ElementReference',
+                              name: 'training.rollout.rollout_corr_training_log_ppl',
+                            },
+                          },
+                        },
+                        {
+                          kind: 'GridLayoutItem',
+                          spec: {
+                            x: 0,
+                            y: 32,
+                            width: 8,
+                            height: 8,
+                            element: {
+                              kind: 'ElementReference',
+                              name: 'training.rollout.rollout_corr_training_ppl',
+                            },
+                          },
+                        },
+                      ],
+                    },
+                  },
+                },
+              },
+              {
+                kind: 'RowsLayoutRow',
+                spec: {
+                  title: 'timing',
+                  collapse: true,
+                  layout: {
+                    kind: 'GridLayout',
+                    spec: {
+                      items: [
+                        {
+                          kind: 'GridLayoutItem',
+                          spec: {
+                            x: 0,
+                            y: 0,
+                            width: 8,
+                            height: 8,
+                            element: {
+                              kind: 'ElementReference',
+                              name: 'training.timing.timing_per_token_ms_adv',
+                            },
+                          },
+                        },
+                        {
+                          kind: 'GridLayoutItem',
+                          spec: {
+                            x: 8,
+                            y: 0,
+                            width: 8,
+                            height: 8,
+                            element: {
+                              kind: 'ElementReference',
+                              name: 'training.timing.timing_per_token_ms_gen',
+                            },
+                          },
+                        },
+                        {
+                          kind: 'GridLayoutItem',
+                          spec: {
+                            x: 16,
+                            y: 0,
+                            width: 8,
+                            height: 8,
+                            element: {
+                              kind: 'ElementReference',
+                              name: 'training.timing.timing_per_token_ms_ref',
+                            },
+                          },
+                        },
+                        {
+                          kind: 'GridLayoutItem',
+                          spec: {
+                            x: 0,
+                            y: 8,
+                            width: 8,
+                            height: 8,
+                            element: {
+                              kind: 'ElementReference',
+                              name: 'training.timing.timing_per_token_ms_update_actor',
+                            },
+                          },
+                        },
+                        {
+                          kind: 'GridLayoutItem',
+                          spec: {
+                            x: 8,
+                            y: 8,
+                            width: 8,
+                            height: 8,
+                            element: {
+                              kind: 'ElementReference',
+                              name: 'training.timing.timing_s_adv',
+                            },
+                          },
+                        },
+                        {
+                          kind: 'GridLayoutItem',
+                          spec: {
+                            x: 16,
+                            y: 8,
+                            width: 8,
+                            height: 8,
+                            element: {
+                              kind: 'ElementReference',
+                              name: 'training.timing.timing_s_gen',
+                            },
+                          },
+                        },
+                        {
+                          kind: 'GridLayoutItem',
+                          spec: {
+                            x: 0,
+                            y: 16,
+                            width: 8,
+                            height: 8,
+                            element: {
+                              kind: 'ElementReference',
+                              name: 'training.timing.timing_s_old_log_prob',
+                            },
+                          },
+                        },
+                        {
+                          kind: 'GridLayoutItem',
+                          spec: {
+                            x: 8,
+                            y: 16,
+                            width: 8,
+                            height: 8,
+                            element: {
+                              kind: 'ElementReference',
+                              name: 'training.timing.timing_s_ref',
+                            },
+                          },
+                        },
+                        {
+                          kind: 'GridLayoutItem',
+                          spec: {
+                            x: 16,
+                            y: 16,
+                            width: 8,
+                            height: 8,
+                            element: {
+                              kind: 'ElementReference',
+                              name: 'training.timing.rl_insight_monitor_timing_s_update_actor',
+                            },
+                          },
+                        },
+                        {
+                          kind: 'GridLayoutItem',
+                          spec: {
+                            x: 0,
+                            y: 24,
+                            width: 8,
+                            height: 8,
+                            element: {
+                              kind: 'ElementReference',
+                              name: 'training.timing.timing_s_update_weights',
+                            },
+                          },
+                        },
+                        {
+                          kind: 'GridLayoutItem',
+                          spec: {
+                            x: 8,
+                            y: 24,
+                            width: 8,
+                            height: 8,
+                            element: {
+                              kind: 'ElementReference',
+                              name: 'training.timing.timing_s_step',
+                            },
+                          },
+                        },
+                        {
+                          kind: 'GridLayoutItem',
+                          spec: {
+                            x: 16,
+                            y: 24,
+                            width: 8,
+                            height: 8,
+                            element: {
+                              kind: 'ElementReference',
+                              name: 'training.timing.timing_s_testing',
+                            },
+                          },
+                        },
+                      ],
+                    },
+                  },
+                },
+              },
+              {
+                kind: 'RowsLayoutRow',
+                spec: {
+                  title: 'training',
+                  collapse: true,
+                  layout: {
+                    kind: 'GridLayout',
+                    spec: {
+                      items: [
+                        {
+                          kind: 'GridLayoutItem',
+                          spec: {
+                            x: 0,
+                            y: 0,
+                            width: 8,
+                            height: 8,
+                            element: {
+                              kind: 'ElementReference',
+                              name: 'training.training.training_epoch',
+                            },
+                          },
+                        },
+                        {
+                          kind: 'GridLayoutItem',
+                          spec: {
+                            x: 8,
+                            y: 0,
+                            width: 8,
+                            height: 8,
+                            element: {
+                              kind: 'ElementReference',
+                              name: 'training.training.training_global_step',
+                            },
+                          },
+                        },
+                        {
+                          kind: 'GridLayoutItem',
+                          spec: {
+                            x: 16,
+                            y: 0,
+                            width: 8,
+                            height: 8,
+                            element: {
+                              kind: 'ElementReference',
+                              name: 'training.training.training_num_turns_max',
+                            },
+                          },
+                        },
+                        {
+                          kind: 'GridLayoutItem',
+                          spec: {
+                            x: 0,
+                            y: 8,
+                            width: 8,
+                            height: 8,
+                            element: {
+                              kind: 'ElementReference',
+                              name: 'training.training.training_num_turns_mean',
+                            },
+                          },
+                        },
+                        {
+                          kind: 'GridLayoutItem',
+                          spec: {
+                            x: 8,
+                            y: 8,
+                            width: 8,
+                            height: 8,
+                            element: {
+                              kind: 'ElementReference',
+                              name: 'training.training.training_num_turns_min',
+                            },
+                          },
+                        },
+                        {
+                          kind: 'GridLayoutItem',
+                          spec: {
+                            x: 16,
+                            y: 8,
+                            width: 8,
+                            height: 8,
+                            element: {
+                              kind: 'ElementReference',
+                              name: 'training.training.training_rollout_actor_probs_pearson_corr',
+                            },
+                          },
+                        },
+                        {
+                          kind: 'GridLayoutItem',
+                          spec: {
+                            x: 0,
+                            y: 16,
+                            width: 8,
+                            height: 8,
+                            element: {
+                              kind: 'ElementReference',
+                              name: 'training.training.training_rollout_probs_diff_max',
+                            },
+                          },
+                        },
+                        {
+                          kind: 'GridLayoutItem',
+                          spec: {
+                            x: 8,
+                            y: 16,
+                            width: 8,
+                            height: 8,
+                            element: {
+                              kind: 'ElementReference',
+                              name: 'training.training.training_rollout_probs_diff_mean',
+                            },
+                          },
+                        },
+                        {
+                          kind: 'GridLayoutItem',
+                          spec: {
+                            x: 16,
+                            y: 16,
+                            width: 8,
+                            height: 8,
+                            element: {
+                              kind: 'ElementReference',
+                              name: 'training.training.training_rollout_probs_diff_std',
+                            },
+                          },
+                        },
+                        {
+                          kind: 'GridLayoutItem',
+                          spec: {
+                            x: 0,
+                            y: 24,
+                            width: 8,
+                            height: 8,
+                            element: {
+                              kind: 'ElementReference',
+                              name: 'training.training.training_rollout_probs_diff_valid',
+                            },
+                          },
+                        },
+                        {
+                          kind: 'GridLayoutItem',
+                          spec: {
+                            x: 8,
+                            y: 24,
+                            width: 8,
+                            height: 8,
+                            element: {
+                              kind: 'ElementReference',
+                              name: 'training.training.training_off_policy_trajectory_spans_max',
+                            },
+                          },
+                        },
+                        {
+                          kind: 'GridLayoutItem',
+                          spec: {
+                            x: 16,
+                            y: 24,
+                            width: 8,
+                            height: 8,
+                            element: {
+                              kind: 'ElementReference',
+                              name: 'training.training.training_off_policy_trajectory_spans_mean',
+                            },
+                          },
+                        },
+                        {
+                          kind: 'GridLayoutItem',
+                          spec: {
+                            x: 0,
+                            y: 32,
+                            width: 8,
+                            height: 8,
+                            element: {
+                              kind: 'ElementReference',
+                              name: 'training.training.training_off_policy_trajectory_spans_min',
+                            },
+                          },
+                        },
+                        {
+                          kind: 'GridLayoutItem',
+                          spec: {
+                            x: 8,
+                            y: 32,
+                            width: 8,
+                            height: 8,
+                            element: {
+                              kind: 'ElementReference',
+                              name: 'training.training.training_off_policy_trajectory_staleness_max',
+                            },
+                          },
+                        },
+                        {
+                          kind: 'GridLayoutItem',
+                          spec: {
+                            x: 16,
+                            y: 32,
+                            width: 8,
+                            height: 8,
+                            element: {
+                              kind: 'ElementReference',
+                              name: 'training.training.training_off_policy_trajectory_staleness_mean',
+                            },
+                          },
+                        },
+                        {
+                          kind: 'GridLayoutItem',
+                          spec: {
+                            x: 0,
+                            y: 40,
+                            width: 8,
+                            height: 8,
+                            element: {
+                              kind: 'ElementReference',
+                              name: 'training.training.training_off_policy_trajectory_staleness_worst_max',
+                            },
+                          },
+                        },
+                        {
+                          kind: 'GridLayoutItem',
+                          spec: {
+                            x: 8,
+                            y: 40,
+                            width: 8,
+                            height: 8,
+                            element: {
+                              kind: 'ElementReference',
+                              name: 'training.training.training_off_policy_trajectory_staleness_worst_mean',
+                            },
+                          },
+                        },
+                        {
+                          kind: 'GridLayoutItem',
+                          spec: {
+                            x: 16,
+                            y: 40,
+                            width: 8,
+                            height: 8,
+                            element: {
+                              kind: 'ElementReference',
+                              name: 'training.training.training_off_policy_trajectory_staleness_worst_min',
+                            },
+                          },
+                        },
+                      ],
+                    },
+                  },
+                },
+              },
+              {
+                kind: 'RowsLayoutRow',
+                spec: {
+                  title: 'val',
+                  collapse: true,
+                  layout: {
+                    kind: 'GridLayout',
+                    spec: {
+                      items: [
+                        {
+                          kind: 'GridLayoutItem',
+                          spec: {
+                            x: 0,
+                            y: 0,
+                            width: 8,
+                            height: 8,
+                            element: {
+                              kind: 'ElementReference',
+                              name: 'training.val.val_aux_num_turns_max',
+                            },
+                          },
+                        },
+                        {
+                          kind: 'GridLayoutItem',
+                          spec: {
+                            x: 8,
+                            y: 0,
+                            width: 8,
+                            height: 8,
+                            element: {
+                              kind: 'ElementReference',
+                              name: 'training.val.val_aux_num_turns_mean',
+                            },
+                          },
+                        },
+                        {
+                          kind: 'GridLayoutItem',
+                          spec: {
+                            x: 16,
+                            y: 0,
+                            width: 8,
+                            height: 8,
+                            element: {
+                              kind: 'ElementReference',
+                              name: 'training.val.val_aux_num_turns_min',
+                            },
+                          },
+                        },
+                        {
+                          kind: 'GridLayoutItem',
+                          spec: {
+                            x: 0,
+                            y: 8,
+                            width: 8,
+                            height: 8,
+                            element: {
+                              kind: 'ElementReference',
+                              name: 'training.val.val_aux_openai_gsm8k_reward_mean_1',
+                            },
+                          },
+                        },
+                        {
+                          kind: 'GridLayoutItem',
+                          spec: {
+                            x: 8,
+                            y: 8,
+                            width: 8,
+                            height: 8,
+                            element: {
+                              kind: 'ElementReference',
+                              name: 'training.val.val_core_openai_gsm8k_acc_mean_1',
+                            },
+                          },
+                        },
+                      ],
+                    },
+                  },
+                },
+              },
+            ],
+          },
+        },
+      },
+    },
+    'transfer queue metric': {
+      kind: 'RowsLayoutRow',
+      spec: {
+        title: 'transfer queue metric',
+        collapse: true,
+        layout: {
+          kind: 'RowsLayout',
+          spec: {
+            rows: [
+              {
+                kind: 'RowsLayoutRow',
+                spec: {
+                  title: 'Controller Overview',
+                  collapse: true,
+                  layout: {
+                    kind: 'GridLayout',
+                    spec: {
+                      items: [
+                        {
+                          kind: 'GridLayoutItem',
+                          spec: {
+                            x: 0,
+                            y: 0,
+                            width: 4,
+                            height: 8,
+                            element: {
+                              kind: 'ElementReference',
+                              name: 'controller.controller_overview.controller_uptime',
+                            },
+                          },
+                        },
+                        {
+                          kind: 'GridLayoutItem',
+                          spec: {
+                            x: 4,
+                            y: 0,
+                            width: 4,
+                            height: 8,
+                            element: {
+                              kind: 'ElementReference',
+                              name: 'controller.controller_overview.controller_rss_memory',
+                            },
+                          },
+                        },
+                        {
+                          kind: 'GridLayoutItem',
+                          spec: {
+                            x: 8,
+                            y: 0,
+                            width: 4,
+                            height: 8,
+                            element: {
+                              kind: 'ElementReference',
+                              name: 'controller.controller_overview.active_partitions',
+                            },
+                          },
+                        },
+                        {
+                          kind: 'GridLayoutItem',
+                          spec: {
+                            x: 12,
+                            y: 0,
+                            width: 4,
+                            height: 8,
+                            element: {
+                              kind: 'ElementReference',
+                              name: 'controller.controller_overview.global_indexes_allocated',
+                            },
+                          },
+                        },
+                        {
+                          kind: 'GridLayoutItem',
+                          spec: {
+                            x: 16,
+                            y: 0,
+                            width: 4,
+                            height: 8,
+                            element: {
+                              kind: 'ElementReference',
+                              name: 'controller.controller_overview.reusable_indexes',
+                            },
+                          },
+                        },
+                      ],
+                    },
+                  },
+                },
+              },
+              {
+                kind: 'RowsLayoutRow',
+                spec: {
+                  title: 'Request Throughput & Latency',
+                  collapse: true,
+                  layout: {
+                    kind: 'GridLayout',
+                    spec: {
+                      items: [
+                        {
+                          kind: 'GridLayoutItem',
+                          spec: {
+                            x: 0,
+                            y: 0,
+                            width: 12,
+                            height: 8,
+                            element: {
+                              kind: 'ElementReference',
+                              name: 'controller.request_throughput_latency.controller_request_rate_per_second',
+                            },
+                          },
+                        },
+                        {
+                          kind: 'GridLayoutItem',
+                          spec: {
+                            x: 12,
+                            y: 0,
+                            width: 12,
+                            height: 8,
+                            element: {
+                              kind: 'ElementReference',
+                              name: 'controller.request_throughput_latency.controller_request_latency_p50_p99',
+                            },
+                          },
+                        },
+                      ],
+                    },
+                  },
+                },
+              },
+              {
+                kind: 'RowsLayoutRow',
+                spec: {
+                  title: 'Partition Status',
+                  collapse: true,
+                  layout: {
+                    kind: 'GridLayout',
+                    spec: {
+                      items: [
+                        {
+                          kind: 'GridLayoutItem',
+                          spec: {
+                            x: 0,
+                            y: 0,
+                            width: 12,
+                            height: 8,
+                            element: {
+                              kind: 'ElementReference',
+                              name: 'storage.partition_status.samples_per_partition',
+                            },
+                          },
+                        },
+                        {
+                          kind: 'GridLayoutItem',
+                          spec: {
+                            x: 12,
+                            y: 0,
+                            width: 12,
+                            height: 8,
+                            element: {
+                              kind: 'ElementReference',
+                              name: 'storage.partition_status.consumption_progress',
+                            },
+                          },
+                        },
+                        {
+                          kind: 'GridLayoutItem',
+                          spec: {
+                            x: 0,
+                            y: 8,
+                            width: 12,
+                            height: 8,
+                            element: {
+                              kind: 'ElementReference',
+                              name: 'storage.partition_status.production_progress',
+                            },
+                          },
+                        },
+                      ],
+                    },
+                  },
+                },
+              },
+              {
+                kind: 'RowsLayoutRow',
+                spec: {
+                  title: 'Storage Units',
+                  collapse: true,
+                  layout: {
+                    kind: 'GridLayout',
+                    spec: {
+                      items: [
+                        {
+                          kind: 'GridLayoutItem',
+                          spec: {
+                            x: 0,
+                            y: 0,
+                            width: 24,
+                            height: 8,
+                            element: {
+                              kind: 'ElementReference',
+                              name: 'storage.storage_units.storage_utilization',
+                            },
+                          },
+                        },
+                        {
+                          kind: 'GridLayoutItem',
+                          spec: {
+                            x: 0,
+                            y: 8,
+                            width: 12,
+                            height: 8,
+                            element: {
+                              kind: 'ElementReference',
+                              name: 'storage.storage_units.active_keys_per_storage_unit',
+                            },
+                          },
+                        },
+                        {
+                          kind: 'GridLayoutItem',
+                          spec: {
+                            x: 12,
+                            y: 8,
+                            width: 12,
+                            height: 8,
+                            element: {
+                              kind: 'ElementReference',
+                              name: 'storage.storage_units.storage_capacity_vs_active_keys',
+                            },
+                          },
+                        },
+                        {
+                          kind: 'GridLayoutItem',
+                          spec: {
+                            x: 0,
+                            y: 16,
+                            width: 12,
+                            height: 8,
+                            element: {
+                              kind: 'ElementReference',
+                              name: 'storage.storage_units.storage_process_rss_memory',
+                            },
+                          },
+                        },
+                        {
+                          kind: 'GridLayoutItem',
+                          spec: {
+                            x: 12,
+                            y: 16,
+                            width: 12,
+                            height: 8,
+                            element: {
+                              kind: 'ElementReference',
+                              name: 'storage.storage_units.storage_request_latency_p50_p99',
+                            },
+                          },
+                        },
+                        {
+                          kind: 'GridLayoutItem',
+                          spec: {
+                            x: 0,
+                            y: 24,
+                            width: 12,
+                            height: 8,
+                            element: {
+                              kind: 'ElementReference',
+                              name: 'storage.storage_units.storage_request_rate_per_second',
+                            },
+                          },
+                        },
+                        {
+                          kind: 'GridLayoutItem',
+                          spec: {
+                            x: 0,
+                            y: 32,
+                            width: 12,
+                            height: 8,
+                            element: {
+                              kind: 'ElementReference',
+                              name: 'storage.storage_units.produced_vs_cleared_samples_per_second',
+                            },
+                          },
+                        },
+                        {
+                          kind: 'GridLayoutItem',
+                          spec: {
+                            x: 0,
+                            y: 40,
+                            width: 24,
+                            height: 8,
+                            element: {
+                              kind: 'ElementReference',
+                              name: 'storage.storage_units.active_keys_delta_put_clear_accumulation',
+                            },
+                          },
+                        },
+                      ],
+                    },
+                  },
+                },
+              },
+            ],
+          },
+        },
+      },
+    },
+  },
+  variables: {
+    task_name: {
+      kind: 'QueryVariable',
+      spec: {
+        name: 'task_name',
+        current: {
+          text: '',
+          value: '',
+        },
+        label: 'transfer queue: Task',
+        hide: 'dontHide',
+        refresh: 'onDashboardLoad',
+        skipUrlSync: false,
+        query: {
+          kind: 'DataQuery',
+          group: 'prometheus',
+          version: 'v0',
+          datasource: {
+            name: '${datasource}',
+          },
+          spec: {
+            query: 'label_values(tq_partition_consumption_progress, task_name)',
+            refId: 'StandardVariableQuery',
+          },
+        },
+        regex: '',
+        regexApplyTo: 'value',
+        sort: 'disabled',
+        definition: 'label_values(tq_partition_consumption_progress, task_name)',
+        options: [],
+        multi: true,
+        includeAll: true,
+        allValue: '.*',
+        allowCustomValue: true,
+      },
+    },
+    quantile: {
+      kind: 'CustomVariable',
+      spec: {
+        name: 'quantile',
+        query: 'p50,p99',
+        current: {
+          text: 'All',
+          value: '$__all',
+        },
+        options: [],
+        multi: true,
+        includeAll: true,
+        allValue: '.*',
+        label: 'transfer queue: Quantile',
+        hide: 'dontHide',
+        skipUrlSync: false,
+        allowCustomValue: true,
+        valuesFormat: 'csv',
+      },
+    },
+    experiment_name: {
+      kind: 'QueryVariable',
+      spec: {
+        name: 'experiment_name',
+        current: {
+          text: 'All',
+          value: '$__all',
+        },
+        label: 'training: Experiment Name',
+        hide: 'dontHide',
+        refresh: 'onDashboardLoad',
+        skipUrlSync: false,
+        query: {
+          kind: 'DataQuery',
+          group: 'prometheus',
+          version: 'v0',
+          datasource: {
+            name: '${datasource}',
+          },
+          spec: {
+            query: 'label_values({__name__=~"rl_insight_monitor_.*"}, experiment_name)',
+            refId: 'StandardVariableQuery',
+          },
+        },
+        regex: '',
+        regexApplyTo: 'value',
+        sort: 'alphabeticalAsc',
+        definition: 'label_values({__name__=~"rl_insight_monitor_.*"}, experiment_name)',
+        options: [],
+        multi: true,
+        includeAll: true,
+        allValue: '.*',
+        allowCustomValue: true,
+      },
+    },
+    op_type: {
+      kind: 'CustomVariable',
+      spec: {
+        name: 'op_type',
+        query: 'PUT_DATA,GET_DATA,CLEAR_DATA,GET_META,CLEAR_META,NOTIFY_DATA_UPDATE',
+        current: {
+          text: 'All',
+          value: '$__all',
+        },
+        options: [],
+        multi: true,
+        includeAll: true,
+        allValue: '.*',
+        label: 'transfer queue: Op Type',
+        hide: 'dontHide',
+        skipUrlSync: false,
+        allowCustomValue: true,
+        valuesFormat: 'csv',
+      },
+    },
+    datasource: {
+      kind: 'DatasourceVariable',
+      spec: {
+        name: 'datasource',
+        pluginId: 'prometheus',
+        refresh: 'onDashboardLoad',
+        regex: '',
+        current: {
+          text: '',
+          value: '',
+        },
+        options: [],
+        multi: false,
+        includeAll: false,
+        hide: 'hideVariable',
+        skipUrlSync: false,
+        description: 'Filter queries of a specific Prometheus type.',
+        allowCustomValue: true,
+      },
+    },
+    project: {
+      kind: 'QueryVariable',
+      spec: {
+        name: 'project',
+        current: {
+          text: 'All',
+          value: '$__all',
+        },
+        label: 'training: Project',
+        hide: 'dontHide',
+        refresh: 'onDashboardLoad',
+        skipUrlSync: false,
+        query: {
+          kind: 'DataQuery',
+          group: 'prometheus',
+          version: 'v0',
+          datasource: {
+            name: '${datasource}',
+          },
+          spec: {
+            query: 'label_values({__name__=~"rl_insight_monitor_.*"}, project)',
+            refId: 'StandardVariableQuery',
+          },
+        },
+        regex: '',
+        regexApplyTo: 'value',
+        sort: 'alphabeticalAsc',
+        definition: 'label_values({__name__=~"rl_insight_monitor_.*"}, project)',
+        options: [],
+        multi: true,
+        includeAll: true,
+        allValue: '.*',
+        allowCustomValue: true,
+      },
+    },
+  },
+  trainingMetrics: [
+    ['training.actor.actor_entropy_loss', 'panel-185', 185, 'actor_entropy_loss'],
+    ['training.actor.actor_grad_norm', 'panel-186', 186, 'actor_grad_norm'],
+    ['training.actor.actor_kl_coef', 'panel-187', 187, 'actor_kl_coef'],
+    ['training.actor.actor_kl_loss', 'panel-188', 188, 'actor_kl_loss'],
+    ['training.actor.actor_loss', 'panel-189', 189, 'actor_loss'],
+    ['training.actor.actor_lr', 'panel-190', 190, 'actor_lr'],
+    ['training.actor.actor_perf_cpu_memory_used_gb', 'panel-191', 191, 'actor_perf_cpu_memory_used_gb'],
+    ['training.actor.actor_perf_max_memory_allocated_gb', 'panel-192', 192, 'actor_perf_max_memory_allocated_gb'],
+    ['training.actor.actor_perf_max_memory_reserved_gb', 'panel-193', 193, 'actor_perf_max_memory_reserved_gb'],
+    ['training.actor.actor_pg_clipfrac', 'panel-194', 194, 'actor_pg_clipfrac'],
+    ['training.actor.actor_pg_clipfrac_lower', 'panel-195', 195, 'actor_pg_clipfrac_lower'],
+    ['training.actor.actor_pg_loss', 'panel-196', 196, 'actor_pg_loss'],
+    ['training.actor.actor_ppo_kl', 'panel-197', 197, 'actor_ppo_kl'],
+    ['training.critic.critic_advantages_max', 'panel-198', 198, 'critic_advantages_max'],
+    ['training.critic.critic_advantages_mean', 'panel-199', 199, 'critic_advantages_mean'],
+    ['training.critic.critic_advantages_min', 'panel-200', 200, 'critic_advantages_min'],
+    ['training.critic.critic_returns_max', 'panel-201', 201, 'critic_returns_max'],
+    ['training.critic.critic_returns_mean', 'panel-202', 202, 'critic_returns_mean'],
+    ['training.critic.critic_returns_min', 'panel-203', 203, 'critic_returns_min'],
+    ['training.critic.critic_rewards_max', 'panel-204', 204, 'critic_rewards_max'],
+    ['training.critic.critic_rewards_mean', 'panel-205', 205, 'critic_rewards_mean'],
+    ['training.critic.critic_rewards_min', 'panel-206', 206, 'critic_rewards_min'],
+    ['training.global_seqlen.global_seqlen_balanced_max', 'panel-210', 210, 'global_seqlen_balanced_max'],
+    ['training.global_seqlen.global_seqlen_balanced_min', 'panel-211', 211, 'global_seqlen_balanced_min'],
+    ['training.global_seqlen.global_seqlen_max', 'panel-212', 212, 'global_seqlen_max'],
+    ['training.global_seqlen.global_seqlen_mean', 'panel-213', 213, 'global_seqlen_mean'],
+    ['training.global_seqlen.global_seqlen_min', 'panel-214', 214, 'global_seqlen_min'],
+    ['training.global_seqlen.global_seqlen_minmax_diff', 'panel-215', 215, 'global_seqlen_minmax_diff'],
+    ['training.perf.perf_mfu_actor', 'panel-219', 219, 'perf_mfu_actor'],
+    ['training.perf.perf_throughput', 'panel-221', 221, 'perf_throughput'],
+    ['training.perf.perf_time_per_step', 'panel-222', 222, 'perf_time_per_step'],
+    ['training.perf.perf_total_num_tokens', 'panel-223', 223, 'perf_total_num_tokens'],
+    ['training.prompt_length.prompt_length_clip_ratio', 'panel-224', 224, 'prompt_length_clip_ratio'],
+    ['training.prompt_length.prompt_length_max', 'panel-225', 225, 'prompt_length_max'],
+    ['training.prompt_length.prompt_length_mean', 'panel-226', 226, 'prompt_length_mean'],
+    ['training.prompt_length.prompt_length_min', 'panel-227', 227, 'prompt_length_min'],
+    ['training.response.response_aborted_ratio', 'panel-228', 228, 'response_aborted_ratio'],
+    ['training.response.response_length_clip_ratio', 'panel-229', 229, 'response_length_clip_ratio'],
+    ['training.response.response_length_max', 'panel-230', 230, 'response_length_max'],
+    ['training.response.response_length_mean', 'panel-231', 231, 'response_length_mean'],
+    ['training.response.response_length_min', 'panel-232', 232, 'response_length_min'],
+    ['training.response.response_length_non_aborted_clip_ratio', 'panel-233', 233, 'response_length_non_aborted_clip_ratio'],
+    ['training.response.response_length_non_aborted_max', 'panel-234', 234, 'response_length_non_aborted_max'],
+    ['training.response.response_length_non_aborted_mean', 'panel-235', 235, 'response_length_non_aborted_mean'],
+    ['training.response.response_length_non_aborted_min', 'panel-236', 236, 'response_length_non_aborted_min'],
+    ['training.rollout.rollout_corr_chi2_seq', 'panel-237', 237, 'rollout_corr_chi2_seq'],
+    ['training.rollout.rollout_corr_chi2_token', 'panel-238', 238, 'rollout_corr_chi2_token'],
+    ['training.rollout.rollout_corr_k3_kl', 'panel-239', 239, 'rollout_corr_k3_kl'],
+    ['training.rollout.rollout_corr_kl', 'panel-240', 240, 'rollout_corr_kl'],
+    ['training.rollout.rollout_corr_log_ppl_abs_diff', 'panel-241', 241, '_rollout_corr_log_ppl_abs_diff'],
+    ['training.rollout.rollout_corr_log_ppl_diff', 'panel-242', 242, 'rollout_corr_log_ppl_diff'],
+    ['training.rollout.rollout_corr_log_ppl_diff_max', 'panel-243', 243, 'rollout_corr_log_ppl_diff_max'],
+    ['training.rollout.rollout_corr_log_ppl_diff_min', 'panel-244', 244, 'rollout_corr_log_ppl_diff_min'],
+    ['training.rollout.rollout_corr_ppl_ratio', 'panel-245', 245, 'rollout_corr_ppl_ratio'],
+    ['training.rollout.rollout_corr_rollout_log_ppl', 'panel-246', 246, 'rollout_corr_rollout_log_ppl'],
+    ['training.rollout.rollout_corr_rollout_ppl', 'panel-247', 247, 'rollout_corr_rollout_ppl'],
+    ['training.rollout.rollout_corr_training_log_ppl', 'panel-248', 248, 'rollout_corr_training_log_ppl'],
+    ['training.rollout.rollout_corr_training_ppl', 'panel-249', 249, 'rollout_corr_training_ppl'],
+    ['training.timing.timing_per_token_ms_adv', 'panel-250', 250, 'timing_per_token_ms_adv'],
+    ['training.timing.timing_per_token_ms_gen', 'panel-251', 251, 'timing_per_token_ms_gen'],
+    ['training.timing.timing_per_token_ms_ref', 'panel-252', 252, 'timing_per_token_ms_ref'],
+    ['training.timing.timing_per_token_ms_update_actor', 'panel-253', 253, 'timing_per_token_ms_update_actor'],
+    ['training.timing.timing_s_adv', 'panel-254', 254, 'timing_s_adv'],
+    ['training.timing.timing_s_gen', 'panel-273', 273, 'timing_s_gen'],
+    ['training.timing.timing_s_old_log_prob', 'panel-274', 274, 'timing_s_old_log_prob'],
+    ['training.timing.timing_s_ref', 'panel-275', 275, 'timing_s_ref'],
+    ['training.timing.timing_s_step', 'panel-278', 278, 'timing_s_step'],
+    ['training.timing.timing_s_testing', 'panel-280', 280, 'timing_s_testing'],
+    ['training.timing.rl_insight_monitor_timing_s_update_actor', 'panel-281', 281, 'rl_insight_monitor_timing_s_update_actor'],
+    ['training.timing.timing_s_update_weights', 'panel-282', 282, 'timing_s_update_weights'],
+    ['training.training.training_rollout_actor_probs_pearson_corr', 'panel-285', 285, 'training_rollout_actor_probs_pearson_corr'],
+    ['training.training.training_rollout_probs_diff_max', 'panel-286', 286, 'training_rollout_probs_diff_max'],
+    ['training.training.training_rollout_probs_diff_mean', 'panel-287', 287, 'training_rollout_probs_diff_mean'],
+    ['training.training.training_rollout_probs_diff_std', 'panel-288', 288, 'training_rollout_probs_diff_std'],
+    ['training.training.training_rollout_probs_diff_valid', 'panel-289', 289, 'training_rollout_probs_diff_valid'],
+    ['training.val.val_aux_num_turns_max', 'panel-290', 290, 'val_aux_num_turns_max'],
+    ['training.val.val_aux_num_turns_mean', 'panel-291', 291, 'val_aux_num_turns_mean'],
+    ['training.val.val_aux_num_turns_min', 'panel-292', 292, 'val_aux_num_turns_min'],
+    ['training.val.val_aux_openai_gsm8k_reward_mean_1', 'panel-293', 293, 'val_aux_openai_gsm8k_reward_mean_1'],
+    ['training.val.val_core_openai_gsm8k_acc_mean_1', 'panel-294', 294, 'val_core_openai_gsm8k_acc_mean_1'],
+    ['training.training.training_num_turns_max', 'panel-314', 314, 'training_num_turns_max'],
+    ['training.training.training_off_policy_trajectory_spans_mean', 'panel-315', 315, 'training_off_policy_trajectory_spans_mean'],
+    ['training.training.training_num_turns_mean', 'panel-316', 316, 'training_num_turns_mean'],
+    ['training.training.training_off_policy_trajectory_spans_min', 'panel-317', 317, 'training_off_policy_trajectory_spans_min'],
+    ['training.training.training_off_policy_trajectory_staleness_max', 'panel-318', 318, 'training_off_policy_trajectory_staleness_max'],
+    ['training.training.training_off_policy_trajectory_staleness_worst_max', 'panel-319', 319, 'training_off_policy_trajectory_staleness_worst_max'],
+    ['training.training.training_num_turns_min', 'panel-320', 320, 'training_num_turns_min'],
+    ['training.training.training_off_policy_trajectory_staleness_mean', 'panel-321', 321, 'training_off_policy_trajectory_staleness_mean'],
+    ['training.training.training_off_policy_trajectory_spans_max', 'panel-322', 322, 'training_off_policy_trajectory_spans_max'],
+    ['training.training.training_off_policy_trajectory_staleness_worst_min', 'panel-323', 323, 'training_off_policy_trajectory_staleness_worst_min'],
+    ['training.training.training_off_policy_trajectory_staleness_worst_mean', 'panel-324', 324, 'training_off_policy_trajectory_staleness_worst_mean'],
+  ],
+}

--- a/tools/grafana/dashboards/sglang.libsonnet
+++ b/tools/grafana/dashboards/sglang.libsonnet
@@ -1,0 +1,1213 @@
+// sglang specific panels, rows, and variables.
+{
+  metadata: {
+    name: 'd436bdfd-f96e-4c62-b0b1-8e8315c1757a',
+    generation: 1,
+    creationTimestamp: '2026-07-08T14:34:31Z',
+    labels: {},
+    annotations: {},
+  },
+  title: 'verl_trainer_v1_with_sglang_engine',
+  tags: [
+    'RL-Insight',
+    'verl',
+    'sglang',
+  ],
+  panels: [
+    {
+      key: 'engine.sglang.metric.sglang_end_to_end_request_latency',
+      outputKey: 'panel-1',
+      id: 1,
+      title: 'SGLang: End-to-End Request Latency',
+      queries: [
+        {
+          expr: 'histogram_quantile(0.99, sum by (le, replica) (rate({__name__=~"sglang[:_]e2e_request_latency_seconds_bucket", model_name=~"$sglang_model_name", replica=~"$sglang_replica"}[$__rate_interval])))',
+          editorMode: 'code',
+          legend: 'replica {{replica}} P99',
+          extra: {
+            exemplar: true,
+            interval: '',
+            queryType: 'randomWalk',
+          },
+        },
+        {
+          expr: 'histogram_quantile(0.9, sum by (le, replica) (rate({__name__=~"sglang[:_]e2e_request_latency_seconds_bucket", model_name=~"$sglang_model_name", replica=~"$sglang_replica"}[$__rate_interval])))',
+          editorMode: 'code',
+          legend: 'replica {{replica}} P90',
+          extra: {
+            exemplar: true,
+            interval: '',
+            queryType: 'randomWalk',
+          },
+        },
+        {
+          expr: 'histogram_quantile(0.5, sum by (le, replica) (rate({__name__=~"sglang[:_]e2e_request_latency_seconds_bucket", model_name=~"$sglang_model_name", replica=~"$sglang_replica"}[$__rate_interval])))',
+          editorMode: 'code',
+          legend: 'replica {{replica}} P50',
+          extra: {
+            exemplar: true,
+            interval: '',
+            queryType: 'randomWalk',
+          },
+        },
+        {
+          expr: 'sum by (replica) (rate({__name__=~"sglang[:_]e2e_request_latency_seconds_sum", model_name=~"$sglang_model_name", replica=~"$sglang_replica"}[$__rate_interval])) / sum by (replica) (rate({__name__=~"sglang[:_]e2e_request_latency_seconds_count", model_name=~"$sglang_model_name", replica=~"$sglang_replica"}[$__rate_interval]))',
+          editorMode: 'code',
+          legend: 'replica {{replica}} Avg',
+          extra: {
+            exemplar: true,
+            interval: '',
+            queryType: 'randomWalk',
+          },
+        },
+      ],
+      description: 'End-to-end request latency from SGLang metrics (official dashboard query; metric prefix sglang:).',
+      vizPatch: {
+        spec: {
+          options: {
+            alertThreshold: true,
+            legend: {
+              calcs: [
+                'lastNotNull',
+              ],
+              displayMode: 'table',
+            },
+            tooltip: {
+              mode: 'multi',
+            },
+          },
+          fieldConfig: {
+            defaults: {
+              unit: 's',
+              min: 0,
+              custom: {
+                fillOpacity: 10,
+              },
+            },
+            overrides: [
+              {
+                matcher: {
+                  id: 'byName',
+                  options: 'MAX',
+                },
+                properties: [
+                  {
+                    id: 'color',
+                    value: {
+                      fixedColor: '#1F60C4',
+                      mode: 'fixed',
+                    },
+                  },
+                  {
+                    id: 'custom.fillOpacity',
+                    value: 0,
+                  },
+                  {
+                    id: 'custom.stacking',
+                    value: {
+                      group: 'A',
+                      mode: 'none',
+                    },
+                  },
+                  {
+                    id: 'custom.lineStyle',
+                    value: {
+                      dash: [
+                        10,
+                        10,
+                      ],
+                      fill: 'dash',
+                    },
+                  },
+                ],
+              },
+              {
+                matcher: {
+                  id: 'byName',
+                  options: 'MAX + PENDING',
+                },
+                properties: [
+                  {
+                    id: 'color',
+                    value: {
+                      fixedColor: '#777777',
+                      mode: 'fixed',
+                    },
+                  },
+                  {
+                    id: 'custom.fillOpacity',
+                    value: 0,
+                  },
+                  {
+                    id: 'custom.stacking',
+                    value: {
+                      group: 'A',
+                      mode: 'none',
+                    },
+                  },
+                  {
+                    id: 'custom.lineStyle',
+                    value: {
+                      dash: [
+                        10,
+                        10,
+                      ],
+                      fill: 'dash',
+                    },
+                  },
+                ],
+              },
+              {
+                matcher: {
+                  id: 'byValue',
+                  options: {
+                    op: 'gte',
+                    reducer: 'allIsZero',
+                    value: 0,
+                  },
+                },
+                properties: [
+                  {
+                    id: 'custom.hideFrom',
+                    value: {
+                      legend: true,
+                      tooltip: true,
+                      viz: false,
+                    },
+                  },
+                ],
+              },
+            ],
+          },
+        },
+      },
+    },
+    {
+      key: 'engine.sglang.metric.sglang_end_to_end_request_latency_heatmap',
+      outputKey: 'panel-2',
+      id: 2,
+      title: 'SGLang: End-to-End Request Latency Heatmap',
+      queries: [
+        {
+          expr: 'sum by (le, replica) (increase({__name__=~"sglang[:_]e2e_request_latency_seconds_bucket", model_name=~"$sglang_model_name", replica=~"$sglang_replica"}[$__rate_interval]))',
+          legend: 'replica {{replica}} le {{le}}',
+          extra: {
+            exemplar: true,
+            interval: '',
+            queryType: 'randomWalk',
+            format: 'heatmap',
+            fullMetaSearch: false,
+            includeNullMetadata: true,
+            useBackend: false,
+          },
+        },
+      ],
+      description: 'Heatmap of end-to-end request latency buckets.',
+      vizBase: 'heatmap',
+      vizPatch: {
+        spec: {
+          options: {
+            yAxis: {
+              unit: 's',
+            },
+          },
+        },
+      },
+    },
+    {
+      key: 'engine.sglang.metric.sglang_time_to_first_token_latency',
+      outputKey: 'panel-3',
+      id: 3,
+      title: 'SGLang: Time-To-First-Token Latency',
+      queries: [
+        {
+          expr: 'histogram_quantile(0.99, sum by (le, replica) (rate({__name__=~"sglang[:_]time_to_first_token_seconds_bucket", model_name=~"$sglang_model_name", replica=~"$sglang_replica"}[$__rate_interval])))',
+          editorMode: 'code',
+          legend: 'replica {{replica}} P99',
+          extra: {
+            exemplar: true,
+            interval: '',
+            queryType: 'randomWalk',
+          },
+        },
+        {
+          expr: 'histogram_quantile(0.9, sum by (le, replica) (rate({__name__=~"sglang[:_]time_to_first_token_seconds_bucket", model_name=~"$sglang_model_name", replica=~"$sglang_replica"}[$__rate_interval])))',
+          editorMode: 'code',
+          legend: 'replica {{replica}} P90',
+          extra: {
+            exemplar: true,
+            interval: '',
+            queryType: 'randomWalk',
+          },
+        },
+        {
+          expr: 'histogram_quantile(0.5, sum by (le, replica) (rate({__name__=~"sglang[:_]time_to_first_token_seconds_bucket", model_name=~"$sglang_model_name", replica=~"$sglang_replica"}[$__rate_interval])))',
+          editorMode: 'code',
+          legend: 'replica {{replica}} P50',
+          extra: {
+            exemplar: true,
+            interval: '',
+            queryType: 'randomWalk',
+          },
+        },
+        {
+          expr: 'sum by (replica) (rate({__name__=~"sglang[:_]time_to_first_token_seconds_sum", model_name=~"$sglang_model_name", replica=~"$sglang_replica"}[$__rate_interval])) / sum by (replica) (rate({__name__=~"sglang[:_]time_to_first_token_seconds_count", model_name=~"$sglang_model_name", replica=~"$sglang_replica"}[$__rate_interval]))',
+          editorMode: 'code',
+          legend: 'replica {{replica}} Avg',
+          extra: {
+            exemplar: true,
+            interval: '',
+            queryType: 'randomWalk',
+          },
+        },
+      ],
+      description: 'Time to first token latency from SGLang metrics.',
+      vizPatch: {
+        spec: {
+          options: {
+            alertThreshold: true,
+            legend: {
+              calcs: [
+                'lastNotNull',
+              ],
+              displayMode: 'table',
+            },
+            tooltip: {
+              mode: 'multi',
+            },
+          },
+          fieldConfig: {
+            defaults: {
+              unit: 's',
+              min: 0,
+              custom: {
+                fillOpacity: 10,
+              },
+            },
+            overrides: [
+              {
+                matcher: {
+                  id: 'byName',
+                  options: 'MAX',
+                },
+                properties: [
+                  {
+                    id: 'color',
+                    value: {
+                      fixedColor: '#1F60C4',
+                      mode: 'fixed',
+                    },
+                  },
+                  {
+                    id: 'custom.fillOpacity',
+                    value: 0,
+                  },
+                  {
+                    id: 'custom.stacking',
+                    value: {
+                      group: 'A',
+                      mode: 'none',
+                    },
+                  },
+                  {
+                    id: 'custom.lineStyle',
+                    value: {
+                      dash: [
+                        10,
+                        10,
+                      ],
+                      fill: 'dash',
+                    },
+                  },
+                ],
+              },
+              {
+                matcher: {
+                  id: 'byName',
+                  options: 'MAX + PENDING',
+                },
+                properties: [
+                  {
+                    id: 'color',
+                    value: {
+                      fixedColor: '#777777',
+                      mode: 'fixed',
+                    },
+                  },
+                  {
+                    id: 'custom.fillOpacity',
+                    value: 0,
+                  },
+                  {
+                    id: 'custom.stacking',
+                    value: {
+                      group: 'A',
+                      mode: 'none',
+                    },
+                  },
+                  {
+                    id: 'custom.lineStyle',
+                    value: {
+                      dash: [
+                        10,
+                        10,
+                      ],
+                      fill: 'dash',
+                    },
+                  },
+                ],
+              },
+              {
+                matcher: {
+                  id: 'byValue',
+                  options: {
+                    op: 'gte',
+                    reducer: 'allIsZero',
+                    value: 0,
+                  },
+                },
+                properties: [
+                  {
+                    id: 'custom.hideFrom',
+                    value: {
+                      legend: true,
+                      tooltip: true,
+                      viz: false,
+                    },
+                  },
+                ],
+              },
+            ],
+          },
+        },
+      },
+    },
+    {
+      key: 'engine.sglang.metric.sglang_time_to_first_token_heatmap',
+      outputKey: 'panel-4',
+      id: 4,
+      title: 'SGLang: Time-To-First-Token Heatmap',
+      queries: [
+        {
+          expr: 'sum by (le, replica) (increase({__name__=~"sglang[:_]time_to_first_token_seconds_bucket", model_name=~"$sglang_model_name", replica=~"$sglang_replica"}[$__rate_interval]))',
+          legend: 'replica {{replica}} le {{le}}',
+          extra: {
+            exemplar: false,
+            interval: '',
+            queryType: 'randomWalk',
+            format: 'heatmap',
+            fullMetaSearch: false,
+            includeNullMetadata: true,
+            useBackend: false,
+          },
+        },
+      ],
+      description: 'Heatmap of time-to-first-token latency buckets.',
+      vizBase: 'heatmap',
+      vizPatch: {
+        spec: {
+          options: {
+            yAxis: {
+              unit: 's',
+            },
+          },
+        },
+      },
+    },
+    {
+      key: 'engine.sglang.metric.sglang_num_running_requests',
+      outputKey: 'panel-5',
+      id: 5,
+      title: 'SGLang: Num Running Requests',
+      queries: [
+        {
+          expr: '{__name__=~"sglang[:_]num_running_reqs", model_name=~"$sglang_model_name", replica=~"$sglang_replica"}',
+          editorMode: 'code',
+          legend: 'replica {{replica}}',
+          extra: {
+            exemplar: true,
+            interval: '',
+            queryType: 'randomWalk',
+          },
+        },
+      ],
+      description: 'Number of running requests in SGLang.',
+      vizPatch: {
+        spec: {
+          options: {
+            alertThreshold: true,
+            legend: {
+              calcs: [
+                'lastNotNull',
+              ],
+              displayMode: 'table',
+            },
+            tooltip: {
+              mode: 'multi',
+            },
+          },
+          fieldConfig: {
+            defaults: {
+              unit: 'none',
+              min: 0,
+              custom: {
+                fillOpacity: 10,
+              },
+            },
+            overrides: [
+              {
+                matcher: {
+                  id: 'byName',
+                  options: 'MAX',
+                },
+                properties: [
+                  {
+                    id: 'color',
+                    value: {
+                      fixedColor: '#1F60C4',
+                      mode: 'fixed',
+                    },
+                  },
+                  {
+                    id: 'custom.fillOpacity',
+                    value: 0,
+                  },
+                  {
+                    id: 'custom.stacking',
+                    value: {
+                      group: 'A',
+                      mode: 'none',
+                    },
+                  },
+                  {
+                    id: 'custom.lineStyle',
+                    value: {
+                      dash: [
+                        10,
+                        10,
+                      ],
+                      fill: 'dash',
+                    },
+                  },
+                ],
+              },
+              {
+                matcher: {
+                  id: 'byName',
+                  options: 'MAX + PENDING',
+                },
+                properties: [
+                  {
+                    id: 'color',
+                    value: {
+                      fixedColor: '#777777',
+                      mode: 'fixed',
+                    },
+                  },
+                  {
+                    id: 'custom.fillOpacity',
+                    value: 0,
+                  },
+                  {
+                    id: 'custom.stacking',
+                    value: {
+                      group: 'A',
+                      mode: 'none',
+                    },
+                  },
+                  {
+                    id: 'custom.lineStyle',
+                    value: {
+                      dash: [
+                        10,
+                        10,
+                      ],
+                      fill: 'dash',
+                    },
+                  },
+                ],
+              },
+              {
+                matcher: {
+                  id: 'byValue',
+                  options: {
+                    op: 'gte',
+                    reducer: 'allIsZero',
+                    value: 0,
+                  },
+                },
+                properties: [
+                  {
+                    id: 'custom.hideFrom',
+                    value: {
+                      legend: true,
+                      tooltip: true,
+                      viz: false,
+                    },
+                  },
+                ],
+              },
+            ],
+          },
+        },
+      },
+    },
+    {
+      key: 'engine.sglang.metric.sglang_token_generation_throughput',
+      outputKey: 'panel-6',
+      id: 6,
+      title: 'SGLang: Token Generation Throughput',
+      queries: [
+        {
+          expr: '{__name__=~"sglang[:_]gen_throughput", model_name=~"$sglang_model_name", replica=~"$sglang_replica"}',
+          editorMode: 'code',
+          legend: 'replica {{replica}}',
+          extra: {
+            exemplar: true,
+            interval: '',
+            queryType: 'randomWalk',
+          },
+        },
+      ],
+      description: 'Token generation throughput (tokens/s).',
+      vizPatch: {
+        spec: {
+          options: {
+            alertThreshold: true,
+            legend: {
+              calcs: [
+                'lastNotNull',
+              ],
+              displayMode: 'table',
+            },
+            tooltip: {
+              mode: 'multi',
+            },
+          },
+          fieldConfig: {
+            defaults: {
+              unit: 'tokens/s',
+              min: 0,
+              custom: {
+                fillOpacity: 10,
+              },
+            },
+            overrides: [
+              {
+                matcher: {
+                  id: 'byName',
+                  options: 'MAX',
+                },
+                properties: [
+                  {
+                    id: 'color',
+                    value: {
+                      fixedColor: '#1F60C4',
+                      mode: 'fixed',
+                    },
+                  },
+                  {
+                    id: 'custom.fillOpacity',
+                    value: 0,
+                  },
+                  {
+                    id: 'custom.stacking',
+                    value: {
+                      group: 'A',
+                      mode: 'none',
+                    },
+                  },
+                  {
+                    id: 'custom.lineStyle',
+                    value: {
+                      dash: [
+                        10,
+                        10,
+                      ],
+                      fill: 'dash',
+                    },
+                  },
+                ],
+              },
+              {
+                matcher: {
+                  id: 'byName',
+                  options: 'MAX + PENDING',
+                },
+                properties: [
+                  {
+                    id: 'color',
+                    value: {
+                      fixedColor: '#777777',
+                      mode: 'fixed',
+                    },
+                  },
+                  {
+                    id: 'custom.fillOpacity',
+                    value: 0,
+                  },
+                  {
+                    id: 'custom.stacking',
+                    value: {
+                      group: 'A',
+                      mode: 'none',
+                    },
+                  },
+                  {
+                    id: 'custom.lineStyle',
+                    value: {
+                      dash: [
+                        10,
+                        10,
+                      ],
+                      fill: 'dash',
+                    },
+                  },
+                ],
+              },
+              {
+                matcher: {
+                  id: 'byValue',
+                  options: {
+                    op: 'gte',
+                    reducer: 'allIsZero',
+                    value: 0,
+                  },
+                },
+                properties: [
+                  {
+                    id: 'custom.hideFrom',
+                    value: {
+                      legend: true,
+                      tooltip: true,
+                      viz: false,
+                    },
+                  },
+                ],
+              },
+            ],
+          },
+        },
+      },
+    },
+    {
+      key: 'engine.sglang.metric.sglang_cache_hit_rate',
+      outputKey: 'panel-7',
+      id: 7,
+      title: 'SGLang: Cache Hit Rate',
+      queries: [
+        {
+          expr: '{__name__=~"sglang[:_]cache_hit_rate", model_name=~"$sglang_model_name", replica=~"$sglang_replica"}',
+          editorMode: 'code',
+          legend: 'replica {{replica}}',
+          extra: {
+            exemplar: true,
+            interval: '',
+            queryType: 'randomWalk',
+          },
+        },
+      ],
+      description: 'SGLang cache hit rate.',
+      vizPatch: {
+        spec: {
+          options: {
+            alertThreshold: true,
+            legend: {
+              calcs: [
+                'lastNotNull',
+              ],
+              displayMode: 'table',
+            },
+            tooltip: {
+              mode: 'multi',
+            },
+          },
+          fieldConfig: {
+            defaults: {
+              unit: 'percentunit',
+              min: 0,
+              custom: {
+                fillOpacity: 10,
+              },
+            },
+            overrides: [
+              {
+                matcher: {
+                  id: 'byName',
+                  options: 'MAX',
+                },
+                properties: [
+                  {
+                    id: 'color',
+                    value: {
+                      fixedColor: '#1F60C4',
+                      mode: 'fixed',
+                    },
+                  },
+                  {
+                    id: 'custom.fillOpacity',
+                    value: 0,
+                  },
+                  {
+                    id: 'custom.stacking',
+                    value: {
+                      group: 'A',
+                      mode: 'none',
+                    },
+                  },
+                  {
+                    id: 'custom.lineStyle',
+                    value: {
+                      dash: [
+                        10,
+                        10,
+                      ],
+                      fill: 'dash',
+                    },
+                  },
+                ],
+              },
+              {
+                matcher: {
+                  id: 'byName',
+                  options: 'MAX + PENDING',
+                },
+                properties: [
+                  {
+                    id: 'color',
+                    value: {
+                      fixedColor: '#777777',
+                      mode: 'fixed',
+                    },
+                  },
+                  {
+                    id: 'custom.fillOpacity',
+                    value: 0,
+                  },
+                  {
+                    id: 'custom.stacking',
+                    value: {
+                      group: 'A',
+                      mode: 'none',
+                    },
+                  },
+                  {
+                    id: 'custom.lineStyle',
+                    value: {
+                      dash: [
+                        10,
+                        10,
+                      ],
+                      fill: 'dash',
+                    },
+                  },
+                ],
+              },
+              {
+                matcher: {
+                  id: 'byValue',
+                  options: {
+                    op: 'gte',
+                    reducer: 'allIsZero',
+                    value: 0,
+                  },
+                },
+                properties: [
+                  {
+                    id: 'custom.hideFrom',
+                    value: {
+                      legend: true,
+                      tooltip: true,
+                      viz: false,
+                    },
+                  },
+                ],
+              },
+            ],
+          },
+        },
+      },
+    },
+    {
+      key: 'engine.sglang.metric.sglang_number_queued_requests',
+      outputKey: 'panel-8',
+      id: 8,
+      title: 'SGLang: Number Queued Requests',
+      queries: [
+        {
+          expr: '{__name__=~"sglang[:_]num_queue_reqs", model_name=~"$sglang_model_name", replica=~"$sglang_replica"}',
+          editorMode: 'code',
+          legend: 'replica {{replica}}',
+          extra: {
+            exemplar: true,
+            interval: '',
+            queryType: 'randomWalk',
+          },
+        },
+      ],
+      description: 'Number of queued requests in SGLang.',
+      vizPatch: {
+        spec: {
+          options: {
+            alertThreshold: true,
+            legend: {
+              calcs: [
+                'lastNotNull',
+              ],
+              displayMode: 'table',
+            },
+            tooltip: {
+              mode: 'multi',
+            },
+          },
+          fieldConfig: {
+            defaults: {
+              unit: 'none',
+              min: 0,
+              custom: {
+                fillOpacity: 10,
+              },
+            },
+            overrides: [
+              {
+                matcher: {
+                  id: 'byName',
+                  options: 'MAX',
+                },
+                properties: [
+                  {
+                    id: 'color',
+                    value: {
+                      fixedColor: '#1F60C4',
+                      mode: 'fixed',
+                    },
+                  },
+                  {
+                    id: 'custom.fillOpacity',
+                    value: 0,
+                  },
+                  {
+                    id: 'custom.stacking',
+                    value: {
+                      group: 'A',
+                      mode: 'none',
+                    },
+                  },
+                  {
+                    id: 'custom.lineStyle',
+                    value: {
+                      dash: [
+                        10,
+                        10,
+                      ],
+                      fill: 'dash',
+                    },
+                  },
+                ],
+              },
+              {
+                matcher: {
+                  id: 'byName',
+                  options: 'MAX + PENDING',
+                },
+                properties: [
+                  {
+                    id: 'color',
+                    value: {
+                      fixedColor: '#777777',
+                      mode: 'fixed',
+                    },
+                  },
+                  {
+                    id: 'custom.fillOpacity',
+                    value: 0,
+                  },
+                  {
+                    id: 'custom.stacking',
+                    value: {
+                      group: 'A',
+                      mode: 'none',
+                    },
+                  },
+                  {
+                    id: 'custom.lineStyle',
+                    value: {
+                      dash: [
+                        10,
+                        10,
+                      ],
+                      fill: 'dash',
+                    },
+                  },
+                ],
+              },
+              {
+                matcher: {
+                  id: 'byValue',
+                  options: {
+                    op: 'gte',
+                    reducer: 'allIsZero',
+                    value: 0,
+                  },
+                },
+                properties: [
+                  {
+                    id: 'custom.hideFrom',
+                    value: {
+                      legend: true,
+                      tooltip: true,
+                      viz: false,
+                    },
+                  },
+                ],
+              },
+            ],
+          },
+        },
+      },
+    },
+  ],
+  rows: {
+    'sglang engine metric': {
+      kind: 'RowsLayoutRow',
+      spec: {
+        title: 'sglang engine metric',
+        collapse: true,
+        layout: {
+          kind: 'GridLayout',
+          spec: {
+            items: [
+              {
+                kind: 'GridLayoutItem',
+                spec: {
+                  x: 0,
+                  y: 0,
+                  width: 12,
+                  height: 8,
+                  element: {
+                    kind: 'ElementReference',
+                    name: 'engine.sglang.metric.sglang_end_to_end_request_latency',
+                  },
+                },
+              },
+              {
+                kind: 'GridLayoutItem',
+                spec: {
+                  x: 12,
+                  y: 0,
+                  width: 12,
+                  height: 8,
+                  element: {
+                    kind: 'ElementReference',
+                    name: 'engine.sglang.metric.sglang_end_to_end_request_latency_heatmap',
+                  },
+                },
+              },
+              {
+                kind: 'GridLayoutItem',
+                spec: {
+                  x: 0,
+                  y: 8,
+                  width: 12,
+                  height: 8,
+                  element: {
+                    kind: 'ElementReference',
+                    name: 'engine.sglang.metric.sglang_time_to_first_token_latency',
+                  },
+                },
+              },
+              {
+                kind: 'GridLayoutItem',
+                spec: {
+                  x: 12,
+                  y: 8,
+                  width: 12,
+                  height: 8,
+                  element: {
+                    kind: 'ElementReference',
+                    name: 'engine.sglang.metric.sglang_time_to_first_token_heatmap',
+                  },
+                },
+              },
+              {
+                kind: 'GridLayoutItem',
+                spec: {
+                  x: 0,
+                  y: 16,
+                  width: 12,
+                  height: 8,
+                  element: {
+                    kind: 'ElementReference',
+                    name: 'engine.sglang.metric.sglang_num_running_requests',
+                  },
+                },
+              },
+              {
+                kind: 'GridLayoutItem',
+                spec: {
+                  x: 12,
+                  y: 16,
+                  width: 12,
+                  height: 8,
+                  element: {
+                    kind: 'ElementReference',
+                    name: 'engine.sglang.metric.sglang_token_generation_throughput',
+                  },
+                },
+              },
+              {
+                kind: 'GridLayoutItem',
+                spec: {
+                  x: 0,
+                  y: 24,
+                  width: 12,
+                  height: 8,
+                  element: {
+                    kind: 'ElementReference',
+                    name: 'engine.sglang.metric.sglang_cache_hit_rate',
+                  },
+                },
+              },
+              {
+                kind: 'GridLayoutItem',
+                spec: {
+                  x: 12,
+                  y: 24,
+                  width: 12,
+                  height: 8,
+                  element: {
+                    kind: 'ElementReference',
+                    name: 'engine.sglang.metric.sglang_number_queued_requests',
+                  },
+                },
+              },
+            ],
+          },
+        },
+      },
+    },
+    'device metric': {
+      kind: 'RowsLayoutRow',
+      spec: {
+        title: 'device metric',
+        collapse: true,
+        conditionalRendering: {
+          kind: 'ConditionalRenderingGroup',
+          spec: {
+            visibility: 'hide',
+            condition: 'and',
+            items: [
+              {
+                kind: 'ConditionalRenderingVariable',
+                spec: {
+                  variable: 'datasource',
+                  operator: 'equals',
+                  value: '',
+                },
+              },
+            ],
+          },
+        },
+        layout: {
+          kind: 'AutoGridLayout',
+          spec: {
+            maxColumnCount: 3,
+            columnWidthMode: 'standard',
+            rowHeightMode: 'standard',
+            items: [],
+          },
+        },
+      },
+    },
+  },
+  rowOrder: [
+    'rl state timeline',
+    'training metric',
+    'sglang engine metric',
+    'transfer queue metric',
+    'device metric',
+  ],
+  variables: {
+    sglang_model_name: {
+      kind: 'QueryVariable',
+      spec: {
+        name: 'sglang_model_name',
+        current: {
+          text: '',
+          value: '',
+        },
+        label: 'sglang: Model Name',
+        hide: 'dontHide',
+        refresh: 'onDashboardLoad',
+        skipUrlSync: false,
+        query: {
+          kind: 'DataQuery',
+          group: 'prometheus',
+          version: 'v0',
+          datasource: {
+            name: '${datasource}',
+          },
+          spec: {
+            query: 'label_values({__name__=~"sglang[:_]gen_throughput"}, model_name)',
+            refId: 'StandardVariableQuery',
+          },
+        },
+        regex: '',
+        regexApplyTo: 'value',
+        sort: 'disabled',
+        definition: 'label_values({__name__=~"sglang[:_]gen_throughput"}, model_name)',
+        options: [],
+        multi: false,
+        includeAll: true,
+        allValue: '.*',
+        allowCustomValue: true,
+      },
+    },
+    sglang_replica: {
+      kind: 'QueryVariable',
+      spec: {
+        name: 'sglang_replica',
+        current: {
+          text: '',
+          value: '',
+        },
+        label: 'sglang: Rollout Replica',
+        hide: 'dontHide',
+        refresh: 'onDashboardLoad',
+        skipUrlSync: false,
+        description: 'Replica rank of SGLang rollout',
+        query: {
+          kind: 'DataQuery',
+          group: 'prometheus',
+          version: 'v0',
+          datasource: {
+            name: '${datasource}',
+          },
+          spec: {
+            query: 'label_values({__name__=~"sglang[:_]gen_throughput"}, replica)',
+            refId: 'StandardVariableQuery',
+          },
+        },
+        regex: '',
+        regexApplyTo: 'value',
+        sort: 'disabled',
+        definition: 'label_values({__name__=~"sglang[:_]gen_throughput"}, replica)',
+        options: [],
+        multi: false,
+        includeAll: true,
+        allValue: '.*',
+        allowCustomValue: true,
+      },
+    },
+  },
+  variableOrder: [
+    'datasource',
+    'project',
+    'experiment_name',
+    'sglang_model_name',
+    'sglang_replica',
+    'task_name',
+    'op_type',
+    'quantile',
+  ],
+}

--- a/tools/grafana/dashboards/vllm.libsonnet
+++ b/tools/grafana/dashboards/vllm.libsonnet
@@ -1,0 +1,3038 @@
+// vllm specific panels, rows, and variables.
+{
+  metadata: {
+    name: 'a4cabbce-92af-4a84-9399-4deba24ae6d1',
+    generation: 45,
+    creationTimestamp: '2026-07-08T14:34:31Z',
+    labels: {},
+    annotations: {},
+  },
+  title: 'verl_trainer_v1_with_vllm_engine',
+  tags: [
+    'RL-Insight',
+    'verl',
+    'vllm',
+  ],
+  panels: [
+    {
+      key: 'engine.vllm.metric.vllm_token_throughput',
+      outputKey: 'panel-1',
+      id: 1,
+      title: 'vLLM: Token Throughput',
+      queries: [
+        {
+          expr: 'sum by (model_name, engine, replica) (rate(vllm:request_prompt_tokens_sum{model_name=~"$vllm_model_name", engine=~"$workerid", replica=~"$replica"}[$interval]))',
+          editorMode: 'code',
+          legend: 'Prompt Tokens/Sec - {{model_name}} - {{engine}} - replica {{replica}}',
+          extra: {
+            exemplar: true,
+            interval: '',
+            queryType: 'randomWalk',
+          },
+          labels: {
+            'grafana.app/export-label': 'prometheus-1',
+          },
+        },
+        {
+          expr: 'sum by (model_name, engine, replica) (rate(vllm:generation_tokens_total{model_name=~"$vllm_model_name", engine=~"$workerid", replica=~"$replica"}[$interval]))',
+          editorMode: 'code',
+          legend: 'Generation Tokens/Sec - {{model_name}} - {{engine}} - replica {{replica}}',
+          extra: {
+            exemplar: true,
+            interval: '',
+            queryType: 'randomWalk',
+          },
+          labels: {
+            'grafana.app/export-label': 'prometheus-1',
+          },
+        },
+      ],
+      description: 'Number of tokens processed per second',
+      vizPatch: {
+        spec: {
+          options: {
+            alertThreshold: true,
+            legend: {
+              calcs: [
+                'lastNotNull',
+              ],
+              displayMode: 'table',
+            },
+            tooltip: {
+              mode: 'multi',
+            },
+          },
+          fieldConfig: {
+            defaults: {
+              unit: 'tokens/s',
+              min: 0,
+              custom: {
+                fillOpacity: 10,
+              },
+            },
+            overrides: [
+              {
+                matcher: {
+                  id: 'byName',
+                  options: 'MAX',
+                },
+                properties: [
+                  {
+                    id: 'color',
+                    value: {
+                      fixedColor: '#1F60C4',
+                      mode: 'fixed',
+                    },
+                  },
+                  {
+                    id: 'custom.fillOpacity',
+                    value: 0,
+                  },
+                  {
+                    id: 'custom.stacking',
+                    value: {
+                      group: 'A',
+                      mode: 'none',
+                    },
+                  },
+                  {
+                    id: 'custom.lineStyle',
+                    value: {
+                      dash: [
+                        10,
+                        10,
+                      ],
+                      fill: 'dash',
+                    },
+                  },
+                ],
+              },
+              {
+                matcher: {
+                  id: 'byName',
+                  options: 'MAX + PENDING',
+                },
+                properties: [
+                  {
+                    id: 'color',
+                    value: {
+                      fixedColor: '#777777',
+                      mode: 'fixed',
+                    },
+                  },
+                  {
+                    id: 'custom.fillOpacity',
+                    value: 0,
+                  },
+                  {
+                    id: 'custom.stacking',
+                    value: {
+                      group: 'A',
+                      mode: 'none',
+                    },
+                  },
+                  {
+                    id: 'custom.lineStyle',
+                    value: {
+                      dash: [
+                        10,
+                        10,
+                      ],
+                      fill: 'dash',
+                    },
+                  },
+                ],
+              },
+              {
+                matcher: {
+                  id: 'byValue',
+                  options: {
+                    op: 'gte',
+                    reducer: 'allIsZero',
+                    value: 0,
+                  },
+                },
+                properties: [
+                  {
+                    id: 'custom.hideFrom',
+                    value: {
+                      legend: true,
+                      tooltip: true,
+                      viz: false,
+                    },
+                  },
+                ],
+              },
+            ],
+          },
+        },
+      },
+    },
+    {
+      key: 'engine.vllm.metric.vllm_time_per_output_token_latency',
+      outputKey: 'panel-2',
+      id: 2,
+      title: 'vLLM: Time Per Output Token Latency',
+      queries: [
+        {
+          expr: 'histogram_quantile(0.99, sum by(le, model_name, engine) (rate(vllm:request_time_per_output_token_seconds_bucket{model_name=~"$vllm_model_name", engine=~"$workerid", replica=~"$replica"}[$interval])))',
+          editorMode: 'code',
+          legend: 'P99 - {{model_name}} - {{engine}} - replica $replica',
+          extra: {
+            exemplar: true,
+            interval: '',
+            queryType: 'randomWalk',
+          },
+          labels: {
+            'grafana.app/export-label': 'prometheus-1',
+          },
+        },
+        {
+          expr: 'histogram_quantile(0.95, sum by(le, model_name, engine) (rate(vllm:request_time_per_output_token_seconds_bucket{model_name=~"$vllm_model_name", engine=~"$workerid", replica=~"$replica"}[$interval])))',
+          editorMode: 'code',
+          legend: 'P95 - {{model_name}} - {{engine}} - replica $replica',
+          extra: {
+            exemplar: true,
+            interval: '',
+            queryType: 'randomWalk',
+          },
+          labels: {
+            'grafana.app/export-label': 'prometheus-1',
+          },
+        },
+        {
+          expr: 'histogram_quantile(0.9, sum by(le, model_name, engine) (rate(vllm:request_time_per_output_token_seconds_bucket{model_name=~"$vllm_model_name", engine=~"$workerid", replica=~"$replica"}[$interval])))',
+          editorMode: 'code',
+          legend: 'P90 - {{model_name}} - {{engine}} - replica $replica',
+          extra: {
+            exemplar: true,
+            interval: '',
+            queryType: 'randomWalk',
+          },
+          labels: {
+            'grafana.app/export-label': 'prometheus-1',
+          },
+        },
+        {
+          expr: 'histogram_quantile(0.5, sum by(le, model_name, engine) (rate(vllm:request_time_per_output_token_seconds_bucket{model_name=~"$vllm_model_name", engine=~"$workerid", replica=~"$replica"}[$interval])))',
+          editorMode: 'code',
+          legend: 'P50 - {{model_name}} - {{engine}} - replica $replica',
+          extra: {
+            exemplar: true,
+            interval: '',
+            queryType: 'randomWalk',
+          },
+          labels: {
+            'grafana.app/export-label': 'prometheus-1',
+          },
+        },
+        {
+          expr: '(sum by(model_name, engine) (rate(vllm:request_time_per_output_token_seconds_sum{model_name=~"$vllm_model_name", engine=~"$workerid", replica=~"$replica"}[$interval]))\n/\nsum by(model_name, engine) (rate(vllm:request_time_per_output_token_seconds_count{model_name=~"$vllm_model_name", engine=~"$workerid", replica=~"$replica"}[$interval])))',
+          editorMode: 'code',
+          legend: 'Mean - {{model_name}} - {{engine}} - replica $replica',
+          extra: {
+            exemplar: true,
+            interval: '',
+            queryType: 'randomWalk',
+          },
+          labels: {
+            'grafana.app/export-label': 'prometheus-1',
+          },
+        },
+      ],
+      description: 'Time per output token latency.',
+      vizPatch: {
+        spec: {
+          options: {
+            alertThreshold: true,
+            legend: {
+              calcs: [
+                'lastNotNull',
+              ],
+              displayMode: 'table',
+              sortBy: 'Last *',
+              sortDesc: false,
+            },
+            tooltip: {
+              mode: 'multi',
+            },
+          },
+          fieldConfig: {
+            defaults: {
+              unit: 's',
+              min: 0,
+              custom: {
+                fillOpacity: 10,
+              },
+            },
+            overrides: [
+              {
+                matcher: {
+                  id: 'byName',
+                  options: 'MAX',
+                },
+                properties: [
+                  {
+                    id: 'color',
+                    value: {
+                      fixedColor: '#1F60C4',
+                      mode: 'fixed',
+                    },
+                  },
+                  {
+                    id: 'custom.fillOpacity',
+                    value: 0,
+                  },
+                  {
+                    id: 'custom.stacking',
+                    value: {
+                      group: 'A',
+                      mode: 'none',
+                    },
+                  },
+                  {
+                    id: 'custom.lineStyle',
+                    value: {
+                      dash: [
+                        10,
+                        10,
+                      ],
+                      fill: 'dash',
+                    },
+                  },
+                ],
+              },
+              {
+                matcher: {
+                  id: 'byName',
+                  options: 'MAX + PENDING',
+                },
+                properties: [
+                  {
+                    id: 'color',
+                    value: {
+                      fixedColor: '#777777',
+                      mode: 'fixed',
+                    },
+                  },
+                  {
+                    id: 'custom.fillOpacity',
+                    value: 0,
+                  },
+                  {
+                    id: 'custom.stacking',
+                    value: {
+                      group: 'A',
+                      mode: 'none',
+                    },
+                  },
+                  {
+                    id: 'custom.lineStyle',
+                    value: {
+                      dash: [
+                        10,
+                        10,
+                      ],
+                      fill: 'dash',
+                    },
+                  },
+                ],
+              },
+              {
+                matcher: {
+                  id: 'byValue',
+                  options: {
+                    op: 'gte',
+                    reducer: 'allIsZero',
+                    value: 0,
+                  },
+                },
+                properties: [
+                  {
+                    id: 'custom.hideFrom',
+                    value: {
+                      legend: true,
+                      tooltip: true,
+                      viz: false,
+                    },
+                  },
+                ],
+              },
+            ],
+          },
+        },
+      },
+    },
+    {
+      key: 'engine.vllm.metric.vllm_cache_utilization',
+      outputKey: 'panel-3',
+      id: 3,
+      title: 'vLLM: Cache Utilization',
+      queries: [
+        {
+          expr: 'vllm:kv_cache_usage_perc{model_name=~"$vllm_model_name", engine=~"$workerid", replica=~"$replica"}',
+          editorMode: 'code',
+          legend: 'KV Cache Usage - {{model_name}} - {{engine}} - replica {{replica}}',
+          extra: {
+            exemplar: true,
+            interval: '',
+            queryType: 'randomWalk',
+          },
+          labels: {
+            'grafana.app/export-label': 'prometheus-1',
+          },
+        },
+      ],
+      description: 'Percentage of used cache blocks by vLLM.',
+      vizPatch: {
+        spec: {
+          options: {
+            alertThreshold: true,
+            legend: {
+              calcs: [
+                'lastNotNull',
+              ],
+              displayMode: 'table',
+            },
+            tooltip: {
+              mode: 'multi',
+            },
+          },
+          fieldConfig: {
+            defaults: {
+              unit: 'percentunit',
+              min: 0,
+              custom: {
+                fillOpacity: 10,
+              },
+            },
+            overrides: [
+              {
+                matcher: {
+                  id: 'byName',
+                  options: 'MAX',
+                },
+                properties: [
+                  {
+                    id: 'color',
+                    value: {
+                      fixedColor: '#1F60C4',
+                      mode: 'fixed',
+                    },
+                  },
+                  {
+                    id: 'custom.fillOpacity',
+                    value: 0,
+                  },
+                  {
+                    id: 'custom.stacking',
+                    value: {
+                      group: 'A',
+                      mode: 'none',
+                    },
+                  },
+                  {
+                    id: 'custom.lineStyle',
+                    value: {
+                      dash: [
+                        10,
+                        10,
+                      ],
+                      fill: 'dash',
+                    },
+                  },
+                ],
+              },
+              {
+                matcher: {
+                  id: 'byName',
+                  options: 'MAX + PENDING',
+                },
+                properties: [
+                  {
+                    id: 'color',
+                    value: {
+                      fixedColor: '#777777',
+                      mode: 'fixed',
+                    },
+                  },
+                  {
+                    id: 'custom.fillOpacity',
+                    value: 0,
+                  },
+                  {
+                    id: 'custom.stacking',
+                    value: {
+                      group: 'A',
+                      mode: 'none',
+                    },
+                  },
+                  {
+                    id: 'custom.lineStyle',
+                    value: {
+                      dash: [
+                        10,
+                        10,
+                      ],
+                      fill: 'dash',
+                    },
+                  },
+                ],
+              },
+              {
+                matcher: {
+                  id: 'byValue',
+                  options: {
+                    op: 'gte',
+                    reducer: 'allIsZero',
+                    value: 0,
+                  },
+                },
+                properties: [
+                  {
+                    id: 'custom.hideFrom',
+                    value: {
+                      legend: true,
+                      tooltip: true,
+                      viz: false,
+                    },
+                  },
+                ],
+              },
+            ],
+          },
+        },
+      },
+    },
+    {
+      key: 'engine.vllm.metric.vllm_time_to_first_token_latency',
+      outputKey: 'panel-5',
+      id: 5,
+      title: 'vLLM: Time To First Token Latency',
+      queries: [
+        {
+          expr: '(sum by(model_name, engine) (rate(vllm:time_to_first_token_seconds_sum{model_name=~"$vllm_model_name", engine=~"$workerid", replica=~"$replica"}[$interval]))\n/\nsum by(model_name, engine) (rate(vllm:time_to_first_token_seconds_count{model_name=~"$vllm_model_name", engine=~"$workerid", replica=~"$replica"}[$interval])))',
+          editorMode: 'code',
+          legend: 'Average - {{model_name}} - {{engine}} - replica $replica ',
+          extra: {
+            exemplar: true,
+            interval: '',
+            queryType: 'randomWalk',
+          },
+          labels: {
+            'grafana.app/export-label': 'prometheus-1',
+          },
+        },
+        {
+          expr: 'histogram_quantile(0.5, sum by(le, model_name, engine)(rate(vllm:time_to_first_token_seconds_bucket{model_name=~"$vllm_model_name", engine=~"$workerid", replica=~"$replica"}[$interval])))',
+          editorMode: 'code',
+          legend: 'P50 - {{model_name}} - {{engine}} - replica $replica',
+          extra: {
+            exemplar: true,
+            interval: '',
+            queryType: 'randomWalk',
+          },
+          labels: {
+            'grafana.app/export-label': 'prometheus-1',
+          },
+        },
+        {
+          expr: 'histogram_quantile(0.9, sum by(le, model_name, engine)(rate(vllm:time_to_first_token_seconds_bucket{model_name=~"$vllm_model_name", engine=~"$workerid", replica=~"$replica"}[$interval])))',
+          editorMode: 'code',
+          legend: 'P90 - {{model_name}} - {{engine}} - replica $replica',
+          extra: {
+            exemplar: true,
+            interval: '',
+            queryType: 'randomWalk',
+          },
+          labels: {
+            'grafana.app/export-label': 'prometheus-1',
+          },
+        },
+        {
+          expr: 'histogram_quantile(0.95, sum by(le, model_name, engine) (rate(vllm:time_to_first_token_seconds_bucket{model_name=~"$vllm_model_name", engine=~"$workerid", replica=~"$replica"}[$interval])))',
+          editorMode: 'code',
+          legend: 'P95 - {{model_name}} - {{engine}} - replica $replica',
+          extra: {
+            exemplar: true,
+            interval: '',
+            queryType: 'randomWalk',
+          },
+          labels: {
+            'grafana.app/export-label': 'prometheus-1',
+          },
+        },
+        {
+          expr: 'histogram_quantile(0.99, sum by(le, model_name, engine)(rate(vllm:time_to_first_token_seconds_bucket{model_name=~"$vllm_model_name", engine=~"$workerid", replica=~"$replica"}[$interval])))',
+          editorMode: 'code',
+          legend: 'P99 - {{model_name}} - {{engine}} - replica $replica',
+          extra: {
+            exemplar: true,
+            interval: '',
+            queryType: 'randomWalk',
+          },
+          labels: {
+            'grafana.app/export-label': 'prometheus-1',
+          },
+        },
+      ],
+      description: 'P50, P90, P95, and P99 TTFT latency.',
+      vizPatch: {
+        spec: {
+          options: {
+            alertThreshold: true,
+            legend: {
+              calcs: [
+                'lastNotNull',
+              ],
+              displayMode: 'table',
+            },
+            tooltip: {
+              mode: 'multi',
+            },
+          },
+          fieldConfig: {
+            defaults: {
+              unit: 's',
+              min: 0,
+              custom: {
+                fillOpacity: 10,
+              },
+            },
+            overrides: [
+              {
+                matcher: {
+                  id: 'byName',
+                  options: 'MAX',
+                },
+                properties: [
+                  {
+                    id: 'color',
+                    value: {
+                      fixedColor: '#1F60C4',
+                      mode: 'fixed',
+                    },
+                  },
+                  {
+                    id: 'custom.fillOpacity',
+                    value: 0,
+                  },
+                  {
+                    id: 'custom.stacking',
+                    value: {
+                      group: 'A',
+                      mode: 'none',
+                    },
+                  },
+                  {
+                    id: 'custom.lineStyle',
+                    value: {
+                      dash: [
+                        10,
+                        10,
+                      ],
+                      fill: 'dash',
+                    },
+                  },
+                ],
+              },
+              {
+                matcher: {
+                  id: 'byName',
+                  options: 'MAX + PENDING',
+                },
+                properties: [
+                  {
+                    id: 'color',
+                    value: {
+                      fixedColor: '#777777',
+                      mode: 'fixed',
+                    },
+                  },
+                  {
+                    id: 'custom.fillOpacity',
+                    value: 0,
+                  },
+                  {
+                    id: 'custom.stacking',
+                    value: {
+                      group: 'A',
+                      mode: 'none',
+                    },
+                  },
+                  {
+                    id: 'custom.lineStyle',
+                    value: {
+                      dash: [
+                        10,
+                        10,
+                      ],
+                      fill: 'dash',
+                    },
+                  },
+                ],
+              },
+              {
+                matcher: {
+                  id: 'byValue',
+                  options: {
+                    op: 'gte',
+                    reducer: 'allIsZero',
+                    value: 0,
+                  },
+                },
+                properties: [
+                  {
+                    id: 'custom.hideFrom',
+                    value: {
+                      legend: true,
+                      tooltip: true,
+                      viz: false,
+                    },
+                  },
+                ],
+              },
+            ],
+          },
+        },
+      },
+    },
+    {
+      key: 'engine.vllm.metric.vllm_e2e_request_latency',
+      outputKey: 'panel-6',
+      id: 6,
+      title: 'vLLM: E2E Request Latency',
+      queries: [
+        {
+          expr: 'sum by(model_name, engine) (rate(vllm:e2e_request_latency_seconds_sum{model_name=~"$vllm_model_name", engine=~"$workerid", replica=~"$replica"}[$interval]))\n/\nsum by(model_name, engine) (rate(vllm:e2e_request_latency_seconds_count{model_name=~"$vllm_model_name", engine=~"$workerid", replica=~"$replica"}[$interval]))',
+          editorMode: 'code',
+          legend: 'Average - {{model_name}} - {{engine}} - replica $replica',
+          extra: {
+            exemplar: true,
+            interval: '',
+            queryType: 'randomWalk',
+          },
+          labels: {
+            'grafana.app/export-label': 'prometheus-1',
+          },
+        },
+        {
+          expr: 'histogram_quantile(0.5, sum by(le, model_name, engine) (rate(vllm:e2e_request_latency_seconds_bucket{model_name=~"$vllm_model_name", engine=~"$workerid", replica=~"$replica"}[$interval])))',
+          editorMode: 'code',
+          legend: 'P50 - {{model_name}} - {{engine}} - replica $replica',
+          extra: {
+            exemplar: true,
+            interval: '',
+            queryType: 'randomWalk',
+          },
+          labels: {
+            'grafana.app/export-label': 'prometheus-1',
+          },
+        },
+        {
+          expr: 'histogram_quantile(0.9, sum by(le, model_name, engine) (rate(vllm:e2e_request_latency_seconds_bucket{model_name=~"$vllm_model_name", engine=~"$workerid", replica=~"$replica"}[$interval])))',
+          editorMode: 'code',
+          legend: 'P90 - {{model_name}} - {{engine}} - replica $replica',
+          extra: {
+            exemplar: true,
+            interval: '',
+            queryType: 'randomWalk',
+          },
+          labels: {
+            'grafana.app/export-label': 'prometheus-1',
+          },
+        },
+        {
+          expr: 'histogram_quantile(0.95, sum by(le, model_name, engine) (rate(vllm:e2e_request_latency_seconds_bucket{model_name=~"$vllm_model_name", engine=~"$workerid", replica=~"$replica"}[$interval])))',
+          editorMode: 'code',
+          legend: 'P95 - {{model_name}} - {{engine}} - replica $replica',
+          extra: {
+            exemplar: true,
+            interval: '',
+            queryType: 'randomWalk',
+          },
+          labels: {
+            'grafana.app/export-label': 'prometheus-1',
+          },
+        },
+        {
+          expr: 'histogram_quantile(0.99, sum by(le, model_name, engine) (rate(vllm:e2e_request_latency_seconds_bucket{model_name=~"$vllm_model_name", engine=~"$workerid", replica=~"$replica"}[$interval])))',
+          editorMode: 'code',
+          legend: 'P99 - {{model_name}} - {{engine}} - replica $replica',
+          extra: {
+            exemplar: true,
+            interval: '',
+            queryType: 'randomWalk',
+          },
+          labels: {
+            'grafana.app/export-label': 'prometheus-1',
+          },
+        },
+      ],
+      description: 'Latency from request start to first token returned (in seconds).',
+      vizPatch: {
+        spec: {
+          options: {
+            alertThreshold: true,
+            legend: {
+              calcs: [
+                'lastNotNull',
+              ],
+              displayMode: 'table',
+            },
+            tooltip: {
+              mode: 'multi',
+            },
+          },
+          fieldConfig: {
+            defaults: {
+              unit: 's',
+              min: 0,
+              custom: {
+                fillOpacity: 10,
+              },
+            },
+            overrides: [
+              {
+                matcher: {
+                  id: 'byName',
+                  options: 'MAX',
+                },
+                properties: [
+                  {
+                    id: 'color',
+                    value: {
+                      fixedColor: '#1F60C4',
+                      mode: 'fixed',
+                    },
+                  },
+                  {
+                    id: 'custom.fillOpacity',
+                    value: 0,
+                  },
+                  {
+                    id: 'custom.stacking',
+                    value: {
+                      group: 'A',
+                      mode: 'none',
+                    },
+                  },
+                  {
+                    id: 'custom.lineStyle',
+                    value: {
+                      dash: [
+                        10,
+                        10,
+                      ],
+                      fill: 'dash',
+                    },
+                  },
+                ],
+              },
+              {
+                matcher: {
+                  id: 'byName',
+                  options: 'MAX + PENDING',
+                },
+                properties: [
+                  {
+                    id: 'color',
+                    value: {
+                      fixedColor: '#777777',
+                      mode: 'fixed',
+                    },
+                  },
+                  {
+                    id: 'custom.fillOpacity',
+                    value: 0,
+                  },
+                  {
+                    id: 'custom.stacking',
+                    value: {
+                      group: 'A',
+                      mode: 'none',
+                    },
+                  },
+                  {
+                    id: 'custom.lineStyle',
+                    value: {
+                      dash: [
+                        10,
+                        10,
+                      ],
+                      fill: 'dash',
+                    },
+                  },
+                ],
+              },
+              {
+                matcher: {
+                  id: 'byValue',
+                  options: {
+                    op: 'gte',
+                    reducer: 'allIsZero',
+                    value: 0,
+                  },
+                },
+                properties: [
+                  {
+                    id: 'custom.hideFrom',
+                    value: {
+                      legend: true,
+                      tooltip: true,
+                      viz: false,
+                    },
+                  },
+                ],
+              },
+            ],
+          },
+        },
+      },
+    },
+    {
+      key: 'engine.vllm.metric.vllm_scheduler_state',
+      outputKey: 'panel-7',
+      id: 7,
+      title: 'vLLM: Scheduler State',
+      queries: [
+        {
+          expr: 'vllm:num_requests_running{model_name=~"$vllm_model_name", engine=~"$workerid", replica=~"$replica"}',
+          editorMode: 'code',
+          legend: 'Num Running - {{model_name}} - {{engine}} - replica {{replica}}',
+          extra: {
+            exemplar: true,
+            interval: '',
+            queryType: 'randomWalk',
+          },
+          labels: {
+            'grafana.app/export-label': 'prometheus-1',
+          },
+        },
+        {
+          expr: 'vllm:num_requests_swapped{model_name=~"$vllm_model_name", engine=~"$workerid", replica=~"$replica"}',
+          editorMode: 'code',
+          legend: 'Num Swapped - {{model_name}} - {{engine}} -  replica {{replica}}',
+          extra: {
+            exemplar: true,
+            interval: '',
+            queryType: 'randomWalk',
+          },
+          labels: {
+            'grafana.app/export-label': 'prometheus-1',
+          },
+        },
+        {
+          expr: 'vllm:num_requests_waiting{model_name=~"$vllm_model_name", engine=~"$workerid", replica=~"$replica"}',
+          editorMode: 'code',
+          legend: 'Num Waiting - {{model_name}} - {{engine}} - replica {{replica}}',
+          extra: {
+            exemplar: true,
+            interval: '',
+            queryType: 'randomWalk',
+          },
+          labels: {
+            'grafana.app/export-label': 'prometheus-1',
+          },
+        },
+      ],
+      description: 'Number of requests in RUNNING, WAITING, and SWAPPED state',
+      vizPatch: {
+        spec: {
+          options: {
+            alertThreshold: true,
+            legend: {
+              calcs: [
+                'lastNotNull',
+              ],
+              displayMode: 'table',
+            },
+            tooltip: {
+              mode: 'multi',
+            },
+          },
+          fieldConfig: {
+            defaults: {
+              unit: 'Requests',
+              min: 0,
+              custom: {
+                fillOpacity: 10,
+              },
+            },
+            overrides: [
+              {
+                matcher: {
+                  id: 'byName',
+                  options: 'MAX',
+                },
+                properties: [
+                  {
+                    id: 'color',
+                    value: {
+                      fixedColor: '#1F60C4',
+                      mode: 'fixed',
+                    },
+                  },
+                  {
+                    id: 'custom.fillOpacity',
+                    value: 0,
+                  },
+                  {
+                    id: 'custom.stacking',
+                    value: {
+                      group: 'A',
+                      mode: 'none',
+                    },
+                  },
+                  {
+                    id: 'custom.lineStyle',
+                    value: {
+                      dash: [
+                        10,
+                        10,
+                      ],
+                      fill: 'dash',
+                    },
+                  },
+                ],
+              },
+              {
+                matcher: {
+                  id: 'byName',
+                  options: 'MAX + PENDING',
+                },
+                properties: [
+                  {
+                    id: 'color',
+                    value: {
+                      fixedColor: '#777777',
+                      mode: 'fixed',
+                    },
+                  },
+                  {
+                    id: 'custom.fillOpacity',
+                    value: 0,
+                  },
+                  {
+                    id: 'custom.stacking',
+                    value: {
+                      group: 'A',
+                      mode: 'none',
+                    },
+                  },
+                  {
+                    id: 'custom.lineStyle',
+                    value: {
+                      dash: [
+                        10,
+                        10,
+                      ],
+                      fill: 'dash',
+                    },
+                  },
+                ],
+              },
+              {
+                matcher: {
+                  id: 'byValue',
+                  options: {
+                    op: 'gte',
+                    reducer: 'allIsZero',
+                    value: 0,
+                  },
+                },
+                properties: [
+                  {
+                    id: 'custom.hideFrom',
+                    value: {
+                      legend: true,
+                      tooltip: true,
+                      viz: false,
+                    },
+                  },
+                ],
+              },
+            ],
+          },
+        },
+      },
+    },
+    {
+      key: 'engine.vllm.metric.vllm_request_prompt_length',
+      outputKey: 'panel-8',
+      id: 8,
+      title: 'vLLM: Request Prompt Length',
+      queries: [
+        {
+          expr: 'sum by(le, model_name, engine, replica) (increase(vllm:request_prompt_tokens_bucket{model_name=~"$vllm_model_name", engine=~"$workerid", replica=~"$replica"}[$interval]))',
+          editorMode: 'code',
+          legend: '{{le}} - replica {{replica}}',
+          extra: {
+            format: 'heatmap',
+            fullMetaSearch: false,
+            includeNullMetadata: true,
+            instant: false,
+            useBackend: false,
+          },
+          labels: {
+            'grafana.app/export-label': 'prometheus-1',
+          },
+        },
+      ],
+      description: 'Heatmap of request prompt length',
+      vizBase: 'heatmap',
+    },
+    {
+      key: 'engine.vllm.metric.vllm_request_generation_length',
+      outputKey: 'panel-9',
+      id: 9,
+      title: 'vLLM: Request Generation Length',
+      queries: [
+        {
+          expr: 'sum by(le, model_name, engine, replica) (increase(vllm:request_generation_tokens_bucket{model_name=~"$vllm_model_name", engine=~"$workerid", replica=~"$replica"}[$interval]))',
+          editorMode: 'code',
+          legend: '{{le}} - replica {{replica}}',
+          extra: {
+            format: 'heatmap',
+            fullMetaSearch: false,
+            includeNullMetadata: true,
+            instant: false,
+            useBackend: false,
+          },
+          labels: {
+            'grafana.app/export-label': 'prometheus-1',
+          },
+        },
+      ],
+      description: 'Heatmap of request generation length',
+      vizBase: 'heatmap',
+    },
+    {
+      key: 'engine.vllm.metric.vllm_finish_reason',
+      outputKey: 'panel-10',
+      id: 10,
+      title: 'vLLM: Finish Reason',
+      queries: [
+        {
+          expr: 'sum by(finished_reason, model_name, engine) (increase(vllm:request_success_total{model_name=~"$vllm_model_name", engine=~"$workerid", replica=~"$replica"}[$interval]))',
+          editorMode: 'code',
+          legend: '{{finished_reason}} - {{model_name}} - {{engine}} - replica $replica',
+          extra: {
+            exemplar: true,
+            interval: '',
+            queryType: 'randomWalk',
+          },
+          labels: {
+            'grafana.app/export-label': 'prometheus-1',
+          },
+        },
+      ],
+      description: 'Number of finished requests by their finish reason: either an EOS token was generated or the max sequence length was reached.',
+      vizPatch: {
+        spec: {
+          options: {
+            alertThreshold: true,
+          },
+          fieldConfig: {
+            defaults: {
+              custom: {
+                fillOpacity: 0,
+                lineWidth: 1,
+                showPoints: 'auto',
+              },
+            },
+          },
+        },
+      },
+    },
+    {
+      key: 'engine.vllm.metric.vllm_queue_time',
+      outputKey: 'panel-11',
+      id: 11,
+      title: 'vLLM: Queue Time',
+      queries: [
+        {
+          expr: 'sum by(model_name, engine, replica) (rate(vllm:request_queue_time_seconds_sum{model_name=~"$vllm_model_name", engine=~"$workerid", replica=~"$replica"}[$interval]))',
+          editorMode: 'code',
+          legend: '{{model_name}} - {{engine}} - replica {{replica}}',
+          extra: {
+            exemplar: true,
+            interval: '',
+            queryType: 'randomWalk',
+          },
+          labels: {
+            'grafana.app/export-label': 'prometheus-1',
+          },
+        },
+      ],
+      vizPatch: {
+        spec: {
+          options: {
+            alertThreshold: true,
+          },
+          fieldConfig: {
+            defaults: {
+              custom: {
+                fillOpacity: 0,
+                lineWidth: 1,
+                showPoints: 'auto',
+              },
+            },
+          },
+        },
+      },
+    },
+    {
+      key: 'engine.vllm.metric.vllm_requests_prefill_and_decode_time',
+      outputKey: 'panel-12',
+      id: 12,
+      title: 'vLLM: Requests Prefill and Decode Time',
+      queries: [
+        {
+          expr: 'sum by(model_name, engine, replica) (rate(vllm:request_decode_time_seconds_sum{model_name=~"$vllm_model_name", engine=~"$workerid", replica=~"$replica"}[$interval]))',
+          editorMode: 'code',
+          legend: 'Decode - {{model_name}} - {{engine}} - replica {{replica}}',
+          extra: {
+            exemplar: true,
+            interval: '',
+            queryType: 'randomWalk',
+          },
+          labels: {
+            'grafana.app/export-label': 'prometheus-1',
+          },
+        },
+        {
+          expr: 'sum by(model_name, engine, replica) (rate(vllm:request_prefill_time_seconds_sum{model_name=~"$vllm_model_name", engine=~"$workerid", replica=~"$replica"}[$interval]))',
+          editorMode: 'code',
+          legend: 'Prefill - {{model_name}} - {{engine}} - replica {{replica}}',
+          extra: {
+            exemplar: true,
+            interval: '',
+            queryType: 'randomWalk',
+          },
+          labels: {
+            'grafana.app/export-label': 'prometheus-1',
+          },
+        },
+      ],
+      vizPatch: {
+        spec: {
+          options: {
+            alertThreshold: true,
+          },
+          fieldConfig: {
+            defaults: {
+              custom: {
+                fillOpacity: 0,
+                lineWidth: 1,
+                showPoints: 'auto',
+              },
+            },
+          },
+        },
+      },
+    },
+    {
+      key: 'engine.vllm.metric.vllm_max_generation_token_in_sequence_group',
+      outputKey: 'panel-13',
+      id: 13,
+      title: 'vLLM: Max Generation Token in Sequence Group',
+      queries: [
+        {
+          expr: 'sum by(model_name, engine, replica) (rate(vllm:request_max_num_generation_tokens_sum{model_name=~"$vllm_model_name", engine=~"$workerid", replica=~"$replica"}[$interval]))',
+          editorMode: 'code',
+          legend: '{{model_name}} - {{engine}} - replica {{replica}}',
+          extra: {
+            exemplar: true,
+            interval: '',
+            queryType: 'randomWalk',
+          },
+          labels: {
+            'grafana.app/export-label': 'prometheus-1',
+          },
+        },
+      ],
+      vizPatch: {
+        spec: {
+          options: {
+            alertThreshold: true,
+          },
+          fieldConfig: {
+            defaults: {
+              custom: {
+                fillOpacity: 0,
+                lineWidth: 1,
+                showPoints: 'auto',
+              },
+            },
+          },
+        },
+      },
+    },
+    {
+      key: 'engine.vllm.metric.vllm_prefix_cache_hit_rate',
+      outputKey: 'panel-28',
+      id: 28,
+      title: 'vLLM: Prefix Cache Hit Rate',
+      queries: [
+        {
+          expr: 'increase(vllm:prefix_cache_hits_total{model_name=~"$vllm_model_name", engine=~"$workerid", replica=~"$replica"}[$interval]) / increase(vllm:prefix_cache_queries_total{model_name=~"$vllm_model_name", engine=~"$workerid", replica=~"$replica"}[$interval])',
+          editorMode: 'code',
+          legend: 'Prefix Cache Hit Rate - {{model_name}} - {{engine}} - replica {{replica}}',
+          extra: {
+            exemplar: true,
+            interval: '',
+            queryType: 'randomWalk',
+          },
+          labels: {
+            'grafana.app/export-label': 'prometheus-1',
+          },
+        },
+      ],
+      description: 'Percentage of prefix cache queries that resulted in a cache hit (GPU).',
+      vizPatch: {
+        spec: {
+          options: {
+            alertThreshold: true,
+          },
+          fieldConfig: {
+            defaults: {
+              custom: {
+                fillOpacity: 0,
+                lineWidth: 1,
+                showPoints: 'auto',
+              },
+            },
+          },
+        },
+      },
+    },
+    {
+      key: 'engine.vllm.metric.specdecoding_accepted_vs_drafted_throughput',
+      outputKey: 'panel-30',
+      id: 30,
+      title: 'SpecDecoding: Accepted vs Drafted Throughput',
+      queries: [
+        {
+          expr: 'rate(vllm:spec_decode_num_accepted_tokens_total{model_name=~"$vllm_model_name", engine=~"$workerid", replica=~"$replica"}[$interval])',
+          editorMode: 'code',
+          legend: 'Accepted Throughput - {{model_name}} - replica {{replica}}',
+          extra: {
+            exemplar: true,
+            interval: '',
+            queryType: 'randomWalk',
+          },
+          labels: {
+            'grafana.app/export-label': 'prometheus-1',
+          },
+        },
+        {
+          expr: 'rate(vllm:spec_decode_num_draft_tokens_total{model_name=~"$vllm_model_name", engine=~"$workerid", replica=~"$replica"}[$interval])',
+          editorMode: 'code',
+          legend: 'Drafted Throughput - {{model_name}} - replica {{replica}}',
+          extra: {
+            exemplar: true,
+            interval: '',
+            queryType: 'randomWalk',
+          },
+          labels: {
+            'grafana.app/export-label': 'prometheus-1',
+          },
+        },
+      ],
+      description: 'Speculative Decoding metrics showing draft and accepted token rates',
+      vizPatch: {
+        spec: {
+          options: {
+            alertThreshold: true,
+            legend: {
+              calcs: [
+                'lastNotNull',
+              ],
+              displayMode: 'table',
+            },
+            tooltip: {
+              mode: 'multi',
+            },
+          },
+          fieldConfig: {
+            defaults: {
+              unit: 'tokens/s',
+              min: 0,
+              thresholds: {
+                steps: [
+                  {
+                    value: 0,
+                    color: 'green',
+                  },
+                ],
+              },
+              custom: {
+                fillOpacity: 10,
+              },
+            },
+          },
+        },
+      },
+    },
+    {
+      key: 'engine.vllm.metric.specdecoding_draft_acceptance_rate.2',
+      outputKey: 'panel-31',
+      id: 31,
+      title: 'SpecDecoding: Draft Acceptance Rate',
+      queries: [
+        {
+          expr: 'sum by (model_name, replica) (rate(vllm:spec_decode_num_accepted_tokens_total{model_name=~"$vllm_model_name", engine=~"$workerid", replica=~"$replica"}[$interval])) / sum by (model_name, replica) (rate(vllm:spec_decode_num_draft_tokens_total{model_name=~"$vllm_model_name", engine=~"$workerid", replica=~"$replica"}[$interval])) * 100',
+          editorMode: 'code',
+          legend: '{{model_name}} - replica {{replica}}',
+          extra: {
+            exemplar: true,
+            interval: '',
+            queryType: 'randomWalk',
+          },
+          labels: {
+            'grafana.app/export-label': 'prometheus-1',
+          },
+        },
+      ],
+      description: 'Speculative Decoding acceptance rate percentage',
+      vizBase: 'stat',
+      vizPatch: {
+        spec: {
+          options: {
+            graphMode: 'area',
+          },
+          fieldConfig: {
+            defaults: {
+              unit: 'percent',
+              min: 0,
+              max: 100,
+              thresholds: {
+                steps: [
+                  {
+                    value: 0,
+                    color: 'red',
+                  },
+                  {
+                    value: 80,
+                    color: 'yellow',
+                  },
+                  {
+                    value: 90,
+                    color: 'green',
+                  },
+                ],
+              },
+            },
+          },
+        },
+      },
+    },
+    {
+      key: 'engine.vllm.metric.specdecoding_accepted_vs_drafted_tokens',
+      outputKey: 'panel-32',
+      id: 32,
+      title: 'SpecDecoding: Accepted vs Drafted Tokens',
+      queries: [
+        {
+          expr: 'increase(vllm:spec_decode_num_accepted_tokens_total{model_name=~"$vllm_model_name", engine=~"$workerid", replica=~"$replica"}[$interval])',
+          editorMode: 'code',
+          legend: 'Accepted - {{model_name}} - replica {{replica}}',
+          extra: {
+            exemplar: true,
+            interval: '',
+            queryType: 'randomWalk',
+          },
+          labels: {
+            'grafana.app/export-label': 'prometheus-1',
+          },
+        },
+        {
+          expr: 'increase(vllm:spec_decode_num_draft_tokens_total{model_name=~"$vllm_model_name", engine=~"$workerid", replica=~"$replica"}[$interval])',
+          editorMode: 'code',
+          legend: 'Drafted - {{model_name}} - replica {{replica}}',
+          extra: {
+            exemplar: true,
+            interval: '',
+            queryType: 'randomWalk',
+          },
+          labels: {
+            'grafana.app/export-label': 'prometheus-1',
+          },
+        },
+      ],
+      description: 'Total accepted and drafted tokens in speculative decoding',
+      vizPatch: {
+        spec: {
+          options: {
+            alertThreshold: true,
+            legend: {
+              calcs: [
+                'lastNotNull',
+              ],
+              displayMode: 'table',
+            },
+            tooltip: {
+              mode: 'multi',
+            },
+          },
+          fieldConfig: {
+            defaults: {
+              unit: 'short',
+              min: 0,
+              thresholds: {
+                steps: [
+                  {
+                    value: 0,
+                    color: 'green',
+                  },
+                ],
+              },
+              custom: {
+                fillOpacity: 10,
+              },
+            },
+          },
+        },
+      },
+    },
+    {
+      key: 'engine.vllm.metric.specdecoding_draft_acceptance_rate',
+      outputKey: 'panel-33',
+      id: 33,
+      title: 'SpecDecoding: Draft Acceptance Rate',
+      queries: [
+        {
+          expr: 'sum by (model_name, replica) (rate(vllm:spec_decode_num_accepted_tokens_total{model_name=~"$vllm_model_name", engine=~"$workerid", replica=~"$replica"}[$interval])) / sum by (model_name, replica) (rate(vllm:spec_decode_num_draft_tokens_total{model_name=~"$vllm_model_name", engine=~"$workerid", replica=~"$replica"}[$interval])) * 100',
+          editorMode: 'code',
+          legend: '{{model_name}} - replica {{replica}}',
+          extra: {
+            exemplar: true,
+            interval: '',
+            queryType: 'randomWalk',
+          },
+          labels: {
+            'grafana.app/export-label': 'prometheus-1',
+          },
+        },
+      ],
+      description: 'Speculative Decoding acceptance rate percentage',
+      vizPatch: {
+        spec: {
+          options: {
+            alertThreshold: true,
+            legend: {
+              calcs: [
+                'lastNotNull',
+              ],
+              displayMode: 'table',
+            },
+            tooltip: {
+              mode: 'multi',
+            },
+          },
+          fieldConfig: {
+            defaults: {
+              unit: 'percent',
+              min: 0,
+              max: 100,
+              thresholds: {
+                steps: [
+                  {
+                    value: 0,
+                    color: 'red',
+                  },
+                  {
+                    value: 80,
+                    color: 'yellow',
+                  },
+                  {
+                    value: 90,
+                    color: 'green',
+                  },
+                ],
+              },
+              custom: {
+                fillOpacity: 10,
+                thresholdsStyle: {
+                  mode: 'line',
+                },
+              },
+            },
+          },
+        },
+      },
+    },
+    {
+      key: 'engine.vllm.metric.specdecoding_mean_acceptance_length',
+      outputKey: 'panel-35',
+      id: 35,
+      title: 'SpecDecoding: Mean Acceptance Length',
+      queries: [
+        {
+          expr: 'sum by (model_name, replica) (rate(vllm:spec_decode_num_draft_tokens_total{model_name=~"$vllm_model_name", engine=~"$workerid", replica=~"$replica"}[$interval])) / sum by (model_name, replica) (rate(vllm:spec_decode_num_drafts_total{model_name=~"$vllm_model_name", engine=~"$workerid", replica=~"$replica"}[$interval]))',
+          editorMode: 'code',
+          legend: '{{model_name}} - replica {{replica}}',
+          extra: {
+            exemplar: true,
+            interval: '',
+            queryType: 'randomWalk',
+          },
+          labels: {
+            'grafana.app/export-label': 'prometheus-1',
+          },
+        },
+      ],
+      description: 'Mean number of drafts per speculation',
+      vizPatch: {
+        spec: {
+          options: {
+            alertThreshold: true,
+            legend: {
+              calcs: [
+                'lastNotNull',
+              ],
+              displayMode: 'table',
+            },
+            tooltip: {
+              mode: 'multi',
+            },
+          },
+          fieldConfig: {
+            defaults: {
+              unit: 'short',
+              min: 0,
+              thresholds: {
+                steps: [
+                  {
+                    value: 0,
+                    color: 'super-light-yellow',
+                  },
+                  {
+                    value: 1,
+                    color: 'super-light-green',
+                  },
+                  {
+                    value: 2,
+                    color: 'green',
+                  },
+                ],
+              },
+              custom: {
+                fillOpacity: 10,
+                thresholdsStyle: {
+                  mode: 'line',
+                },
+              },
+            },
+          },
+        },
+      },
+    },
+    {
+      key: 'engine.vllm.metric.specdecoding_mean_acceptance_length.2',
+      outputKey: 'panel-36',
+      id: 36,
+      title: 'SpecDecoding: Mean Acceptance Length',
+      queries: [
+        {
+          expr: 'sum by (model_name, replica) (rate(vllm:spec_decode_num_draft_tokens_total{model_name=~"$vllm_model_name", engine=~"$workerid", replica=~"$replica"}[$interval])) / sum by (model_name, replica) (rate(vllm:spec_decode_num_drafts_total{model_name=~"$vllm_model_name", engine=~"$workerid", replica=~"$replica"}[$interval]))',
+          editorMode: 'code',
+          legend: '{{model_name}} - replica {{replica}}',
+          extra: {
+            exemplar: true,
+            interval: '',
+            queryType: 'randomWalk',
+          },
+          labels: {
+            'grafana.app/export-label': 'prometheus-1',
+          },
+        },
+      ],
+      description: 'Mean number of drafts per speculation',
+      vizBase: 'stat',
+      vizPatch: {
+        spec: {
+          options: {
+            graphMode: 'area',
+          },
+          fieldConfig: {
+            defaults: {
+              unit: 'short',
+              min: 0,
+              thresholds: {
+                steps: [
+                  {
+                    value: 0,
+                    color: 'super-light-yellow',
+                  },
+                  {
+                    value: 1,
+                    color: 'super-light-green',
+                  },
+                  {
+                    value: 2,
+                    color: 'green',
+                  },
+                ],
+              },
+            },
+          },
+        },
+      },
+    },
+    {
+      key: 'hardware.cpu_host_metrics.cpu_utilization',
+      outputKey: 'panel-325',
+      id: 325,
+      title: 'CPU Utilization',
+      queries: [
+        {
+          expr: '100 - avg by (node, instance) (rate(node_cpu_seconds_total{job="node-exporter", mode="idle"}[$__rate_interval])) * 100',
+          editorMode: 'code',
+          legend: '{{node}} ({{instance}})',
+          labels: {
+            'grafana.app/export-label': 'prometheus-1',
+          },
+        },
+      ],
+      description: 'CPU utilization for all node_exporter targets',
+      vizPatch: {
+        spec: {
+          options: {
+            legend: {
+              calcs: [
+                'mean',
+                'max',
+              ],
+              displayMode: 'table',
+            },
+            tooltip: {
+              mode: 'multi',
+            },
+          },
+          fieldConfig: {
+            defaults: {
+              unit: 'percent',
+              thresholds: {
+                steps: [
+                  {
+                    value: 0,
+                    color: 'green',
+                  },
+                ],
+              },
+              custom: {
+                fillOpacity: 20,
+                showPoints: 'auto',
+              },
+              min: 0,
+              max: 100,
+            },
+          },
+        },
+      },
+    },
+    {
+      key: 'hardware.cpu_host_metrics.memory_used',
+      outputKey: 'panel-326',
+      id: 326,
+      title: 'Memory Used',
+      queries: [
+        {
+          expr: 'node_memory_MemTotal_bytes{job="node-exporter"} - node_memory_MemAvailable_bytes{job="node-exporter"}',
+          editorMode: 'code',
+          legend: '{{node}} ({{instance}})',
+          labels: {
+            'grafana.app/export-label': 'prometheus-1',
+          },
+        },
+      ],
+      description: 'Used memory for all node_exporter targets',
+      vizPatch: {
+        spec: {
+          options: {
+            legend: {
+              calcs: [
+                'mean',
+                'max',
+              ],
+              displayMode: 'table',
+            },
+            tooltip: {
+              mode: 'multi',
+            },
+          },
+          fieldConfig: {
+            defaults: {
+              unit: 'bytes',
+              thresholds: {
+                steps: [
+                  {
+                    value: 0,
+                    color: 'green',
+                  },
+                ],
+              },
+              custom: {
+                fillOpacity: 20,
+                showPoints: 'auto',
+              },
+              min: 0,
+            },
+          },
+        },
+      },
+    },
+    {
+      key: 'hardware.cpu_host_metrics.network_throughput',
+      outputKey: 'panel-328',
+      id: 328,
+      title: 'Network Throughput',
+      queries: [
+        {
+          expr: 'sum by (node, instance) (rate(node_network_receive_bytes_total{job="node-exporter", device!~"lo"}[$__rate_interval]))',
+          editorMode: 'code',
+          legend: '{{node}} RX',
+          labels: {
+            'grafana.app/export-label': 'prometheus-1',
+          },
+        },
+        {
+          expr: 'sum by (node, instance) (rate(node_network_transmit_bytes_total{job="node-exporter", device!~"lo"}[$__rate_interval]))',
+          editorMode: 'code',
+          legend: '{{node}} TX',
+          labels: {
+            'grafana.app/export-label': 'prometheus-1',
+          },
+        },
+      ],
+      description: 'Receive and transmit throughput for all node_exporter targets',
+      vizPatch: {
+        spec: {
+          options: {
+            legend: {
+              calcs: [
+                'mean',
+                'max',
+              ],
+              displayMode: 'table',
+            },
+            tooltip: {
+              mode: 'multi',
+            },
+          },
+          fieldConfig: {
+            defaults: {
+              unit: 'Bps',
+              thresholds: {
+                steps: [
+                  {
+                    value: 0,
+                    color: 'green',
+                  },
+                ],
+              },
+              custom: {
+                fillOpacity: 20,
+                showPoints: 'auto',
+              },
+              min: 0,
+            },
+          },
+        },
+      },
+    },
+    {
+      key: 'hardware.ascend_npu_metrics.npu_ai_core_utilization',
+      outputKey: 'panel-329',
+      id: 329,
+      title: 'NPU AI Core Utilization',
+      queries: [
+        {
+          expr: 'npu_chip_info_utilization{job="npu-exporter", instance=~"$npu_instance"}',
+          editorMode: 'code',
+          legend: 'NPU {{id}}',
+          labels: {
+            'grafana.app/export-label': 'prometheus-1',
+          },
+        },
+      ],
+      description: 'AI Core utilization by NPU',
+      vizPatch: {
+        spec: {
+          options: {
+            legend: {
+              calcs: [
+                'mean',
+                'max',
+              ],
+              displayMode: 'table',
+            },
+            tooltip: {
+              mode: 'multi',
+            },
+          },
+          fieldConfig: {
+            defaults: {
+              unit: 'percent',
+              thresholds: {
+                steps: [
+                  {
+                    value: 0,
+                    color: 'green',
+                  },
+                ],
+              },
+              custom: {
+                fillOpacity: 20,
+                showPoints: 'auto',
+              },
+              min: 0,
+              max: 100,
+            },
+          },
+        },
+      },
+    },
+    {
+      key: 'hardware.ascend_npu_metrics.npu_hbm_utilization',
+      outputKey: 'panel-330',
+      id: 330,
+      title: 'NPU HBM Utilization',
+      queries: [
+        {
+          expr: 'npu_chip_info_hbm_utilization{job="npu-exporter", instance=~"$npu_instance"}',
+          editorMode: 'code',
+          legend: 'NPU {{id}}',
+          labels: {
+            'grafana.app/export-label': 'prometheus-1',
+          },
+        },
+      ],
+      description: 'HBM utilization by NPU',
+      vizPatch: {
+        spec: {
+          options: {
+            legend: {
+              calcs: [
+                'mean',
+                'max',
+              ],
+              displayMode: 'table',
+            },
+            tooltip: {
+              mode: 'multi',
+            },
+          },
+          fieldConfig: {
+            defaults: {
+              unit: 'percent',
+              thresholds: {
+                steps: [
+                  {
+                    value: 0,
+                    color: 'green',
+                  },
+                ],
+              },
+              custom: {
+                fillOpacity: 20,
+                showPoints: 'auto',
+              },
+              min: 0,
+              max: 100,
+            },
+          },
+        },
+      },
+    },
+    {
+      key: 'hardware.ascend_npu_metrics.npu_hbm_used_memory',
+      outputKey: 'panel-331',
+      id: 331,
+      title: 'NPU HBM Used Memory',
+      queries: [
+        {
+          expr: 'npu_chip_info_hbm_used_memory{job="npu-exporter", instance=~"$npu_instance"}',
+          editorMode: 'code',
+          legend: 'NPU {{id}}',
+          labels: {
+            'grafana.app/export-label': 'prometheus-1',
+          },
+        },
+      ],
+      description: 'Used HBM memory by NPU',
+      vizPatch: {
+        spec: {
+          options: {
+            legend: {
+              calcs: [
+                'mean',
+                'max',
+              ],
+              displayMode: 'table',
+            },
+            tooltip: {
+              mode: 'multi',
+            },
+          },
+          fieldConfig: {
+            defaults: {
+              unit: 'decmbytes',
+              thresholds: {
+                steps: [
+                  {
+                    value: 0,
+                    color: 'green',
+                  },
+                ],
+              },
+              custom: {
+                fillOpacity: 20,
+                showPoints: 'auto',
+              },
+              min: 0,
+            },
+          },
+        },
+      },
+    },
+    {
+      key: 'hardware.ascend_npu_metrics.npu_power',
+      outputKey: 'panel-332',
+      id: 332,
+      title: 'NPU Power',
+      queries: [
+        {
+          expr: 'npu_chip_info_power{job="npu-exporter", instance=~"$npu_instance"}',
+          editorMode: 'code',
+          legend: 'NPU {{id}}',
+          labels: {
+            'grafana.app/export-label': 'prometheus-1',
+          },
+        },
+      ],
+      description: 'Power consumption by NPU',
+      vizPatch: {
+        spec: {
+          options: {
+            legend: {
+              calcs: [
+                'mean',
+                'max',
+              ],
+              displayMode: 'table',
+            },
+            tooltip: {
+              mode: 'multi',
+            },
+          },
+          fieldConfig: {
+            defaults: {
+              unit: 'watt',
+              thresholds: {
+                steps: [
+                  {
+                    value: 0,
+                    color: 'green',
+                  },
+                ],
+              },
+              custom: {
+                fillOpacity: 20,
+                showPoints: 'auto',
+              },
+              min: 0,
+            },
+          },
+        },
+      },
+    },
+    {
+      key: 'hardware.ascend_npu_metrics.npu_temperature',
+      outputKey: 'panel-333',
+      id: 333,
+      title: 'NPU Temperature',
+      queries: [
+        {
+          expr: 'npu_chip_info_temperature{job="npu-exporter", instance=~"$npu_instance"}',
+          editorMode: 'code',
+          legend: 'NPU {{id}}',
+          labels: {
+            'grafana.app/export-label': 'prometheus-1',
+          },
+        },
+      ],
+      description: 'Chip temperature by NPU',
+      vizPatch: {
+        spec: {
+          options: {
+            legend: {
+              calcs: [
+                'mean',
+                'max',
+              ],
+              displayMode: 'table',
+            },
+            tooltip: {
+              mode: 'multi',
+            },
+          },
+          fieldConfig: {
+            defaults: {
+              unit: 'celsius',
+              thresholds: {
+                steps: [
+                  {
+                    value: 0,
+                    color: 'green',
+                  },
+                ],
+              },
+              custom: {
+                fillOpacity: 20,
+                showPoints: 'auto',
+              },
+              min: 0,
+            },
+          },
+        },
+      },
+    },
+    {
+      key: 'hardware.ascend_npu_metrics.npu_health_status',
+      outputKey: 'panel-334',
+      id: 334,
+      title: 'NPU Health Status',
+      queries: [
+        {
+          expr: 'npu_chip_info_health_status{job="npu-exporter", instance=~"$npu_instance"}',
+          editorMode: 'code',
+          legend: 'NPU {{id}}',
+          labels: {
+            'grafana.app/export-label': 'prometheus-1',
+          },
+        },
+      ],
+      description: 'Health status code reported by NPU Exporter',
+      vizPatch: {
+        spec: {
+          options: {
+            legend: {
+              calcs: [
+                'mean',
+                'max',
+              ],
+              displayMode: 'table',
+            },
+            tooltip: {
+              mode: 'multi',
+            },
+          },
+          fieldConfig: {
+            defaults: {
+              unit: 'short',
+              thresholds: {
+                steps: [
+                  {
+                    value: 0,
+                    color: 'green',
+                  },
+                ],
+              },
+              custom: {
+                fillOpacity: 20,
+                showPoints: 'auto',
+              },
+              min: 0,
+            },
+          },
+        },
+      },
+    },
+    {
+      key: 'hardware.ascend_npu_metrics.npu_hbm_bandwidth_utilization',
+      outputKey: 'panel-335',
+      id: 335,
+      title: 'NPU HBM Bandwidth Utilization',
+      queries: [
+        {
+          expr: 'npu_chip_info_hbm_bandwidth_utilization{job="npu-exporter", instance=~"$npu_instance"}',
+          editorMode: 'code',
+          legend: 'NPU {{id}}',
+          labels: {
+            'grafana.app/export-label': 'prometheus-1',
+          },
+        },
+      ],
+      description: 'HBM bandwidth utilization by NPU',
+      vizPatch: {
+        spec: {
+          options: {
+            legend: {
+              calcs: [
+                'mean',
+                'max',
+              ],
+              displayMode: 'table',
+            },
+            tooltip: {
+              mode: 'multi',
+            },
+          },
+          fieldConfig: {
+            defaults: {
+              unit: 'percent',
+              thresholds: {
+                steps: [
+                  {
+                    value: 0,
+                    color: 'green',
+                  },
+                ],
+              },
+              custom: {
+                fillOpacity: 20,
+                showPoints: 'auto',
+              },
+              min: 0,
+              max: 100,
+            },
+          },
+        },
+      },
+    },
+    {
+      key: 'hardware.ascend_npu_metrics.npu_network_throughput',
+      outputKey: 'panel-336',
+      id: 336,
+      title: 'NPU Network Throughput',
+      queries: [
+        {
+          expr: 'npu_chip_info_bandwidth_rx{job="npu-exporter", instance=~"$npu_instance"}',
+          editorMode: 'code',
+          legend: 'NPU {{id}} RX',
+          labels: {
+            'grafana.app/export-label': 'prometheus-1',
+          },
+        },
+        {
+          expr: 'npu_chip_info_bandwidth_tx{job="npu-exporter", instance=~"$npu_instance"}',
+          editorMode: 'code',
+          legend: 'NPU {{id}} TX',
+          labels: {
+            'grafana.app/export-label': 'prometheus-1',
+          },
+        },
+      ],
+      description: 'NPU network receive and transmit throughput',
+      vizPatch: {
+        spec: {
+          options: {
+            legend: {
+              calcs: [
+                'mean',
+                'max',
+              ],
+              displayMode: 'table',
+            },
+            tooltip: {
+              mode: 'multi',
+            },
+          },
+          fieldConfig: {
+            defaults: {
+              unit: 'MBs',
+              thresholds: {
+                steps: [
+                  {
+                    value: 0,
+                    color: 'green',
+                  },
+                ],
+              },
+              custom: {
+                fillOpacity: 20,
+                showPoints: 'auto',
+              },
+              min: 0,
+            },
+          },
+        },
+      },
+    },
+  ],
+  rows: {
+    'vllm engine metric': {
+      kind: 'RowsLayoutRow',
+      spec: {
+        title: 'vllm engine metric',
+        collapse: true,
+        layout: {
+          kind: 'GridLayout',
+          spec: {
+            items: [
+              {
+                kind: 'GridLayoutItem',
+                spec: {
+                  x: 0,
+                  y: 0,
+                  width: 12,
+                  height: 8,
+                  element: {
+                    kind: 'ElementReference',
+                    name: 'engine.vllm.metric.vllm_token_throughput',
+                  },
+                },
+              },
+              {
+                kind: 'GridLayoutItem',
+                spec: {
+                  x: 12,
+                  y: 0,
+                  width: 12,
+                  height: 8,
+                  element: {
+                    kind: 'ElementReference',
+                    name: 'engine.vllm.metric.vllm_time_per_output_token_latency',
+                  },
+                },
+              },
+              {
+                kind: 'GridLayoutItem',
+                spec: {
+                  x: 0,
+                  y: 8,
+                  width: 12,
+                  height: 8,
+                  element: {
+                    kind: 'ElementReference',
+                    name: 'engine.vllm.metric.vllm_cache_utilization',
+                  },
+                },
+              },
+              {
+                kind: 'GridLayoutItem',
+                spec: {
+                  x: 12,
+                  y: 8,
+                  width: 12,
+                  height: 8,
+                  element: {
+                    kind: 'ElementReference',
+                    name: 'engine.vllm.metric.vllm_time_to_first_token_latency',
+                  },
+                },
+              },
+              {
+                kind: 'GridLayoutItem',
+                spec: {
+                  x: 0,
+                  y: 16,
+                  width: 12,
+                  height: 8,
+                  element: {
+                    kind: 'ElementReference',
+                    name: 'engine.vllm.metric.vllm_e2e_request_latency',
+                  },
+                },
+              },
+              {
+                kind: 'GridLayoutItem',
+                spec: {
+                  x: 12,
+                  y: 16,
+                  width: 12,
+                  height: 8,
+                  element: {
+                    kind: 'ElementReference',
+                    name: 'engine.vllm.metric.vllm_scheduler_state',
+                  },
+                },
+              },
+              {
+                kind: 'GridLayoutItem',
+                spec: {
+                  x: 0,
+                  y: 24,
+                  width: 12,
+                  height: 8,
+                  element: {
+                    kind: 'ElementReference',
+                    name: 'engine.vllm.metric.vllm_request_prompt_length',
+                  },
+                },
+              },
+              {
+                kind: 'GridLayoutItem',
+                spec: {
+                  x: 12,
+                  y: 24,
+                  width: 12,
+                  height: 8,
+                  element: {
+                    kind: 'ElementReference',
+                    name: 'engine.vllm.metric.vllm_request_generation_length',
+                  },
+                },
+              },
+              {
+                kind: 'GridLayoutItem',
+                spec: {
+                  x: 0,
+                  y: 32,
+                  width: 12,
+                  height: 8,
+                  element: {
+                    kind: 'ElementReference',
+                    name: 'engine.vllm.metric.vllm_finish_reason',
+                  },
+                },
+              },
+              {
+                kind: 'GridLayoutItem',
+                spec: {
+                  x: 12,
+                  y: 32,
+                  width: 12,
+                  height: 8,
+                  element: {
+                    kind: 'ElementReference',
+                    name: 'engine.vllm.metric.vllm_queue_time',
+                  },
+                },
+              },
+              {
+                kind: 'GridLayoutItem',
+                spec: {
+                  x: 0,
+                  y: 40,
+                  width: 12,
+                  height: 8,
+                  element: {
+                    kind: 'ElementReference',
+                    name: 'engine.vllm.metric.vllm_requests_prefill_and_decode_time',
+                  },
+                },
+              },
+              {
+                kind: 'GridLayoutItem',
+                spec: {
+                  x: 12,
+                  y: 40,
+                  width: 12,
+                  height: 8,
+                  element: {
+                    kind: 'ElementReference',
+                    name: 'engine.vllm.metric.vllm_max_generation_token_in_sequence_group',
+                  },
+                },
+              },
+              {
+                kind: 'GridLayoutItem',
+                spec: {
+                  x: 0,
+                  y: 48,
+                  width: 12,
+                  height: 8,
+                  element: {
+                    kind: 'ElementReference',
+                    name: 'engine.vllm.metric.vllm_prefix_cache_hit_rate',
+                  },
+                },
+              },
+              {
+                kind: 'GridLayoutItem',
+                spec: {
+                  x: 12,
+                  y: 48,
+                  width: 12,
+                  height: 8,
+                  element: {
+                    kind: 'ElementReference',
+                    name: 'engine.vllm.metric.specdecoding_mean_acceptance_length',
+                  },
+                },
+              },
+              {
+                kind: 'GridLayoutItem',
+                spec: {
+                  x: 0,
+                  y: 56,
+                  width: 12,
+                  height: 8,
+                  element: {
+                    kind: 'ElementReference',
+                    name: 'engine.vllm.metric.specdecoding_accepted_vs_drafted_throughput',
+                  },
+                },
+              },
+              {
+                kind: 'GridLayoutItem',
+                spec: {
+                  x: 12,
+                  y: 56,
+                  width: 12,
+                  height: 8,
+                  element: {
+                    kind: 'ElementReference',
+                    name: 'engine.vllm.metric.specdecoding_draft_acceptance_rate',
+                  },
+                },
+              },
+              {
+                kind: 'GridLayoutItem',
+                spec: {
+                  x: 0,
+                  y: 64,
+                  width: 12,
+                  height: 8,
+                  element: {
+                    kind: 'ElementReference',
+                    name: 'engine.vllm.metric.specdecoding_accepted_vs_drafted_tokens',
+                  },
+                },
+              },
+              {
+                kind: 'GridLayoutItem',
+                spec: {
+                  x: 12,
+                  y: 64,
+                  width: 12,
+                  height: 8,
+                  element: {
+                    kind: 'ElementReference',
+                    name: 'engine.vllm.metric.specdecoding_draft_acceptance_rate.2',
+                  },
+                },
+              },
+              {
+                kind: 'GridLayoutItem',
+                spec: {
+                  x: 0,
+                  y: 72,
+                  width: 12,
+                  height: 8,
+                  element: {
+                    kind: 'ElementReference',
+                    name: 'engine.vllm.metric.specdecoding_mean_acceptance_length.2',
+                  },
+                },
+              },
+            ],
+          },
+        },
+      },
+    },
+    'hardware metric': {
+      kind: 'RowsLayoutRow',
+      spec: {
+        title: 'hardware metric',
+        collapse: true,
+        layout: {
+          kind: 'RowsLayout',
+          spec: {
+            rows: [
+              {
+                kind: 'RowsLayoutRow',
+                spec: {
+                  title: 'CPU / Host Metrics',
+                  collapse: false,
+                  layout: {
+                    kind: 'AutoGridLayout',
+                    spec: {
+                      maxColumnCount: 2,
+                      columnWidthMode: 'standard',
+                      rowHeightMode: 'standard',
+                      items: [
+                        {
+                          kind: 'AutoGridLayoutItem',
+                          spec: {
+                            element: {
+                              kind: 'ElementReference',
+                              name: 'hardware.cpu_host_metrics.cpu_utilization',
+                            },
+                            conditionalRendering: {
+                              kind: 'ConditionalRenderingGroup',
+                              spec: {
+                                visibility: 'hide',
+                                condition: 'and',
+                                items: [
+                                  {
+                                    kind: 'ConditionalRenderingData',
+                                    spec: {
+                                      value: false,
+                                    },
+                                  },
+                                ],
+                              },
+                            },
+                          },
+                        },
+                        {
+                          kind: 'AutoGridLayoutItem',
+                          spec: {
+                            element: {
+                              kind: 'ElementReference',
+                              name: 'hardware.cpu_host_metrics.memory_used',
+                            },
+                            conditionalRendering: {
+                              kind: 'ConditionalRenderingGroup',
+                              spec: {
+                                visibility: 'hide',
+                                condition: 'and',
+                                items: [
+                                  {
+                                    kind: 'ConditionalRenderingData',
+                                    spec: {
+                                      value: false,
+                                    },
+                                  },
+                                ],
+                              },
+                            },
+                          },
+                        },
+                        {
+                          kind: 'AutoGridLayoutItem',
+                          spec: {
+                            element: {
+                              kind: 'ElementReference',
+                              name: 'hardware.cpu_host_metrics.network_throughput',
+                            },
+                            conditionalRendering: {
+                              kind: 'ConditionalRenderingGroup',
+                              spec: {
+                                visibility: 'hide',
+                                condition: 'and',
+                                items: [
+                                  {
+                                    kind: 'ConditionalRenderingData',
+                                    spec: {
+                                      value: false,
+                                    },
+                                  },
+                                ],
+                              },
+                            },
+                          },
+                        },
+                      ],
+                    },
+                  },
+                },
+              },
+              {
+                kind: 'RowsLayoutRow',
+                spec: {
+                  title: 'Ascend NPU Metrics',
+                  collapse: false,
+                  layout: {
+                    kind: 'TabsLayout',
+                    spec: {
+                      tabs: [
+                        {
+                          kind: 'TabsLayoutTab',
+                          spec: {
+                            title: '$npu_instance',
+                            repeat: {
+                              mode: 'variable',
+                              value: 'npu_instance',
+                            },
+                            layout: {
+                              kind: 'AutoGridLayout',
+                              spec: {
+                                maxColumnCount: 2,
+                                columnWidthMode: 'standard',
+                                rowHeightMode: 'standard',
+                                items: [
+                                  {
+                                    kind: 'AutoGridLayoutItem',
+                                    spec: {
+                                      element: {
+                                        kind: 'ElementReference',
+                                        name: 'hardware.ascend_npu_metrics.npu_ai_core_utilization',
+                                      },
+                                      conditionalRendering: {
+                                        kind: 'ConditionalRenderingGroup',
+                                        spec: {
+                                          visibility: 'hide',
+                                          condition: 'and',
+                                          items: [
+                                            {
+                                              kind: 'ConditionalRenderingData',
+                                              spec: {
+                                                value: false,
+                                              },
+                                            },
+                                          ],
+                                        },
+                                      },
+                                    },
+                                  },
+                                  {
+                                    kind: 'AutoGridLayoutItem',
+                                    spec: {
+                                      element: {
+                                        kind: 'ElementReference',
+                                        name: 'hardware.ascend_npu_metrics.npu_hbm_utilization',
+                                      },
+                                      conditionalRendering: {
+                                        kind: 'ConditionalRenderingGroup',
+                                        spec: {
+                                          visibility: 'hide',
+                                          condition: 'and',
+                                          items: [
+                                            {
+                                              kind: 'ConditionalRenderingData',
+                                              spec: {
+                                                value: false,
+                                              },
+                                            },
+                                          ],
+                                        },
+                                      },
+                                    },
+                                  },
+                                  {
+                                    kind: 'AutoGridLayoutItem',
+                                    spec: {
+                                      element: {
+                                        kind: 'ElementReference',
+                                        name: 'hardware.ascend_npu_metrics.npu_hbm_used_memory',
+                                      },
+                                      conditionalRendering: {
+                                        kind: 'ConditionalRenderingGroup',
+                                        spec: {
+                                          visibility: 'hide',
+                                          condition: 'and',
+                                          items: [
+                                            {
+                                              kind: 'ConditionalRenderingData',
+                                              spec: {
+                                                value: false,
+                                              },
+                                            },
+                                          ],
+                                        },
+                                      },
+                                    },
+                                  },
+                                  {
+                                    kind: 'AutoGridLayoutItem',
+                                    spec: {
+                                      element: {
+                                        kind: 'ElementReference',
+                                        name: 'hardware.ascend_npu_metrics.npu_power',
+                                      },
+                                      conditionalRendering: {
+                                        kind: 'ConditionalRenderingGroup',
+                                        spec: {
+                                          visibility: 'hide',
+                                          condition: 'and',
+                                          items: [
+                                            {
+                                              kind: 'ConditionalRenderingData',
+                                              spec: {
+                                                value: false,
+                                              },
+                                            },
+                                          ],
+                                        },
+                                      },
+                                    },
+                                  },
+                                  {
+                                    kind: 'AutoGridLayoutItem',
+                                    spec: {
+                                      element: {
+                                        kind: 'ElementReference',
+                                        name: 'hardware.ascend_npu_metrics.npu_temperature',
+                                      },
+                                      conditionalRendering: {
+                                        kind: 'ConditionalRenderingGroup',
+                                        spec: {
+                                          visibility: 'hide',
+                                          condition: 'and',
+                                          items: [
+                                            {
+                                              kind: 'ConditionalRenderingData',
+                                              spec: {
+                                                value: false,
+                                              },
+                                            },
+                                          ],
+                                        },
+                                      },
+                                    },
+                                  },
+                                  {
+                                    kind: 'AutoGridLayoutItem',
+                                    spec: {
+                                      element: {
+                                        kind: 'ElementReference',
+                                        name: 'hardware.ascend_npu_metrics.npu_health_status',
+                                      },
+                                      conditionalRendering: {
+                                        kind: 'ConditionalRenderingGroup',
+                                        spec: {
+                                          visibility: 'hide',
+                                          condition: 'and',
+                                          items: [
+                                            {
+                                              kind: 'ConditionalRenderingData',
+                                              spec: {
+                                                value: false,
+                                              },
+                                            },
+                                          ],
+                                        },
+                                      },
+                                    },
+                                  },
+                                  {
+                                    kind: 'AutoGridLayoutItem',
+                                    spec: {
+                                      element: {
+                                        kind: 'ElementReference',
+                                        name: 'hardware.ascend_npu_metrics.npu_hbm_bandwidth_utilization',
+                                      },
+                                      conditionalRendering: {
+                                        kind: 'ConditionalRenderingGroup',
+                                        spec: {
+                                          visibility: 'hide',
+                                          condition: 'and',
+                                          items: [
+                                            {
+                                              kind: 'ConditionalRenderingData',
+                                              spec: {
+                                                value: false,
+                                              },
+                                            },
+                                          ],
+                                        },
+                                      },
+                                    },
+                                  },
+                                  {
+                                    kind: 'AutoGridLayoutItem',
+                                    spec: {
+                                      element: {
+                                        kind: 'ElementReference',
+                                        name: 'hardware.ascend_npu_metrics.npu_network_throughput',
+                                      },
+                                      conditionalRendering: {
+                                        kind: 'ConditionalRenderingGroup',
+                                        spec: {
+                                          visibility: 'hide',
+                                          condition: 'and',
+                                          items: [
+                                            {
+                                              kind: 'ConditionalRenderingData',
+                                              spec: {
+                                                value: false,
+                                              },
+                                            },
+                                          ],
+                                        },
+                                      },
+                                    },
+                                  },
+                                ],
+                              },
+                            },
+                          },
+                        },
+                      ],
+                    },
+                  },
+                },
+              },
+            ],
+          },
+        },
+      },
+    },
+  },
+  rowOrder: [
+    'rl state timeline',
+    'training metric',
+    'vllm engine metric',
+    'transfer queue metric',
+    'hardware metric',
+  ],
+  variables: {
+    vllm_model_name: {
+      kind: 'QueryVariable',
+      spec: {
+        name: 'vllm_model_name',
+        current: {
+          text: '',
+          value: '',
+        },
+        label: 'vllm: vLLM Model Name',
+        hide: 'dontHide',
+        refresh: 'onDashboardLoad',
+        skipUrlSync: false,
+        query: {
+          kind: 'DataQuery',
+          group: 'prometheus',
+          version: 'v0',
+          datasource: {
+            name: '${datasource}',
+          },
+          spec: {
+            query: 'label_values(vllm:request_prompt_tokens_sum{}, model_name)',
+            refId: 'StandardVariableQuery',
+          },
+        },
+        regex: '',
+        regexApplyTo: 'value',
+        sort: 'disabled',
+        definition: 'label_values(vllm:request_prompt_tokens_sum{}, model_name)',
+        options: [],
+        multi: false,
+        includeAll: true,
+        allValue: '.*',
+        allowCustomValue: true,
+      },
+    },
+    workerid: {
+      kind: 'QueryVariable',
+      spec: {
+        name: 'workerid',
+        current: {
+          text: '',
+          value: '',
+        },
+        label: 'vllm: vLLM Engine ID',
+        hide: 'dontHide',
+        refresh: 'onDashboardLoad',
+        skipUrlSync: false,
+        query: {
+          kind: 'DataQuery',
+          group: 'prometheus',
+          version: 'v0',
+          datasource: {
+            name: '${datasource}',
+          },
+          spec: {
+            query: 'label_values(vllm:request_prompt_tokens_sum{}, engine)',
+            refId: 'StandardVariableQuery',
+          },
+        },
+        regex: '',
+        regexApplyTo: 'value',
+        sort: 'disabled',
+        definition: 'label_values(vllm:request_prompt_tokens_sum{}, engine)',
+        options: [],
+        multi: false,
+        includeAll: true,
+        allValue: '.*',
+        allowCustomValue: true,
+      },
+    },
+    interval: {
+      kind: 'CustomVariable',
+      spec: {
+        name: 'interval',
+        query: '',
+        current: {
+          text: '5m',
+          value: '5m',
+        },
+        options: [],
+        multi: false,
+        includeAll: false,
+        label: 'vllm: Interval',
+        hide: 'dontHide',
+        skipUrlSync: false,
+        allowCustomValue: true,
+        valuesFormat: 'csv',
+      },
+    },
+    replica: {
+      kind: 'QueryVariable',
+      spec: {
+        name: 'replica',
+        current: {
+          text: '',
+          value: '',
+        },
+        label: 'vllm: Rollout Replica',
+        hide: 'dontHide',
+        refresh: 'onDashboardLoad',
+        skipUrlSync: false,
+        description: 'Replica rank of rollout',
+        query: {
+          kind: 'DataQuery',
+          group: 'prometheus',
+          version: 'v0',
+          spec: {
+            qryType: 1,
+            query: 'label_values(vllm:request_prompt_tokens_sum,replica)',
+            refId: 'PrometheusVariableQueryEditor-VariableQuery',
+          },
+        },
+        regex: '',
+        regexApplyTo: 'value',
+        sort: 'disabled',
+        definition: 'label_values(vllm:request_prompt_tokens_sum,replica)',
+        options: [],
+        multi: false,
+        includeAll: true,
+        allValue: '.*',
+        allowCustomValue: true,
+      },
+    },
+    npu_instance: {
+      kind: 'QueryVariable',
+      spec: {
+        name: 'npu_instance',
+        current: {
+          text: 'All',
+          value: '$__all',
+        },
+        label: 'hardware: NPU Node',
+        hide: 'hideVariable',
+        refresh: 'onDashboardLoad',
+        skipUrlSync: false,
+        query: {
+          kind: 'DataQuery',
+          group: 'prometheus',
+          version: 'v0',
+          datasource: {
+            name: '${datasource}',
+          },
+          spec: {
+            query: 'label_values(npu_chip_info_name{job="npu-exporter"}, instance)',
+            refId: 'StandardVariableQuery',
+          },
+        },
+        regex: '',
+        regexApplyTo: 'value',
+        sort: 'alphabeticalAsc',
+        definition: 'label_values(npu_chip_info_name{job="npu-exporter"}, instance)',
+        options: [],
+        multi: true,
+        includeAll: true,
+        allValue: '.*',
+        allowCustomValue: false,
+      },
+    },
+  },
+  variableOrder: [
+    'datasource',
+    'project',
+    'experiment_name',
+    'vllm_model_name',
+    'workerid',
+    'interval',
+    'replica',
+    'task_name',
+    'op_type',
+    'quantile',
+    'npu_instance',
+  ],
+}

--- a/tools/grafana/generate_dashboards.py
+++ b/tools/grafana/generate_dashboards.py
@@ -1,0 +1,113 @@
+# Copyright (c) 2026 verl-project authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Generate the checked-in Grafana dashboards from their Jsonnet sources."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import shutil
+import subprocess
+import sys
+from pathlib import Path
+from typing import Any
+
+
+ROOT = Path(__file__).resolve().parents[2]
+ENTRYPOINT = ROOT / "tools/grafana/dashboards.jsonnet"
+DASHBOARD_DIR = ROOT / "rl_insight/config/services/grafana/dashboards/verl"
+OUTPUTS = {
+    "vllm": DASHBOARD_DIR / "verl_tainer_v1_with_vllm_engine.json",
+    "sglang": DASHBOARD_DIR / "verl_tainer_v1_with_sglang_engine.json",
+}
+
+
+def render_sources() -> dict[str, Any]:
+    """Evaluate the Jsonnet entry point and return both dashboards."""
+    jsonnet = shutil.which("jsonnet")
+    if jsonnet is None:
+        raise RuntimeError(
+            "jsonnet was not found; install go-jsonnet v0.22.0 or newer first"
+        )
+    completed = subprocess.run(
+        [jsonnet, str(ENTRYPOINT)],
+        cwd=ROOT,
+        check=True,
+        capture_output=True,
+        text=True,
+    )
+    return json.loads(completed.stdout)
+
+
+def preserve_order(value: Any, template: Any) -> Any:
+    """Use the checked-in artifact's key order to keep generated diffs focused."""
+    if isinstance(value, dict) and isinstance(template, dict):
+        ordered = {
+            key: preserve_order(value[key], template[key])
+            for key in template
+            if key in value
+        }
+        ordered.update((key, value[key]) for key in value if key not in template)
+        return ordered
+    if isinstance(value, list) and isinstance(template, list):
+        return [
+            preserve_order(item, template[index]) if index < len(template) else item
+            for index, item in enumerate(value)
+        ]
+    return value
+
+
+def generated_text(value: Any, path: Path) -> str:
+    template = json.loads(path.read_text(encoding="utf-8")) if path.exists() else {}
+    ordered = preserve_order(value, template)
+    return json.dumps(ordered, ensure_ascii=False, indent=2) + "\n"
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument(
+        "--check",
+        action="store_true",
+        help="fail if checked-in dashboards do not match the Jsonnet sources",
+    )
+    args = parser.parse_args()
+
+    try:
+        dashboards = render_sources()
+    except (RuntimeError, subprocess.CalledProcessError) as error:
+        print(f"error: {error}", file=sys.stderr)
+        return 2
+
+    stale: list[Path] = []
+    for engine, path in OUTPUTS.items():
+        text = generated_text(dashboards[engine], path)
+        if args.check:
+            if not path.exists() or path.read_text(encoding="utf-8") != text:
+                stale.append(path)
+        else:
+            path.write_text(text, encoding="utf-8")
+            print(path.relative_to(ROOT))
+
+    if stale:
+        print("Generated Grafana dashboards are out of date:", file=sys.stderr)
+        for path in stale:
+            print(f"  {path.relative_to(ROOT)}", file=sys.stderr)
+        print("Run tools/grafana/generate_dashboards.py", file=sys.stderr)
+        return 1
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
### What does this PR do?

Introduces modular Jsonnet sources for the vLLM and SGLang Grafana dashboards and resolves #156.

The two dashboards previously duplicated 116 identical panels. This PR moves those panels and their shared rows and variables into `common.libsonnet`, keeps the 30 vLLM-only and 8 SGLang-only panels in explicit engine modules, and composes both dashboards through one small builder. NPU hardware panels and the `npu_instance` variable remain vLLM-only.

The checked-in Grafana JSON files remain byte-for-byte unchanged, so this refactor does not change runtime dashboard behavior or create a large generated-artifact diff.

### Checklist Before Starting

- [x] Searched for similar PRs: https://github.com/verl-project/rl-insight/pulls?q=is%3Apr+grafana+dashboard+jsonnet
- [x] Formatted the PR title as `[{modules}] {type}: {description}`.

### Test

Re-run locally on commit `69ef8b33f3ae23cd0c6aed22afe2df2a74006c6b`:

- `python3 tools/grafana/generate_dashboards.py --check` — passed
- `uv run --extra test pytest -q tests/monitor/ut` — 67 passed
- `uvx pre-commit run --all-files --show-diff-on-failure --color=always` — all hooks passed (Ruff, Ruff format, mypy, license, compileall)

The source PR's GitHub checks also passed, including monitor unit tests, monitor smoke tests, pre-commit, recipe tests, documentation links, and PR title validation.

The tests verify that:

- the Jsonnet source contains 116 shared, 30 vLLM-only, and 8 SGLang-only panels;
- the generated dashboards exactly match the checked-in artifacts;
- every layout element reference resolves to a generated panel;
- the NPU selector remains present only in the vLLM dashboard.

### API and Usage Example

There is no runtime API change. Grafana continues to consume the existing JSON files.

After editing a Jsonnet source, regenerate the artifacts with:

```bash
python tools/grafana/generate_dashboards.py
```

Verify that generated artifacts are current with:

```bash
python tools/grafana/generate_dashboards.py --check
```

This requires go-jsonnet v0.22.0 or newer. CI installs the pinned version automatically.

### Design & Code Changes

The source structure follows the explicit composition pattern used by monitoring mixins:

```text
common.libsonnet + vllm.libsonnet   -> vLLM dashboard JSON
common.libsonnet + sglang.libsonnet -> SGLang dashboard JSON
```

![Grafana Jsonnet module structure](https://github.com/a550580874/rl-insight/releases/download/pr-171-design-assets/grafana-jsonnet-module-structure.png)

![Grafana dashboard generation structure](https://github.com/a550580874/rl-insight/releases/download/pr-171-design-assets/grafana-dashboard-generation-structure.png)

(Both diagrams are hosted as release assets on the author's fork so every reviewer can view them; they are intentionally not committed to the repository.) An interactive HTML version of the architecture diagram is also hosted there: [rl-insight-jsonnet-architecture.html](https://github.com/a550580874/rl-insight/releases/download/pr-171-design-assets/rl-insight-jsonnet-architecture.html).

- `common.libsonnet` owns only content that is identical in both dashboards.
- `vllm.libsonnet` and `sglang.libsonnet` own real engine differences.
- `base/viz.libsonnet` centralizes repeated visualization defaults.
- `base/dashboard.libsonnet` expands compact panel definitions, resolves semantic source references, and builds Grafana Dashboard v2 resources.
- `generate_dashboards.py` evaluates Jsonnet deterministically while preserving existing JSON key order for focused diffs.
- CI runs whenever Jsonnet sources or generated dashboard artifacts change.

The source uses semantic panel keys for maintainability while retaining the current `panel-N` keys as generated compatibility aliases. Renaming generated element keys can therefore be handled separately without mixing migration noise into the deduplication refactor.

### Checklist Before Submitting

- [x] Read the [Contribute Guide](https://github.com/verl-project/rl-insight/blob/main/CONTRIBUTING.md).
- [x] Apply [pre-commit checks](https://github.com/verl-project/rl-insight/blob/main/CONTRIBUTING.md#code-linting-and-formatting).
- [x] Documentation update is not needed: this is an internal dashboard source refactor with no user-facing API or runtime change.
- [x] Add unit tests and CI coverage for generation and module boundaries.
